### PR TITLE
fix(meeting): 修复 reprocessMeetingRecord 返回过期记录的问题

### DIFF
--- a/src/meeting/meeting.service.ts
+++ b/src/meeting/meeting.service.ts
@@ -193,6 +193,12 @@ export class MeetingService {
     // 重新处理录制文件
     // 这里可以根据需要重新调用处理逻辑
 
-    return record;
+    // 返回更新后的记录
+    const updatedRecord = await this.meetingRepository.findById(id);
+    if (!updatedRecord) {
+      throw new MeetingRecordNotFoundException(id);
+    }
+
+    return updatedRecord;
   }
 }


### PR DESCRIPTION
## 问题描述

修复 Issue #185: `reprocessMeetingRecord` 返回过期记录而非更新后记录

### 问题原因

`reprocessMeetingRecord` 方法在更新处理状态后，直接返回了更新前查询的 `record` 变量，导致返回的数据不包含最新的 `processingStatus` 变更。

### 解决方案

在更新状态后，重新查询记录，确保返回的是最新的数据。

### 变更内容

- 更新状态后重新查询记录
- 添加空值检查以确保数据一致性

### 关联 Issue

Fixes #185