### PR TITLE
feat(meeting-stats): add periodType to participant summary query

### DIFF
--- a/src/mcp-server/repositories/participant-summary.repository.ts
+++ b/src/mcp-server/repositories/participant-summary.repository.ts
@@ -2,7 +2,7 @@
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2026-03-18 14:04:00
  * @LastEditors: 杨仕明 shiming.y@qq.com
- * @LastEditTime: 2026-03-18 14:04:01
+ * @LastEditTime: 2026-03-19 18:30:45
  * @FilePath: /nove_api/src/mcp-server/repositories/participant-summary.repository.ts
  * @Description:
  *
@@ -11,6 +11,7 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
+import { PeriodType } from '@prisma/client';
 import type { Meeting, ParticipantSummary } from '@prisma/client';
 
 @Injectable()
@@ -21,6 +22,7 @@ export class ParticipantSummaryRepository {
     platformUserIds: string[];
     startDate: Date;
     endDate: Date;
+    periodType: PeriodType;
   }): Promise<
     (ParticipantSummary & {
       meeting: Pick<
@@ -29,10 +31,11 @@ export class ParticipantSummaryRepository {
       > | null;
     })[]
   > {
-    const { platformUserIds, startDate, endDate } = params;
+    const { platformUserIds, startDate, endDate, periodType } = params;
     return this.prisma.participantSummary.findMany({
       where: {
         platformUserId: { in: platformUserIds },
+        periodType,
         createdAt: {
           gte: startDate,
           lte: endDate,

--- a/src/mcp-server/tools/meeting-stats.tool.ts
+++ b/src/mcp-server/tools/meeting-stats.tool.ts
@@ -6,6 +6,7 @@ import {
   ParticipantSummaryRepository,
   PlatformUserRepository,
 } from '../repositories';
+import { PeriodType } from '@prisma/client';
 
 @Injectable()
 export class MeetingStatsTool {
@@ -66,6 +67,7 @@ export class MeetingStatsTool {
       platformUserIds,
       startDate: startDateObj,
       endDate: endDateObj,
+      periodType: PeriodType.SINGLE,
     });
 
     await context.reportProgress({ progress: 70, total: 100 });
@@ -169,14 +171,12 @@ export class MeetingStatsTool {
           ? {
               userId: meeting.createdBy.id,
               name: meeting.createdBy.displayName,
-              email: meeting.createdBy.email,
             }
           : null,
         host: meeting.host
           ? {
               userId: meeting.host.id,
               name: meeting.host.displayName,
-              email: meeting.host.email,
             }
           : null,
         startTime: meeting.startAt?.toISOString(),


### PR DESCRIPTION
Add PeriodType parameter to participant summary repository query to filter by single period meetings. Remove email fields from meeting host and creator objects in response.