### PR TITLE
fix(api-key): 修复 API Key Repository 使用 console.error 的日志规范问题

### DIFF
--- a/src/api-key/repositories/api-key.repository.ts
+++ b/src/api-key/repositories/api-key.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ApiKey, ApiKeyStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
@@ -8,6 +8,8 @@ import { PrismaService } from '@/prisma/prisma.service';
  */
 @Injectable()
 export class ApiKeyRepository {
+  private readonly logger = new Logger(ApiKeyRepository.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   /**
@@ -135,7 +137,7 @@ export class ApiKeyRepository {
       })
       .catch((error) => {
         // 静默失败，记录错误但不影响主流程
-        console.error('Failed to update lastUsedAt:', error);
+        this.logger.error('Failed to update lastUsedAt:', error instanceof Error ? error.message : String(error));
       });
   }
 


### PR DESCRIPTION
## 问题描述

修复 Issue #212: API Key Repository 使用 console.error 可能泄露敏感信息

### 问题原因

`APIKeyRepository` 使用 `console.error` 记录错误，且在 catch 块中可能输出敏感信息，不符合项目日志规范。

### 解决方案

1. 导入 `Logger` 类
2. 创建 logger 实例
3. 将 `console.error` 替换为 `this.logger.error()`

### 关联 Issue

Fixes #212