### PR TITLE
fix(meeting): 修复 meeting.dto 和 repository 使用 'any' 类型的类型安全问题

### DIFF
--- a/src/meeting/dto/meeting-record-create.dto.ts
+++ b/src/meeting/dto/meeting-record-create.dto.ts
@@ -144,5 +144,5 @@ export class CreateMeetingRecordDto {
     example: { source: 'api' },
   })
   @IsOptional()
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }

--- a/src/meeting/dto/meeting-record-response.dto.ts
+++ b/src/meeting/dto/meeting-record-response.dto.ts
@@ -69,7 +69,7 @@ export class MeetingRecordResponseDto {
   processingStatus: ProcessingStatus;
 
   @ApiPropertyOptional({ description: '元数据' })
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 
   @ApiProperty({ description: '创建时间' })
   createdAt: Date;

--- a/src/meeting/dto/meeting-record-update.dto.ts
+++ b/src/meeting/dto/meeting-record-update.dto.ts
@@ -113,12 +113,12 @@ export class UpdateMeetingRecordDto {
     example: [{ name: '张三', userId: 'user_123' }],
   })
   @IsOptional()
-  participantList?: any;
+  participantList?: Record<string, unknown>[];
 
   @ApiPropertyOptional({
     description: '元数据',
     example: { updatedBy: 'admin' },
   })
   @IsOptional()
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import type { GetMeetingRecordsParams } from '@/meeting/types';
+import { MeetingRecordResponseDto } from '@/meeting/dto';
 
 import { MeetingPlatform, Prisma } from '@prisma/client';
 
@@ -133,7 +134,7 @@ export class MeetingRepository {
    * Get meeting records list
    */
   async get(params: GetMeetingRecordsParams): Promise<{
-    records: any[];
+    records: MeetingRecordResponseDto[];
     total: number;
     page: number;
     limit: number;


### PR DESCRIPTION
## 问题描述

修复 Issue #207, #208: meeting.dto 和 repository 使用 'any' 类型导致类型安全问题

### 问题原因

1. `meeting-record-create.dto.ts` 中 `metadata` 使用 `any`
2. `meeting-record-update.dto.ts` 中 `participantList` 和 `metadata` 使用 `any`
3. `meeting-record-response.dto.ts` 中 `metadata` 使用 `any`
4. `meeting.repository.ts` 中 `get()` 返回值 `records` 使用 `any[]`

### 解决方案

1. 将 `metadata` 类型改为 `Record<string, unknown>`
2. 将 `participantList` 类型改为 `Record<string, unknown>[]`
3. 将 `repository.get()` 返回值改为 `MeetingRecordResponseDto[]`

### 关联 Issue

Fixes #207, Fixes #208