### PR TITLE
fix(pagination): add type decorator for includeChildren boolean

### DIFF
--- a/src/org-member/dto/pagination.dto.ts
+++ b/src/org-member/dto/pagination.dto.ts
@@ -1,3 +1,14 @@
+/*
+ * @Author: 杨仕明 shiming.y@qq.com
+ * @Date: 2026-01-19 01:17:20
+ * @LastEditors: 杨仕明 shiming.y@qq.com
+ * @LastEditTime: 2026-01-20 12:05:51
+ * @FilePath: /nove_api/src/org-member/dto/pagination.dto.ts
+ * @Description: 
+ * 
+ * Copyright (c) 2026 by LuLab-Team, All Rights Reserved. 
+ */
+
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsOptional,
@@ -70,6 +81,7 @@ export class PaginationDto {
     example: false,
   })
   @IsOptional()
+  @Type(() => Boolean)
   @IsBoolean()
   includeChildren?: boolean;
 }


### PR DESCRIPTION
The @Type decorator was missing for the includeChildren property, which could cause type conversion issues. This ensures proper boolean type validation.