### PR TITLE
feat(api-key): add user permission checks and createdBy filtering

### DIFF
--- a/src/api-key/controllers/api-key.controller.spec.ts
+++ b/src/api-key/controllers/api-key.controller.spec.ts
@@ -174,7 +174,11 @@ describe('ApiKeyController', () => {
       const result = await controller.listKeys(mockUser, pagination);
 
       expect(getPrimaryOrganizationIdSpy).toHaveBeenCalledWith(mockUser.id);
-      expect(listKeysSpy).toHaveBeenCalledWith(mockOrganizationId, pagination);
+      expect(listKeysSpy).toHaveBeenCalledWith(
+        mockOrganizationId,
+        pagination,
+        mockUser.id,
+      );
       expect(result).toEqual(mockApiKeyListResponse);
     });
 
@@ -199,7 +203,11 @@ describe('ApiKeyController', () => {
 
       const result = await controller.listKeys(mockUser, pagination);
 
-      expect(listKeysSpy).toHaveBeenCalledWith(mockOrganizationId, pagination);
+      expect(listKeysSpy).toHaveBeenCalledWith(
+        mockOrganizationId,
+        pagination,
+        mockUser.id,
+      );
       expect(result).toEqual(customListResponse);
     });
 
@@ -250,6 +258,7 @@ describe('ApiKeyController', () => {
         mockOrganizationId,
         'key-123',
         updateDto,
+        mockUser.id,
       );
       expect(result).toEqual(updatedKey);
     });
@@ -277,6 +286,7 @@ describe('ApiKeyController', () => {
         mockOrganizationId,
         'key-123',
         updateDto,
+        mockUser.id,
       );
       expect(result).toEqual(updatedKey);
     });
@@ -304,6 +314,7 @@ describe('ApiKeyController', () => {
         mockOrganizationId,
         'key-123',
         updateDto,
+        mockUser.id,
       );
       expect(result).toEqual(updatedKey);
     });
