### PR TITLE
Feature/refactor user search repository (#144)

### DIFF
--- a/src/auth/services/jwt-user-lookup.service.ts
+++ b/src/auth/services/jwt-user-lookup.service.ts
@@ -19,7 +19,7 @@ export class JwtUserLookupService implements JwtUserLookup {
   async getAuthenticatedUserById(
     id: string,
   ): Promise<AuthenticatedUser | null> {
-    const user = await this.userRepo.getUserByIdWithProfileAndRoles(id);
+    const user = await this.userRepo.findWithRoles(id);
     if (!user) return null;
 
     if (!user.active) {

--- a/src/auth/services/login.service.ts
+++ b/src/auth/services/login.service.ts
@@ -83,7 +83,7 @@ export class LoginService {
         }
       }
 
-      await this.userRepo.updateUserLastLoginAt(user.id, new Date());
+      await this.userRepo.updateLastLogin(user.id, new Date());
 
       await this.authPolicy.createLoginLog({
         userId: user.id,
@@ -133,6 +133,6 @@ export class LoginService {
     } else {
       conditions.push({ phone: target });
     }
-    return await this.userRepo.findUserByTarget(target, countryCode);
+    return await this.userRepo.findByTarget(target, countryCode);
   }
 }

--- a/src/auth/services/password.service.ts
+++ b/src/auth/services/password.service.ts
@@ -46,7 +46,7 @@ export class PasswordService {
       throw new BadRequestException(verifyResult.message);
     }
 
-    const user = await this.userRepo.findUserByTarget(target);
+    const user = await this.userRepo.findByTarget(target);
     if (!user) {
       throw new BadRequestException('用户不存在');
     }
@@ -54,7 +54,7 @@ export class PasswordService {
     validatePassword(newPassword);
 
     const hashedPassword = await hashPassword(newPassword);
-    await this.userRepo.updateUserPassword(user.id, hashedPassword);
+    await this.userRepo.updatePassword(user.id, hashedPassword);
 
     await this.authPolicy.createLoginLog({
       userId: user.id,

--- a/src/auth/services/register.service.ts
+++ b/src/auth/services/register.service.ts
@@ -52,7 +52,7 @@ export class RegisterService {
     const hashedPassword = password ? await hashPassword(password) : null;
     const now = new Date();
 
-    const user = await this.userRepo.createUserWithProfile({
+    const user = await this.userRepo.createWithProfile({
       username,
       email: email || null,
       phone,
@@ -148,7 +148,7 @@ export class RegisterService {
 
     if (conditions.length === 0) return;
 
-    const existingUser = await this.userRepo.findFirstByConditions(conditions);
+    const existingUser = await this.userRepo.findFirst(conditions);
 
     if (existingUser) {
       if (username && existingUser.username === username) {

--- a/src/auth/services/token.service.ts
+++ b/src/auth/services/token.service.ts
@@ -2,8 +2,8 @@
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2025-10-01 21:54:50
  * @LastEditors: 杨仕明 shiming.y@qq.com
- * @LastEditTime: 2026-01-09 00:52:45
- * @FilePath: /lulab_backend/src/auth/services/token.service.ts
+ * @LastEditTime: 2026-03-14 20:00:39
+ * @FilePath: /nove_api/src/auth/services/token.service.ts
  * @Description:
  *
  * Copyright (c) 2025 by LuLab-Team, All Rights Reserved.
@@ -124,7 +124,7 @@ export class TokenService {
         throw new UnauthorizedException('刷新令牌无效或已过期');
       }
 
-      const user = await this.userRepo.getUserById(oldTokenRecord.userId);
+      const user = await this.userRepo.findById(oldTokenRecord.userId);
       if (!user) {
         throw new UnauthorizedException('用户不存在');
       }

--- a/src/mcp-server/types/meeting-stats.types.ts
+++ b/src/mcp-server/types/meeting-stats.types.ts
@@ -1,4 +1,8 @@
-import type { Meeting, MeetingParticipant, MeetingRecording } from '@prisma/client';
+import type {
+  Meeting,
+  MeetingParticipant,
+  MeetingRecording,
+} from '@prisma/client';
 
 export type MeetingDetailsResult = Meeting & {
   createdBy: {

--- a/src/tencent-mtg-hook/services/speaker.service.ts
+++ b/src/tencent-mtg-hook/services/speaker.service.ts
@@ -2,7 +2,7 @@
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2025-12-29 01:59:25
  * @LastEditors: 杨仕明 shiming.y@qq.com
- * @LastEditTime: 2026-03-09 14:09:01
+ * @LastEditTime: 2026-03-14 20:02:23
  * @FilePath: /nove_api/src/tencent-mtg-hook/services/speaker.service.ts
  * @Description:
  *
@@ -24,8 +24,8 @@ export class SpeakerService {
   private readonly logger = new Logger(SpeakerService.name);
 
   constructor(
-    private readonly ptUserRepository: PlatformUserRepository,
-    private readonly userRepository: UserRepository,
+    private readonly ptUserRepo: PlatformUserRepository,
+    private readonly userRepo: UserRepository,
   ) {}
 
   async enrichSpeakerInfo(
@@ -96,10 +96,7 @@ export class SpeakerService {
     if (!userid) {
       return null;
     }
-    return this.ptUserRepository.findByPtUserId(
-      Platform.TENCENT_MEETING,
-      userid,
-    );
+    return this.ptUserRepo.findByPtUserId(Platform.TENCENT_MEETING, userid);
   }
 
   private async findUserByName(
@@ -108,10 +105,7 @@ export class SpeakerService {
     if (!username) {
       return null;
     }
-    return this.ptUserRepository.findByPtName(
-      Platform.TENCENT_MEETING,
-      username,
-    );
+    return this.ptUserRepo.findByPtName(Platform.TENCENT_MEETING, username);
   }
 
   private enrichParticipant(
@@ -160,7 +154,7 @@ export class SpeakerService {
       for (const participant of uniqueParticipants) {
         if (participant.phone && participant.phone !== excludedPhoneHash) {
           const ptByPhone =
-            await this.ptUserRepository.findByPlatformAndPhoneHashWithoutLocalUser(
+            await this.ptUserRepo.findByPlatformAndPhoneHashWithoutLocalUser(
               Platform.TENCENT_MEETING,
               countryCode,
               participant.phone,
@@ -169,20 +163,19 @@ export class SpeakerService {
           let userByPhone: User | null = null;
 
           if (ptByPhone?.phone) {
-            userByPhone = await this.userRepository.findUserByPhoneCombination(
+            userByPhone = await this.userRepo.findByPhone(
               countryCode,
               ptByPhone.phone,
             );
           }
 
-          const ptByUnionId =
-            await this.ptUserRepository.findByPlatformAndUnionId(
-              Platform.TENCENT_MEETING,
-              participant.uuid,
-            );
+          const ptByUnionId = await this.ptUserRepo.findByPlatformAndUnionId(
+            Platform.TENCENT_MEETING,
+            participant.uuid,
+          );
 
           if (ptByPhone && !ptByUnionId && userByPhone) {
-            await this.ptUserRepository.update(ptByPhone.id, {
+            await this.ptUserRepo.update(ptByPhone.id, {
               ptUserId: participant.userid,
               displayName: participant.user_name,
               phoneHash: participant.phone,
@@ -192,7 +185,7 @@ export class SpeakerService {
           }
 
           if (ptByPhone && ptByUnionId && userByPhone) {
-            const updatedPtByUnionId = await this.ptUserRepository.update(
+            const updatedPtByUnionId = await this.ptUserRepo.update(
               ptByUnionId.id,
               {
                 ptUserId: participant.userid,
@@ -205,12 +198,12 @@ export class SpeakerService {
             );
 
             if (updatedPtByUnionId) {
-              await this.ptUserRepository.deleteById(ptByPhone.id);
+              await this.ptUserRepo.deleteById(ptByPhone.id);
             }
           }
 
           if (!ptByPhone && !ptByUnionId) {
-            await this.ptUserRepository.upsert(
+            await this.ptUserRepo.upsert(
               {
                 platform: Platform.TENCENT_MEETING,
                 ptUnionId: participant.uuid,
@@ -225,7 +218,7 @@ export class SpeakerService {
 
           if (!ptByPhone && ptByUnionId && !userByPhone) {
             const ptByPhoneHasUser =
-              await this.ptUserRepository.findByPlatformAndPhoneHash(
+              await this.ptUserRepo.findByPlatformAndPhoneHash(
                 Platform.TENCENT_MEETING,
                 countryCode,
                 participant.phone,
@@ -236,14 +229,13 @@ export class SpeakerService {
             }
 
             if (ptByPhoneHasUser?.phone) {
-              const userByPhoneHasUser =
-                await this.userRepository.findUserByPhoneCombination(
-                  countryCode,
-                  ptByPhoneHasUser.phone,
-                );
+              const userByPhoneHasUser = await this.userRepo.findByPhone(
+                countryCode,
+                ptByPhoneHasUser.phone,
+              );
 
               if (userByPhoneHasUser) {
-                await this.ptUserRepository.update(ptByUnionId.id, {
+                await this.ptUserRepo.update(ptByUnionId.id, {
                   ptUserId: participant.userid,
                   displayName: participant.user_name,
                   phoneHash: participant.phone,
@@ -257,7 +249,7 @@ export class SpeakerService {
         }
 
         if (!participant.phone || participant.phone == excludedPhoneHash) {
-          await this.ptUserRepository.upsert(
+          await this.ptUserRepo.upsert(
             {
               platform: Platform.TENCENT_MEETING,
               ptUnionId: participant.uuid,

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -6,11 +6,11 @@ import type { User, UserProfile } from '@prisma/client';
 export class UserRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  getUserById(id: string): Promise<User | null> {
+  findById(id: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-  getUserByIdWithProfile(
+  findWithProfile(
     id: string,
   ): Promise<(User & { profile: UserProfile | null }) | null> {
     return this.prisma.user.findUnique({
@@ -19,7 +19,7 @@ export class UserRepository {
     });
   }
 
-  getUserByIdWithProfileAndRoles(id: string): Promise<
+  findWithRoles(id: string): Promise<
     | (User & {
         profile: UserProfile | null;
         orgMembers: Array<{
@@ -66,18 +66,15 @@ export class UserRepository {
     >;
   }
 
-  findUserByUsername(username: string): Promise<User | null> {
+  findByUsername(username: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { username } });
   }
 
-  findUserByEmail(email: string): Promise<User | null> {
+  findByEmail(email: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { email } });
   }
 
-  findUserByPhoneCombination(
-    countryCode: string,
-    phone: string,
-  ): Promise<User | null> {
+  findByPhone(countryCode: string, phone: string): Promise<User | null> {
     return this.prisma.user.findUnique({
       where: {
         uq_users_country_code_phone: {
@@ -88,7 +85,7 @@ export class UserRepository {
     });
   }
 
-  findUserByTarget(
+  findByTarget(
     target: string,
     countryCode?: string,
   ): Promise<
@@ -151,11 +148,11 @@ export class UserRepository {
     >;
   }
 
-  findFirstByConditions(conditions: Array<Record<string, unknown>>) {
+  findFirst(conditions: Array<Record<string, unknown>>) {
     return this.prisma.user.findFirst({ where: { OR: conditions } });
   }
 
-  createUserWithProfile(data: {
+  createWithProfile(data: {
     username?: string | null;
     email?: string | null;
     phone?: string | null;
@@ -223,21 +220,21 @@ export class UserRepository {
     >;
   }
 
-  updateUserLastLoginAt(id: string, date: Date): Promise<User> {
+  updateLastLogin(id: string, date: Date): Promise<User> {
     return this.prisma.user.update({
       where: { id },
       data: { lastLoginAt: date },
     });
   }
 
-  updateUserPassword(id: string, password: string): Promise<User> {
+  updatePassword(id: string, password: string): Promise<User> {
     return this.prisma.user.update({
       where: { id },
       data: { passwordHash: password },
     });
   }
 
-  updateUserWithProfileUpsert(
+  updateProfile(
     id: string,
     data: {
       username?: string;

--- a/src/user/services/profile.service.ts
+++ b/src/user/services/profile.service.ts
@@ -27,7 +27,7 @@ export class ProfileService {
   constructor(private readonly userRepo: UserRepository) {}
 
   async getProfile(userId: string): Promise<UserProfileResponseDto> {
-    const user = await this.userRepo.getUserByIdWithProfile(userId);
+    const user = await this.userRepo.findWithProfile(userId);
     if (!user) {
       throw new BadRequestException('用户不存在');
     }
@@ -44,20 +44,20 @@ export class ProfileService {
     const { username, email, phone, countryCode, displayName, avatar, bio } =
       updateProfileDto;
 
-    const existingUser = await this.userRepo.getUserByIdWithProfile(userId);
+    const existingUser = await this.userRepo.findWithProfile(userId);
     if (!existingUser) {
       throw new BadRequestException('用户不存在');
     }
 
     if (username && username !== existingUser.username) {
-      const usernameExists = await this.userRepo.findUserByUsername(username);
+      const usernameExists = await this.userRepo.findByUsername(username);
       if (usernameExists) {
         throw new ConflictException('用户名已被使用');
       }
     }
 
     if (email && email !== existingUser.email) {
-      const emailExists = await this.userRepo.findUserByEmail(email);
+      const emailExists = await this.userRepo.findByEmail(email);
       if (emailExists) {
         throw new ConflictException('邮箱已被使用');
       }
@@ -68,7 +68,7 @@ export class ProfileService {
       (phone !== existingUser.phone ||
         updateProfileDto.countryCode !== existingUser.countryCode)
     ) {
-      const phoneExists = await this.userRepo.findUserByPhoneCombination(
+      const phoneExists = await this.userRepo.findByPhone(
         updateProfileDto.countryCode || existingUser.countryCode || '',
         phone,
       );
@@ -77,20 +77,17 @@ export class ProfileService {
       }
     }
 
-    const updatedUser = await this.userRepo.updateUserWithProfileUpsert(
-      userId,
-      {
-        ...(username ? { username } : {}),
-        email,
-        phone,
-        countryCode,
-        profile: {
-          displayName: displayName || username || email?.split('@')[0] || phone,
-          avatar,
-          bio,
-        },
+    const updatedUser = await this.userRepo.updateProfile(userId, {
+      ...(username ? { username } : {}),
+      email,
+      phone,
+      countryCode,
+      profile: {
+        displayName: displayName || username || email?.split('@')[0] || phone,
+        avatar,
+        bio,
       },
-    );
+    });
 
     return formatUserResponse(updatedUser);
   }


### PR DESCRIPTION
* refactor(repositories): simplify repository methods and rename classes

- Rename UserIdSearchRepository to UserSearchRepository and simplify method names
- Simplify findActivePlatformUsersByLocalUserId to findActiveUsers in MeetingStatsRepository
- Remove unused search methods from UserSearchRepository

* refactor(repositories): rename methods for consistency and clarity

- Rename repository methods to use 'get' prefix instead of 'find'
- Shorten method names while maintaining clarity
- Update all references to renamed methods in tools

* refactor(meeting-stats): move MeetingDetailsResult type to separate file

Extract MeetingDetailsResult type definition from repository to dedicated types file for better code organization and reusability

* refactor(tools): reorganize imports in userid-search tool