### PR TITLE
refactor(platform-user): simplify method names in repository

### DIFF
--- a/src/tencent-mtg-hook/services/speaker.service.ts
+++ b/src/tencent-mtg-hook/services/speaker.service.ts
@@ -154,7 +154,7 @@ export class SpeakerService {
       for (const participant of uniqueParticipants) {
         if (participant.phone && participant.phone !== excludedPhoneHash) {
           const ptByPhone =
-            await this.ptUserRepo.findByPlatformAndPhoneHashWithoutLocalUser(
+            await this.ptUserRepo.findByPhoneHashWithoutLocalUser(
               Platform.TENCENT_MEETING,
               countryCode,
               participant.phone,
@@ -169,7 +169,7 @@ export class SpeakerService {
             );
           }
 
-          const ptByUnionId = await this.ptUserRepo.findByPlatformAndUnionId(
+          const ptByUnionId = await this.ptUserRepo.findByUnionId(
             Platform.TENCENT_MEETING,
             participant.uuid,
           );
@@ -217,12 +217,11 @@ export class SpeakerService {
           }
 
           if (!ptByPhone && ptByUnionId && !userByPhone) {
-            const ptByPhoneHasUser =
-              await this.ptUserRepo.findByPlatformAndPhoneHash(
-                Platform.TENCENT_MEETING,
-                countryCode,
-                participant.phone,
-              );
+            const ptByPhoneHasUser = await this.ptUserRepo.findByPhoneHash(
+              Platform.TENCENT_MEETING,
+              countryCode,
+              participant.phone,
+            );
 
             if (ptByPhoneHasUser?.ptUnionId === participant.uuid) {
               continue;

--- a/src/user-platform/repositories/platform-user.repository.ts
+++ b/src/user-platform/repositories/platform-user.repository.ts
@@ -82,7 +82,7 @@ export class PlatformUserRepository {
     );
   }
 
-  async findByPlatformAndUnionId(
+  async findByUnionId(
     platform: Platform,
     ptUnionId: string,
   ): Promise<PlatformUser | null> {
@@ -108,9 +108,7 @@ export class PlatformUserRepository {
     });
   }
 
-  async findActivePlatformUsersByPlatform(
-    platform: Platform,
-  ): Promise<PlatformUser[]> {
+  async findActiveByPlatform(platform: Platform): Promise<PlatformUser[]> {
     return this.prisma.platformUser.findMany({
       where: {
         platform,
@@ -145,7 +143,7 @@ export class PlatformUserRepository {
     });
   }
 
-  async findByPlatformAndPhoneHashWithoutLocalUser(
+  async findByPhoneHashWithoutLocalUser(
     platform: Platform,
     countryCode: string,
     phoneHash: string,
@@ -161,7 +159,7 @@ export class PlatformUserRepository {
     });
   }
 
-  async findByPlatformAndPhoneHash(
+  async findByPhoneHash(
     platform: Platform,
     countryCode: string,
     phoneHash: string,
@@ -176,28 +174,28 @@ export class PlatformUserRepository {
     });
   }
 
-  async updateLastSeenAt(id: string): Promise<PlatformUser> {
+  async updateLastSeen(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
       where: { id },
       data: { lastSeenAt: new Date() },
     });
   }
 
-  async deactivatePlatformUser(id: string): Promise<PlatformUser> {
+  async deactivate(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
       where: { id },
       data: { active: false },
     });
   }
 
-  async activatePlatformUser(id: string): Promise<PlatformUser> {
+  async activate(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
       where: { id },
       data: { active: true },
     });
   }
 
-  async deleteByCountryCodeAndPhone(
+  async deleteByPhone(
     countryCode: string,
     phone: string,
   ): Promise<{ count: number }> {


### PR DESCRIPTION
Remove redundant "Platform" and "User" from method names to make them more concise while maintaining clarity. This improves code readability and reduces verbosity in the codebase.