### PR TITLE
feat(scripts): add CSV import and table relation utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Backup files
 /scripts/backups
+/scripts/csv_data
 
 # Documentation (auto-generated)
 /documentation

--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "csv-parse": "^6.1.0",
+    "cuid": "^3.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,12 @@ importers:
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.1.0
+      cuid:
+        specifier: ^3.0.0
+        version: 3.0.0
       eslint:
         specifier: ^9.18.0
         version: 9.37.0(jiti@2.6.1)
@@ -3330,6 +3336,13 @@ packages:
 
   cssfilter@0.0.10:
     resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
+
+  csv-parse@6.1.0:
+    resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
+
+  cuid@3.0.0:
+    resolution: {integrity: sha512-WZYYkHdIDnaxdeP8Misq3Lah5vFjJwGuItJuV+tvMafosMzw0nF297T7mrm8IOWiPJkV6gc7sa8pzx27+w25Zg==}
+    deprecated: Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -10135,6 +10148,10 @@ snapshots:
   css-what@6.2.2: {}
 
   cssfilter@0.0.10: {}
+
+  csv-parse@6.1.0: {}
+
+  cuid@3.0.0: {}
 
   debug@2.6.9:
     dependencies:

--- a/scripts/import-csv-prisma.mjs
+++ b/scripts/import-csv-prisma.mjs
@@ -1,0 +1,260 @@
+import fs from "fs";
+import { parse } from "csv-parse";
+import { PrismaClient, Prisma } from "@prisma/client";
+import cuid from 'cuid';
+
+const prisma = new PrismaClient();
+
+/**
+ * 用法:
+ *   node scripts/import-csv-prisma.mjs --model=User --file=./data.csv --batch=1000 --skipDuplicates=true
+ *   node scripts/import-csv-prisma.mjs --model=User --file=scripts/user.csv --batch=1000 --skipDuplicates=true
+ *   // PlatformUser
+ *
+ * 说明:
+ *   - --model 必填: Prisma 的 Model 名（区分大小写，如 User / Post）
+ *   - --file  必填: CSV 文件路径
+ *   - --batch 可选: 每批写入行数，默认 1000
+ *   - --skipDuplicates 可选: true/false，默认 true（仅对 createMany 生效）
+ *   - --mapping 可选: CSV 表头到 Prisma 模型字段的映射，格式为 "csvHeader:modelField,csvHeader2:modelField2"
+ *                   例如: --mapping=csv_id:id,csv_name:name
+ */
+function getArg(name, def = undefined) {
+  const hit = process.argv.find((x) => x.startsWith(`--${name}=`));
+  if (!hit) return def;
+  return hit.split("=").slice(1).join("=");
+}
+
+const MODEL = getArg("model");
+const FILE = getArg("file");
+const BATCH_SIZE = Number(getArg("batch", "1000"));
+const SKIP_DUPLICATES = (getArg("skipDuplicates", "true") + "").toLowerCase() === "true";
+const MAPPING = getArg("mapping", "");
+
+if (!MODEL || !FILE) {
+  console.error("❌ 缺少参数。示例: node import-csv-prisma.mjs --model=User --file=./data.csv");
+  process.exit(1);
+}
+
+// Prisma DMMF: 运行期拿到 schema 元信息（字段名、类型、可空、默认值等）
+const dmmf = Prisma.dmmf;
+
+function getModelMeta(modelName) {
+  const m = dmmf.datamodel.models.find((x) => x.name === modelName);
+  if (!m) {
+    const all = dmmf.datamodel.models.map((x) => x.name).join(", ");
+    throw new Error(`找不到 model: ${modelName}. 可用 model: [${all}]`);
+  }
+  return m;
+}
+
+// 基础类型转换：按 Prisma 字段类型把字符串转成合适的 JS 值
+function coerceValue(raw, field) {
+  // csv-parse 会给字符串；空串当作 null/undefined
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+
+  const s = String(raw).trim();
+  if (s === "") {
+    // 空串：可空字段 -> null；不可空字段 -> undefined（让 Prisma 用默认值/报错）
+    return field.isRequired ? undefined : null;
+  }
+
+  // field.type: "String"|"Int"|"Float"|"Boolean"|"DateTime"|"Json"|枚举|模型名...
+  switch (field.type) {
+    case "String":
+      return s;
+
+    case "Int": {
+      const n = Number.parseInt(s, 10);
+      return Number.isNaN(n) ? undefined : n;
+    }
+
+    case "BigInt": {
+      try { return BigInt(s); } catch { return undefined; }
+    }
+
+    case "Float":
+    case "Decimal": {
+      const n = Number.parseFloat(s);
+      return Number.isNaN(n) ? undefined : n;
+    }
+
+    case "Boolean": {
+      const v = s.toLowerCase();
+      if (["true", "1", "yes", "y"].includes(v)) return true;
+      if (["false", "0", "no", "n"].includes(v)) return false;
+      return undefined;
+    }
+
+    case "DateTime": {
+      const d = new Date(s);
+      return Number.isNaN(d.getTime()) ? undefined : d;
+    }
+
+    case "Json": {
+      // 允许 CSV 里放 JSON 字符串：{"a":1} 或 [1,2]
+      try { return JSON.parse(s); } catch { return undefined; }
+    }
+
+    case "Bytes": {
+      // 支持 base64
+      try { return Buffer.from(s, "base64"); } catch { return undefined; }
+    }
+
+    default:
+      // 枚举：保持字符串；关系字段/模型字段通常不应从 CSV 直接写（需 nested create/connect）
+      // 这里保持原样（字符串），让 Prisma 自行校验
+      return s;
+  }
+}
+
+function normalizeHeader(h) {
+  // 允许 header 有空格或大小写差异： " createdAt " -> "createdAt"
+  return String(h || "").trim();
+}
+
+async function main() {
+  const modelMeta = getModelMeta(MODEL);
+
+  // 找出可直接写入的字段（排除 relation 字段，包含标量字段和枚举字段）
+  const writableFields = modelMeta.fields.filter((f) => f.kind === "scalar" || f.kind === "enum");
+  const fieldByName = new Map(writableFields.map((f) => [f.name, f]));
+
+  const requiredFields = writableFields.filter((f) => f.isRequired).map((f) => f.name);
+
+  const mapping = new Map();
+  if (MAPPING) {
+    MAPPING.split(",").forEach((pair) => {
+      const [csvHeader, modelField] = pair.split(":").map((s) => s.trim());
+      if (csvHeader && modelField) {
+        mapping.set(csvHeader, modelField);
+      }
+    });
+  }
+
+  // 识别 id 字段（你说 id 用 cuid）
+  const idField = writableFields.find((f) => f.name === "id");
+
+  const clientDelegate = prisma[MODEL.charAt(0).toLowerCase() + MODEL.slice(1)];
+  if (!clientDelegate?.createMany) {
+    throw new Error(`prisma.${MODEL} delegate 不存在或不支持 createMany（检查 model 名大小写）`);
+  }
+
+  let total = 0;
+  let inserted = 0;
+  let skipped = 0;
+
+  const batch = [];
+  let csvHeaders = null;
+  let mappedFields = null;
+
+  const parser = fs
+    .createReadStream(FILE)
+    .pipe(
+      parse({
+        columns: (headers) => headers.map(normalizeHeader),
+        skip_empty_lines: true,
+        bom: true, // 处理 UTF-8 BOM
+        relax_column_count: true,
+        trim: true,
+      })
+    );
+
+  for await (const row of parser) {
+    if (!csvHeaders) {
+      csvHeaders = Object.keys(row);
+
+      // 自动匹配：只保留 Prisma model 里存在的标量字段
+      // 如果提供了 mapping，优先使用 mapping；否则使用自动匹配
+      if (mapping.size > 0) {
+        mappedFields = csvHeaders
+          .filter((h) => mapping.has(h) && fieldByName.has(mapping.get(h)))
+          .map((h) => ({ header: h, field: fieldByName.get(mapping.get(h)) }));
+      } else {
+        mappedFields = csvHeaders
+          .filter((h) => fieldByName.has(h))
+          .map((h) => ({ header: h, field: fieldByName.get(h) }));
+      }
+
+      if (mappedFields.length === 0) {
+        const modelFieldNames = writableFields.map((f) => f.name).join(", ");
+        throw new Error(
+          `CSV 表头与 ${MODEL} 字段无法匹配。\nCSV headers: ${csvHeaders.join(", ")}\nModel writable fields: ${modelFieldNames}`
+        );
+      }
+
+      console.log("✅ 自动匹配字段：", mappedFields.map((x) => x.header).join(", "));
+      if (idField) console.log("✅ 检测到 id 字段：", idField.type, "required=", idField.isRequired);
+    }
+
+    total++;
+
+    // 构建 data：只写入能匹配到的字段
+    const data = {};
+    for (const { header, field } of mappedFields) {
+      const v = coerceValue(row[header], field);
+      if (v !== undefined) data[field.name] = v;
+    }
+
+    // 检查必填字段是否有值（除了 id，因为 id 会自动生成）
+    const missingRequiredFields = [];
+    for (const { field } of mappedFields) {
+      if (field.isRequired && field.name !== "id" && data[field.name] === undefined) {
+        missingRequiredFields.push(field.name);
+      }
+    }
+
+    if (missingRequiredFields.length > 0) {
+      console.warn(`⚠️  跳过第 ${total} 行：缺少必填字段 ${missingRequiredFields.join(", ")}`);
+      skipped++;
+      continue;
+    }
+
+    // 自动生成 cuid：当 model 有 id 且 data.id 为空/缺失
+    if (idField) {
+      const hasId = data.id !== undefined && data.id !== null && String(data.id).trim() !== "";
+      if (!hasId) {
+        // 仅当 id 是 String 且通常为 cuid 使用场景
+        data.id = cuid();
+      }
+    }
+
+    batch.push(data);
+
+    if (batch.length >= BATCH_SIZE) {
+      const res = await clientDelegate.createMany({
+        data: batch,
+        skipDuplicates: SKIP_DUPLICATES,
+      });
+
+      inserted += res.count;
+      skipped += batch.length - res.count;
+      batch.length = 0;
+
+      process.stdout.write(`\r🚚 已处理 ${total} 行 | 写入 ${inserted} | 跳过 ${skipped}`);
+    }
+  }
+
+  // flush last batch
+  if (batch.length > 0) {
+    const res = await clientDelegate.createMany({
+      data: batch,
+      skipDuplicates: SKIP_DUPLICATES,
+    });
+
+    inserted += res.count;
+    skipped += batch.length - res.count;
+  }
+
+  console.log(`\n✅ 完成: 总行数 ${total} | 写入 ${inserted} | 跳过 ${skipped}`);
+}
+
+main()
+  .catch((e) => {
+    console.error("\n❌ 导入失败：", e?.message || e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/import-csv-prisma.mjs
+++ b/scripts/import-csv-prisma.mjs
@@ -8,8 +8,8 @@ const prisma = new PrismaClient();
 /**
  * 用法:
  *   node scripts/import-csv-prisma.mjs --model=User --file=./data.csv --batch=1000 --skipDuplicates=true
- *   node scripts/import-csv-prisma.mjs --model=User --file=scripts/user.csv --batch=1000 --skipDuplicates=true
- *   // PlatformUser
+ *   node scripts/import-csv-prisma.mjs --model=User --file=scripts/csv_data/user.csv --batch=1000 --skipDuplicates=true
+ *   node scripts/import-csv-prisma.mjs --model=PlatformUser --file=scripts/csv_data/data.csv --batch=1000 --skipDuplicates=true
  *
  * 说明:
  *   - --model 必填: Prisma 的 Model 名（区分大小写，如 User / Post）

--- a/scripts/relate-tables.mjs
+++ b/scripts/relate-tables.mjs
@@ -1,0 +1,224 @@
+import { PrismaClient, Prisma } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+/**
+ * 用法:
+ *   node scripts/relate-tables.mjs --sourceModel=PlatformUser --targetModel=User --sourceField=email --targetField=email --foreignKey=localUserId --batch=1000 --dryRun=true
+ *
+ * 说明:
+ *   - --sourceModel 必填: 源模型名称（需要更新外键的模型）
+ *   - --targetModel 必填: 目标模型名称（提供外键值的模型）
+ *   - --sourceField 必填: 源模型中用于匹配的字段
+ *   - --targetField 必填: 目标模型中用于匹配的字段
+ *   - --foreignKey 必填: 源模型中需要更新的外键字段（指向目标模型的主键）
+ *   - --batch 可选: 每批处理行数，默认 1000
+ *   - --dryRun 可选: true/false，默认 true（仅模拟不执行）
+ *   - --where 可选: 源模型的过滤条件（JSON 格式），例如: --where='{"active":true}'
+ *   --targetWhere 可选: 目标模型的过滤条件（JSON 格式），例如: --targetWhere='{"active":true}'
+ */
+function getArg(name, def = undefined) {
+  const hit = process.argv.find((x) => x.startsWith(`--${name}=`));
+  if (!hit) return def;
+  return hit.split("=").slice(1).join("=");
+}
+
+const SOURCE_MODEL = getArg("sourceModel");
+const TARGET_MODEL = getArg("targetModel");
+const SOURCE_FIELD = getArg("sourceField");
+const TARGET_FIELD = getArg("targetField");
+const FOREIGN_KEY = getArg("foreignKey");
+const BATCH_SIZE = Number(getArg("batch", "1000"));
+const DRY_RUN = (getArg("dryRun", "true") + "").toLowerCase() === "true";
+const WHERE = getArg("where", "");
+const TARGET_WHERE = getArg("targetWhere", "");
+
+if (!SOURCE_MODEL || !TARGET_MODEL || !SOURCE_FIELD || !TARGET_FIELD || !FOREIGN_KEY) {
+  console.error("❌ 缺少参数。示例: node relate-tables.mjs --sourceModel=PlatformUser --targetModel=User --sourceField=email --targetField=email --foreignKey=localUserId");
+  process.exit(1);
+}
+
+const dmmf = Prisma.dmmf;
+
+function getModelMeta(modelName) {
+  const m = dmmf.datamodel.models.find((x) => x.name === modelName);
+  if (!m) {
+    const all = dmmf.datamodel.models.map((x) => x.name).join(", ");
+    throw new Error(`找不到 model: ${modelName}. 可用 model: [${all}]`);
+  }
+  return m;
+}
+
+function validateFields(modelMeta, fieldName, fieldType = null) {
+  const field = modelMeta.fields.find((f) => f.name === fieldName);
+  if (!field) {
+    const all = modelMeta.fields.map((f) => f.name).join(", ");
+    throw new Error(`在 ${modelMeta.name} 中找不到字段: ${fieldName}. 可用字段: [${all}]`);
+  }
+  
+  if (fieldType && field.kind !== fieldType) {
+    throw new Error(`字段 ${fieldName} 的类型应为 ${fieldType}，实际为 ${field.kind}`);
+  }
+  
+  return field;
+}
+
+function parseWhereClause(whereStr) {
+  if (!whereStr) return undefined;
+  try {
+    return JSON.parse(whereStr);
+  } catch (e) {
+    throw new Error(`无法解析 where 条件: ${whereStr}. 错误: ${e.message}`);
+  }
+}
+
+async function main() {
+  console.log("🔗 开始关联表数据...");
+  console.log(`源模型: ${SOURCE_MODEL}`);
+  console.log(`目标模型: ${TARGET_MODEL}`);
+  console.log(`匹配字段: ${SOURCE_MODEL}.${SOURCE_FIELD} = ${TARGET_MODEL}.${TARGET_FIELD}`);
+  console.log(`外键字段: ${SOURCE_MODEL}.${FOREIGN_KEY}`);
+  console.log(`批量大小: ${BATCH_SIZE}`);
+  console.log(`模拟模式: ${DRY_RUN ? "是" : "否"}`);
+
+  const sourceMeta = getModelMeta(SOURCE_MODEL);
+  const targetMeta = getModelMeta(TARGET_MODEL);
+
+  validateFields(sourceMeta, SOURCE_FIELD, "scalar");
+  validateFields(targetMeta, TARGET_FIELD, "scalar");
+  validateFields(sourceMeta, FOREIGN_KEY, "scalar");
+
+  const sourceDelegate = prisma[SOURCE_MODEL.charAt(0).toLowerCase() + SOURCE_MODEL.slice(1)];
+  const targetDelegate = prisma[TARGET_MODEL.charAt(0).toLowerCase() + TARGET_MODEL.slice(1)];
+
+  if (!sourceDelegate?.findMany || !sourceDelegate?.updateMany) {
+    throw new Error(`源模型 ${SOURCE_MODEL} 不支持 findMany/updateMany 操作`);
+  }
+  if (!targetDelegate?.findMany) {
+    throw new Error(`目标模型 ${TARGET_MODEL} 不支持 findMany 操作`);
+  }
+
+  const whereClause = parseWhereClause(WHERE);
+  const targetWhereClause = parseWhereClause(TARGET_WHERE);
+
+  console.log(`\n📊 查询条件:`);
+  if (whereClause) console.log(`  源模型过滤: ${JSON.stringify(whereClause)}`);
+  if (targetWhereClause) console.log(`  目标模型过滤: ${JSON.stringify(targetWhereClause)}`);
+
+  let totalProcessed = 0;
+  let totalMatched = 0;
+  let totalUpdated = 0;
+  let skipped = 0;
+
+  let offset = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const sourceRecords = await sourceDelegate.findMany({
+      where: {
+        ...whereClause,
+        [FOREIGN_KEY]: null,
+      },
+      select: {
+        id: true,
+        [SOURCE_FIELD]: true,
+      },
+      take: BATCH_SIZE,
+      skip: offset,
+    });
+
+    if (sourceRecords.length === 0) {
+      hasMore = false;
+      break;
+    }
+
+    const sourceValues = sourceRecords.map((r) => r[SOURCE_FIELD]).filter((v) => v !== null && v !== undefined);
+
+    if (sourceValues.length === 0) {
+      offset += BATCH_SIZE;
+      continue;
+    }
+
+    const targetRecords = await targetDelegate.findMany({
+      where: {
+        ...targetWhereClause,
+        [TARGET_FIELD]: { in: sourceValues },
+      },
+      select: {
+        id: true,
+        [TARGET_FIELD]: true,
+      },
+    });
+
+    const targetMap = new Map();
+    for (const target of targetRecords) {
+      targetMap.set(String(target[TARGET_FIELD]), target.id);
+    }
+
+    const updates = [];
+
+    for (const source of sourceRecords) {
+      totalProcessed++;
+      const sourceValue = String(source[SOURCE_FIELD]);
+      const targetId = targetMap.get(sourceValue);
+
+      if (targetId) {
+        totalMatched++;
+        updates.push({
+          id: source.id,
+          [FOREIGN_KEY]: targetId,
+        });
+      } else {
+        skipped++;
+      }
+    }
+
+    if (updates.length > 0) {
+      if (DRY_RUN) {
+        console.log(`\n🔍 模拟更新 ${updates.length} 条记录:`);
+        for (const update of updates.slice(0, 5)) {
+          console.log(`  ${SOURCE_MODEL}.id=${update.id} -> ${FOREIGN_KEY}=${update[FOREIGN_KEY]}`);
+        }
+        if (updates.length > 5) {
+          console.log(`  ... 还有 ${updates.length - 5} 条`);
+        }
+        totalUpdated += updates.length;
+      } else {
+        for (const update of updates) {
+          await sourceDelegate.update({
+            where: { id: update.id },
+            data: { [FOREIGN_KEY]: update[FOREIGN_KEY] },
+          });
+        }
+        totalUpdated += updates.length;
+        process.stdout.write(`\r🚚 已处理 ${totalProcessed} 行 | 匹配 ${totalMatched} | 更新 ${totalUpdated} | 跳过 ${skipped}`);
+      }
+    }
+
+    offset += BATCH_SIZE;
+    if (sourceRecords.length < BATCH_SIZE) {
+      hasMore = false;
+    }
+  }
+
+  console.log(`\n\n✅ 完成:`);
+  console.log(`  总处理: ${totalProcessed}`);
+  console.log(`  匹配成功: ${totalMatched}`);
+  console.log(`  更新记录: ${totalUpdated} ${DRY_RUN ? "(模拟)" : ""}`);
+  console.log(`  跳过: ${skipped}`);
+
+  if (DRY_RUN) {
+    console.log(`\n💡 当前为模拟模式，实际未修改任何数据。`);
+    console.log(`   如需执行实际更新，请添加 --dryRun=false`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error("\n❌ 关联失败：", e?.message || e);
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Add two new utility scripts for database operations:
1. import-csv-prisma.mjs - Bulk import CSV data into Prisma models with field mapping and type conversion
2. relate-tables.mjs - Establish relationships between tables by matching fields and updating foreign keys

Both scripts support batch processing, dry runs, and comprehensive validation. Added required dependencies (csv-parse, cuid) to package.json and excluded CSV data directory in gitignore.