### PR TITLE
fix(tencent): 修复 Tencent API Service 使用 console.error 的日志规范问题

### DIFF
--- a/src/integrations/tencent-meeting/services/api.service.ts
+++ b/src/integrations/tencent-meeting/services/api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { tencentMeetingConfig } from '@/configs/tencent-mtg.config';
 import { generateSignature } from '../utils/crypto.util';
@@ -21,6 +21,7 @@ import {
 @Injectable()
 export class TencentApiService {
   private readonly BASE_URL = 'https://api.meeting.qq.com';
+  private readonly logger = new Logger(TencentApiService.name);
 
   constructor(
     @Inject(tencentMeetingConfig.KEY)
@@ -108,7 +109,7 @@ export class TencentApiService {
 
       return responseData;
     } catch (error: unknown) {
-      console.error('API请求失败:', error);
+      this.logger.error('API请求失败:', error instanceof Error ? error.message : String(error));
       throw error;
     }
   }


### PR DESCRIPTION
## 问题描述

修复 Issue #213: Tencent API Service 使用 console.error 而非 Logger

### 问题原因

`TencentApiService` 在错误处理中使用 `console.error`，不符合项目使用 NestJS Logger 的日志规范。

### 解决方案

1. 导入 `Logger` 类
2. 创建 logger 实例
3. 将 `console.error` 替换为 `this.logger.error()`

### 关联 Issue

Fixes #213