### PR TITLE
refactor(meeting): rename meeting time fields for clarity

### DIFF
--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -11,15 +11,14 @@ import {
 export interface CreateMeetingRecordData {
     platform: MeetingPlatform;
     platformMeetingId: string;
-    platformRecordingId: string;
     title: string;
     meetingCode: string;
     type: MeetingType;
     hostUserId: string;
     hostUserName: string;
-    actualStartAt: Date;
-    endedAt: Date;
-    duration: number;
+    startTime: Date;
+    endTime: Date;
+    durationSeconds: number;
     hasRecording: boolean;
     recordingStatus: ProcessingStatus;
     processingStatus: ProcessingStatus;
@@ -150,12 +149,12 @@ export class MeetingRepository {
             where.platform = platform;
         }
         if (startDate || endDate) {
-            where.actualStartAt = {};
+            where.startTime = {};
             if (startDate) {
-                where.actualStartAt.gte = startDate;
+                where.startTime.gte = startDate;
             }
             if (endDate) {
-                where.actualStartAt.lte = endDate;
+                where.startTime.lte = endDate;
             }
         }
 
@@ -166,7 +165,7 @@ export class MeetingRepository {
                     files: true
                 },
                 orderBy: {
-                    actualStartAt: 'desc'
+                    createdAt: 'desc'
                 },
                 skip,
                 take: limit

--- a/src/meeting/services/meeting.service.ts
+++ b/src/meeting/services/meeting.service.ts
@@ -55,7 +55,7 @@ export class MeetingService {
         if (existing) {
             throw new MeetingRecordAlreadyExistsException(
                 params.platformMeetingId,
-                params.platformRecordingId || ''
+                ''
             );
         }
 
@@ -63,15 +63,14 @@ export class MeetingService {
         const createData = {
             platform: params.platform,
             platformMeetingId: params.platformMeetingId,
-            platformRecordingId: params.platformRecordingId || '',
             title: params.title,
             meetingCode: params.meetingCode || '',
             type: params.type,
             hostUserId: params.hostUserId || '',
             hostUserName: params.hostUserName,
-            actualStartAt: params.actualStartAt ? new Date(params.actualStartAt) : new Date(),
-            endedAt: params.endedAt ? new Date(params.endedAt) : new Date(),
-            duration: params.duration || 0,
+            startTime: params.actualStartAt ? new Date(params.actualStartAt) : new Date(),
+            endTime: params.endedAt ? new Date(params.endedAt) : new Date(),
+            durationSeconds: params.duration || 0,
             hasRecording: params.hasRecording || false,
             recordingStatus: params.recordingStatus || ProcessingStatus.PENDING,
             processingStatus: params.processingStatus || ProcessingStatus.PENDING,


### PR DESCRIPTION
Rename 'actualStartAt' to 'startTime', 'endedAt' to 'endTime', and 'duration' to 'durationSeconds' to improve field naming consistency. Remove unused 'platformRecordingId' field.