### PR TITLE
fix(meeting): 修复路由冲突问题 - GET /meetings/health 被错误捕获

### DIFF
--- a/src/meeting/meeting.controller.ts
+++ b/src/meeting/meeting.controller.ts
@@ -48,6 +48,21 @@ export class MeetingController {
   constructor(private readonly meetingService: MeetingService) {}
 
   /**
+   * 健康检查端点
+   * 注意：此路由必须放在 @Get(':id') 之前，否则会被捕获
+   */
+  @Get('health')
+  @HttpCode(HttpStatus.OK)
+  @ApiHealthCheckDocs()
+  healthCheck() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      service: 'meeting-service',
+    };
+  }
+
+  /**
    * 获取会议记录列表
    */
   @Get()
@@ -79,20 +94,6 @@ export class MeetingController {
       this.logger.error('获取会议记录失败', (error as Error).stack);
       throw error;
     }
-  }
-
-  /**
-   * 健康检查端点
-   */
-  @Get('health')
-  @HttpCode(HttpStatus.OK)
-  @ApiHealthCheckDocs()
-  healthCheck() {
-    return {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-      service: 'meeting-service',
-    };
   }
 
   /**


### PR DESCRIPTION
## 问题描述

修复 Issue #161: 路由冲突导致 `GET /meetings/health` 被 `GET /meetings/:id` 捕获

### 问题原因

NestJS 的路由匹配是按控制器中方法定义的顺序进行的。当 `@Get(':id')` 定义在 `@Get('health')` 之前时，任何路径参数（包括 "health"）都会被 `:id` 捕获，导致健康检查端点无法正确访问。

### 解决方案

将 `@Get('health')` 路由移到 `@Get(':id')` 之前，确保静态路由优先于参数化路由被匹配。

### 变更内容

- 调整 `MeetingController` 中路由方法的定义顺序
- 添加注释说明路由顺序的重要性

### 测试

- [x] 本地验证路由顺序修复
- [x] 等待 CI 测试通过

### 关联 Issue

Fixes #161