### PR TITLE
fix(mail): 修复 MailProcessor 使用 console.log 的日志规范问题

### DIFF
--- a/src/mail/mail.processor.ts
+++ b/src/mail/mail.processor.ts
@@ -43,6 +43,6 @@ export class MailProcessor extends WorkerHost {
 
   @OnWorkerEvent('completed')
   onCompleted(job: Job) {
-    console.log(`🎉 任务完成: ${job.id}`);
+    this.logger.log(`🎉 任务完成: ${job.id}`);
   }
 }


### PR DESCRIPTION
## 问题描述

修复 Issue #190: MailProcessor 使用 console.log 而非 Logger

### 问题原因

`@OnWorkerEvent('completed')` 方法使用 `console.log`，不符合项目使用 NestJS Logger 的日志规范。

### 解决方案

将 `console.log` 替换为 `this.logger.log()`

### 关联 Issue

Fixes #190