@@ -357,7 +368,11 @@ describe('ApiKeyController', () => {
       await controller.revokeKey(mockUser, 'key-123');
 
       expect(getPrimaryOrganizationIdSpy).toHaveBeenCalledWith(mockUser.id);
-      expect(revokeKeySpy).toHaveBeenCalledWith(mockOrganizationId, 'key-123');
+      expect(revokeKeySpy).toHaveBeenCalledWith(
+        mockOrganizationId,
+        'key-123',
+        mockUser.id,
+      );
     });
 
     it('should throw NotFoundException when key does not exist', async () => {
@@ -386,7 +401,11 @@ describe('ApiKeyController', () => {
       const result = await controller.rotateKey(mockUser, 'key-123');
 
       expect(getPrimaryOrganizationIdSpy).toHaveBeenCalledWith(mockUser.id);
-      expect(rotateKeySpy).toHaveBeenCalledWith(mockOrganizationId, 'key-123');
+      expect(rotateKeySpy).toHaveBeenCalledWith(
+        mockOrganizationId,
+        'key-123',
+        mockUser.id,
+      );
       expect(result).toEqual(mockRotateApiKeyResponse);
       expect(result.key).toBeDefined();
       expect(result.oldKeyId).toBe('key-123');

--- a/src/api-key/controllers/api-key.controller.ts
+++ b/src/api-key/controllers/api-key.controller.ts
@@ -102,7 +102,7 @@ export class ApiKeyController {
       user.id,
     );
 
-    return this.apiKeyService.listKeys(organizationId, pagination);
+    return this.apiKeyService.listKeys(organizationId, pagination, user.id);
   }
 
   /**
@@ -144,7 +144,7 @@ export class ApiKeyController {
       user.id,
     );
 
-    return this.apiKeyService.updateKey(organizationId, id, dto);
+    return this.apiKeyService.updateKey(organizationId, id, dto, user.id);
   }
 
   /**
@@ -181,7 +181,7 @@ export class ApiKeyController {
       user.id,
     );
 
-    await this.apiKeyService.revokeKey(organizationId, id);
+    await this.apiKeyService.revokeKey(organizationId, id, user.id);
   }
 
   /**
@@ -219,6 +219,6 @@ export class ApiKeyController {
       user.id,
     );
 
-    return this.apiKeyService.rotateKey(organizationId, id);
+    return this.apiKeyService.rotateKey(organizationId, id, user.id);
   }
 }

--- a/src/api-key/repositories/api-key.repository.ts
+++ b/src/api-key/repositories/api-key.repository.ts
@@ -59,9 +59,16 @@ export class ApiKeyRepository {
       skip?: number;
       take?: number;
       orderBy?: Prisma.ApiKeyOrderByWithRelationInput;
+      createdBy?: string;
     },
   ): Promise<{ items: ApiKey[]; total: number }> {
-    const where: Prisma.ApiKeyWhereInput = { organizationId };
+    const where: Prisma.ApiKeyWhereInput = {
+      organizationId,
+    };
+
+    if (options?.createdBy) {
+      where.createdBy = options.createdBy;
+    }
 
     const [items, total] = await Promise.all([
       this.prisma.apiKey.findMany({

--- a/src/api-key/services/api-key.service.spec.ts
+++ b/src/api-key/services/api-key.service.spec.ts
@@ -10,12 +10,14 @@ import { apiKeyConfig } from '@/configs/api-key.config';
 import { ApiKeyStatus } from '@prisma/client';
 import { CreateApiKeyDto, UpdateApiKeyDto } from '../dto';
 import { computeKeyHash } from '../utils/crypto.util';
+import { PermissionService } from '@/permission/services/permission.service';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
 describe('ApiKeyService', () => {
   let service: ApiKeyService;
   let repository: jest.Mocked<ApiKeyRepository>;
+  let permissionService: jest.Mocked<PermissionService>;
 
   const mockConfig = {
     environment: 'prod',
@@ -53,6 +55,10 @@ describe('ApiKeyService', () => {
     updateLastUsedAt: jest.fn(),
   };
 
+  const mockPermissionService = {
+    getPermissionsByUserId: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -65,11 +71,16 @@ describe('ApiKeyService', () => {
           provide: apiKeyConfig.KEY,
           useValue: mockConfig,
         },
+        {
+          provide: PermissionService,
+          useValue: mockPermissionService,
+        },
       ],
     }).compile();
 
     service = module.get<ApiKeyService>(ApiKeyService);
     repository = module.get(ApiKeyRepository);
+    permissionService = module.get(PermissionService);
   });
 
   afterEach(() => {
@@ -88,6 +99,9 @@ describe('ApiKeyService', () => {
         expiresAt: '2026-12-31T23:59:59Z',
       };
 
+      permissionService.getPermissionsByUserId.mockResolvedValue([
+        'meetings:read',
+      ]);
       repository.create.mockResolvedValue(mockApiKey);
 
       const result = await service.createKey('org-123', 'user-123', dto);
@@ -215,10 +229,18 @@ describe('ApiKeyService', () => {
         name: dto.name!,
         scopes: dto.scopes!,
       };
+      permissionService.getPermissionsByUserId.mockResolvedValue([
+        'meetings:write',
+      ]);
       repository.findById.mockResolvedValue(mockApiKey);
       repository.update.mockResolvedValue(updatedKey);
 
-      const result = await service.updateKey('org-123', 'key-123', dto);
+      const result = await service.updateKey(
+        'org-123',
+        'key-123',
+        dto,
+        'user-123',
+      );
 
       expect(repository.findById).toHaveBeenCalledWith('key-123', 'org-123');
       expect(repository.update).toHaveBeenCalledWith('key-123', 'org-123', {
@@ -234,10 +256,20 @@ describe('ApiKeyService', () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(
-        service.updateKey('org-123', 'key-123', { name: 'Updated' }),
+        service.updateKey(
+          'org-123',
+          'key-123',
+          { name: 'Updated' },
+          'user-123',
+        ),
       ).rejects.toThrow(NotFoundException);
       await expect(
-        service.updateKey('org-123', 'key-123', { name: 'Updated' }),
+        service.updateKey(
+          'org-123',
+          'key-123',
+          { name: 'Updated' },
+          'user-123',
+        ),
       ).rejects.toThrow('API Key not found');
     });
 
@@ -250,7 +282,7 @@ describe('ApiKeyService', () => {
       repository.findById.mockResolvedValue(mockApiKey);
 
       await expect(
-        service.updateKey('org-123', 'key-123', dto),
+        service.updateKey('org-123', 'key-123', dto, 'user-123'),
       ).rejects.toThrow(BadRequestException);
     });
   });
@@ -260,7 +292,7 @@ describe('ApiKeyService', () => {
       repository.findById.mockResolvedValue(mockApiKey);
       repository.revoke.mockResolvedValue(mockApiKey);
 
-      await service.revokeKey('org-123', 'key-123');
+      await service.revokeKey('org-123', 'key-123', 'user-123');
 
       expect(repository.findById).toHaveBeenCalledWith('key-123', 'org-123');
       expect(repository.revoke).toHaveBeenCalledWith('key-123', 'org-123');
@@ -269,9 +301,9 @@ describe('ApiKeyService', () => {
     it('should throw NotFoundException when key does not exist', async () => {
       repository.findById.mockResolvedValue(null);
 
-      await expect(service.revokeKey('org-123', 'key-123')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.revokeKey('org-123', 'key-123', 'user-123'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -289,7 +321,7 @@ describe('ApiKeyService', () => {
       repository.create.mockResolvedValue(newKey);
       repository.revoke.mockResolvedValue(oldKey);
 
-      const result = await service.rotateKey('org-123', 'key-123');
+      const result = await service.rotateKey('org-123', 'key-123', 'user-123');
 
       expect(repository.findById).toHaveBeenCalledWith('key-123', 'org-123');
       expect(repository.create).toHaveBeenCalledWith(
@@ -308,24 +340,24 @@ describe('ApiKeyService', () => {
     it('should throw NotFoundException when key does not exist', async () => {
       repository.findById.mockResolvedValue(null);
 
-      await expect(service.rotateKey('org-123', 'key-123')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(
+        service.rotateKey('org-123', 'key-123', 'user-123'),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('should preserve createdBy user when rotating', async () => {
-      const oldKey = { ...mockApiKey, createdBy: 'user-456' };
+      const oldKey = { ...mockApiKey, createdBy: 'user-123' };
       const newKey = { ...mockApiKey, id: 'new-key-123' };
 
       repository.findById.mockResolvedValue(oldKey);
       repository.create.mockResolvedValue(newKey);
       repository.revoke.mockResolvedValue(oldKey);
 
-      await service.rotateKey('org-123', 'key-123');
+      await service.rotateKey('org-123', 'key-123', 'user-123');
 
       expect(repository.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          createdByUser: { connect: { id: 'user-456' } },
+          createdByUser: { connect: { id: 'user-123' } },
         }),
       );
     });

--- a/src/api-key/services/api-key.service.ts
+++ b/src/api-key/services/api-key.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
   BadRequestException,
   Inject,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { ApiKeyStatus } from '@prisma/client';
@@ -24,6 +25,7 @@ import {
   RotateApiKeyResponse,
 } from '../dto';
 import { ApiKeyAuthContext } from '../types';
+import { PermissionService } from '@/permission/services/permission.service';
 
 /**
  * API Key Service
@@ -35,6 +37,7 @@ export class ApiKeyService {
     private readonly apiKeyRepository: ApiKeyRepository,
     @Inject(apiKeyConfig.KEY)
     private readonly config: ConfigType<typeof apiKeyConfig>,
+    private readonly permissionService: PermissionService,
   ) {}
 
   /**
@@ -49,7 +52,26 @@ export class ApiKeyService {
     userId: string,
     dto: CreateApiKeyDto,
   ): Promise<CreateApiKeyResponse> {
-    // 验证过期时间（如果提供）
+    const requestedScopes = dto.scopes || [];
+
+    if (requestedScopes.length > 0) {
+      const userPermissions =
+        await this.permissionService.getPermissionsByUserId(userId);
+
+      const hasAllScopes = requestedScopes.every((scope) =>
+        userPermissions.includes(scope),
+      );
+
+      if (!hasAllScopes) {
+        const missingScopes = requestedScopes.filter(
+          (scope) => !userPermissions.includes(scope),
+        );
+        throw new ForbiddenException(
+          `Cannot create API key with scopes you don't have. Missing permissions: ${missingScopes.join(', ')}`,
+        );
+      }
+    }
+
     if (dto.expiresAt) {
       const expiresAt = new Date(dto.expiresAt);
       if (expiresAt <= new Date()) {
@@ -57,13 +79,11 @@ export class ApiKeyService {
       }
     }
 
-    // 生成 API Key
     const { rawKey, prefix, keyHash, last4 } = generateApiKey(
       this.config.environment,
       this.config.secret,
     );
 
-    // 存储到数据库
     const apiKey = await this.apiKeyRepository.create({
       organization: {
         connect: { id: organizationId },
@@ -77,12 +97,11 @@ export class ApiKeyService {
       prefix,
       keyHash,
       last4,
-      scopes: dto.scopes || [],
+      scopes: requestedScopes,
       expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : null,
       status: ApiKeyStatus.ACTIVE,
     });
 
-    // 返回响应（包含明文 key，仅此一次）
     return {
       ...this.toDto(apiKey),
       key: rawKey,
@@ -98,6 +117,7 @@ export class ApiKeyService {
   async listKeys(
     organizationId: string,
     pagination?: PaginationDto,
+    userId?: string,
   ): Promise<ApiKeyListResponse> {
     const page = pagination?.page || 1;
     const pageSize = pagination?.pageSize || 10;
@@ -109,6 +129,7 @@ export class ApiKeyService {
         skip,
         take: pageSize,
         orderBy: { createdAt: 'desc' },
+        createdBy: userId,
       },
     );
 
@@ -132,8 +153,8 @@ export class ApiKeyService {
     organizationId: string,
     keyId: string,
     dto: UpdateApiKeyDto,
+    userId: string,
   ): Promise<ApiKeyDto> {
-    // 验证 key 存在且属于该组织
     const existingKey = await this.apiKeyRepository.findById(
       keyId,
       organizationId,
@@ -142,7 +163,28 @@ export class ApiKeyService {
       throw new NotFoundException('API Key not found');
     }
 
-    // 验证过期时间（如果提供）
+    if (existingKey.createdBy !== userId) {
+      throw new ForbiddenException('You can only update API keys you created');
+    }
+
+    if (dto.scopes && dto.scopes.length > 0) {
+      const userPermissions =
+        await this.permissionService.getPermissionsByUserId(userId);
+
+      const hasAllScopes = dto.scopes.every((scope) =>
+        userPermissions.includes(scope),
+      );
+
+      if (!hasAllScopes) {
+        const missingScopes = dto.scopes.filter(
+          (scope) => !userPermissions.includes(scope),
+        );
+        throw new ForbiddenException(
+          `Cannot update API key with scopes you don't have. Missing permissions: ${missingScopes.join(', ')}`,
+        );
+      }
+    }
+
     if (dto.expiresAt) {
       const expiresAt = new Date(dto.expiresAt);
       if (expiresAt <= new Date()) {
@@ -150,7 +192,6 @@ export class ApiKeyService {
       }
     }
 
-    // 更新 key（不改变 prefix 和 keyHash）
     const updatedKey = await this.apiKeyRepository.update(
       keyId,
       organizationId,
@@ -169,8 +210,11 @@ export class ApiKeyService {
    * @param organizationId 组织 ID
    * @param keyId API Key ID
    */
-  async revokeKey(organizationId: string, keyId: string): Promise<void> {
-    // 验证 key 存在且属于该组织
+  async revokeKey(
+    organizationId: string,
+    keyId: string,
+    userId: string,
+  ): Promise<void> {
     const existingKey = await this.apiKeyRepository.findById(
       keyId,
       organizationId,
@@ -179,7 +223,10 @@ export class ApiKeyService {
       throw new NotFoundException('API Key not found');
     }
 
-    // 撤销 key
+    if (existingKey.createdBy !== userId) {
+      throw new ForbiddenException('You can only revoke API keys you created');
+    }
+
     await this.apiKeyRepository.revoke(keyId, organizationId);
   }
 
@@ -192,20 +239,22 @@ export class ApiKeyService {
   async rotateKey(
     organizationId: string,
     keyId: string,
+    userId: string,
   ): Promise<RotateApiKeyResponse> {
-    // 验证旧 key 存在且属于该组织
     const oldKey = await this.apiKeyRepository.findById(keyId, organizationId);
     if (!oldKey) {
       throw new NotFoundException('API Key not found');
     }
 
-    // 生成新 API Key
+    if (oldKey.createdBy !== userId) {
+      throw new ForbiddenException('You can only rotate API keys you created');
+    }
+
     const { rawKey, prefix, keyHash, last4 } = generateApiKey(
       this.config.environment,
       this.config.secret,
     );
 
-    // 创建新 key（保留名称和 scopes）
     const newKey = await this.apiKeyRepository.create({
       organization: {
         connect: { id: organizationId },
@@ -227,10 +276,8 @@ export class ApiKeyService {
       },
     });
 
-    // 撤销旧 key
     await this.apiKeyRepository.revoke(keyId, organizationId);
 
-    // 返回响应（包含新明文 key，仅此一次）
     return {
       ...this.toDto(newKey),
       key: rawKey,


### PR DESCRIPTION
- Add permission checks for API key creation and updates
- Filter API key list by createdBy user
- Restrict key operations to creator user
- Update tests to reflect new permission requirements