### PR TITLE
ci: add docker workflow for building and pushing images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: build-and-push-docker
+
+on:
+  push:
+    branches: ["main", "develop", "release"]
+    tags: |
+      v*.*.*
+      v*.*.*-alpha.*
+      v*.*.*-beta.*
+      v*.*.*-rc.*
+      v*.*.*-insiders.*
+
+permissions:
+  contents: read
+  packages: write        # 推 GHCR 必须
+  id-token: write        # 可选（未来用 OIDC）
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64  # 明确指定平台
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true


### PR DESCRIPTION
Add GitHub Actions workflow to build and push Docker images to GHCR on push events to main, develop, and release branches, as well as version tags. The workflow includes multi-platform support (amd64/arm64) and utilizes build caching for improved performance.