### PR TITLE
fix(auth): 修复 /me 接口暴露用户完整手机号的安全问题

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -51,6 +51,7 @@ import { User, CurrentUser } from '@/auth/decorators/user.decorator';
 import { ClientType } from '@/auth/types/jwt.types';
 import { PermService } from '@/permission/services/permission.service';
 import { HttpUtil } from '@/common/utils/http.util';
+import { DesensitizationUtil } from '@/common/utils/desensitization.util';
 
 @ApiTags('Auth')
 @Controller({
@@ -337,13 +338,13 @@ export class AuthController {
       id: user.id,
       username: user.username || undefined,
       email: user.email,
-      phone: user.phone || undefined,
+      phone: DesensitizationUtil.maskPhone(user.phone),
       countryCode: user.countryCode || undefined,
       name:
         (user.profile?.displayName as string) ||
         user.username ||
         user.email ||
-        user.phone ||
+        DesensitizationUtil.maskPhone(user.phone) ||
         'Unknown',
       avatar: (user.profile?.avatar as string) || undefined,
       roles,

--- a/src/common/utils/desensitization.util.ts
+++ b/src/common/utils/desensitization.util.ts
@@ -1,0 +1,78 @@
+/**
+ * 数据脱敏工具类
+ * 用于敏感信息的脱敏处理
+ */
+
+export class DesensitizationUtil {
+  /**
+   * 手机号脱敏
+   * 保留前3位和后4位，中间用 **** 替代
+   * @param phone 手机号
+   * @returns 脱敏后的手机号
+   */
+  static maskPhone(phone: string | null | undefined): string | undefined {
+    if (!phone) return undefined;
+    
+    // 移除所有非数字字符
+    const cleaned = phone.replace(/\D/g, '');
+    
+    if (cleaned.length < 7) return phone;
+    
+    const prefix = cleaned.slice(0, 3);
+    const suffix = cleaned.slice(-4);
+    
+    return `${prefix}****${suffix}`;
+  }
+
+  /**
+   * 邮箱脱敏
+   * 保留前2位和@后的域名，中间用 *** 替代
+   * @param email 邮箱地址
+   * @returns 脱敏后的邮箱
+   */
+  static maskEmail(email: string | null | undefined): string | undefined {
+    if (!email) return undefined;
+    
+    const atIndex = email.indexOf('@');
+    if (atIndex === -1) return email;
+    
+    const prefix = email.slice(0, Math.min(2, atIndex));
+    const domain = email.slice(atIndex);
+    
+    return `${prefix}***${domain}`;
+  }
+
+  /**
+   * 姓名脱敏
+   * 保留姓氏，名字用 * 替代
+   * @param name 姓名
+   * @returns 脱敏后的姓名
+   */
+  static maskName(name: string | null | undefined): string | undefined {
+    if (!name) return undefined;
+    
+    if (name.length <= 1) return name;
+    
+    const firstChar = name.charAt(0);
+    const masked = '*'.repeat(name.length - 1);
+    
+    return `${firstChar}${masked}`;
+  }
+
+  /**
+   * 身份证号脱敏
+   * 保留前6位和后4位，中间用 ******** 替代
+   * @param idCard 身份证号
+   * @returns 脱敏后的身份证号
+   */
+  static maskIdCard(idCard: string | null | undefined): string | undefined {
+    if (!idCard) return undefined;
+    
+    if (idCard.length < 10) return idCard;
+    
+    const prefix = idCard.slice(0, 6);
+    const suffix = idCard.slice(-4);
+    
+    return `${prefix}********${suffix}`;
+  }
+}


### PR DESCRIPTION
## 问题描述

修复 Issue #187: Auth /me 接口暴露用户完整手机号未脱敏

### 安全风险

`/api/auth/me` 接口直接返回用户的完整手机号，存在隐私泄露风险。

### 解决方案

1. 新增 `DesensitizationUtil` 脱敏工具类，支持：
   - 手机号脱敏：保留前3位和后4位，中间用 **** 替代
   - 邮箱脱敏：保留前2位和域名
   - 姓名脱敏：保留姓氏
   - 身份证号脱敏：保留前6位和后4位

2. 在 `/me` 接口中使用 `DesensitizationUtil.maskPhone()` 对手机号进行脱敏处理

### 变更内容

- 新增 `src/common/utils/desensitization.util.ts`
- 修改 `src/auth/auth.controller.ts` 使用脱敏工具

### 示例

脱敏前：`13812345678`
脱敏后：`138****5678`

### 关联 Issue

Fixes #187