### PR TITLE
fix: getMeetingStats returns hardcoded empty data

### DIFF
--- a/src/meeting/meeting.controller.ts
+++ b/src/meeting/meeting.controller.ts
@@ -202,16 +202,18 @@ export class MeetingController {
   @Get('stats/summary')
   @HttpCode(HttpStatus.OK)
   @ApiGetMeetingStatsDocs()
-  getMeetingStats(
+  async getMeetingStats(
     @Query('startDate') startDate?: string,
     @Query('endDate') endDate?: string,
-  ): MeetingStatsResponseDto {
-    this.logger.log('获取会议统计信息', { startDate, endDate });
+    @Query('platform') platform?: string,
+  ): Promise<MeetingStatsResponseDto> {
+    this.logger.log('获取会议统计信息', { startDate, endDate, platform });
 
     try {
-      const stats = this.meetingService.getMeetingStats({
+      const stats = await this.meetingService.getMeetingStats({
         startDate: startDate ? new Date(startDate) : undefined,
         endDate: endDate ? new Date(endDate) : undefined,
+        platform,
       });
 
       this.logger.log('获取会议统计信息成功');

--- a/src/meeting/meeting.service.ts
+++ b/src/meeting/meeting.service.ts
@@ -155,24 +155,53 @@ export class MeetingService {
   /**
    * 获取会议统计信息
    */
-  getMeetingStats(params: {
+  async getMeetingStats(params: {
     startDate?: Date;
     endDate?: Date;
     platform?: string;
-  }): MeetingStatsResponseDto {
-    void params;
-    // TODO: 实现统计逻辑 - 根据日期范围、平台等条件统计会议数据
-    // - 统计会议总数
-    // - 按平台分组统计
-    // - 按状态分组统计
-    // - 按类型分组统计
-    // - 获取最近会议记录
+  }): Promise<MeetingStatsResponseDto> {
+    const { startDate, endDate, platform } = params;
+
+    // 构建查询条件
+    const where: Prisma.MeetingWhereInput = {
+      deletedAt: null,
+    };
+
+    if (platform) {
+      where.platform = platform as MeetingPlatform;
+    }
+
+    if (startDate || endDate) {
+      where.startAt = {};
+      if (startDate) {
+        where.startAt.gte = startDate;
+      }
+      if (endDate) {
+        where.startAt.lte = endDate;
+      }
+    }
+
+    // 获取总会议数
+    const total = await this.meetingRepository.count(where);
+
+    // 按平台分组统计
+    const platformStats = await this.meetingRepository.groupByPlatform(where);
+
+    // 按状态分组统计
+    const statusStats = await this.meetingRepository.groupByProcessingStatus(where);
+
+    // 按类型分组统计
+    const typeStats = await this.meetingRepository.groupByType(where);
+
+    // 获取最近的会议记录
+    const recentMeetings = await this.meetingRepository.findRecent(where, 5);
+
     return {
-      total: 0,
-      platformStats: [],
-      statusStats: [],
-      typeStats: [],
-      recentMeetings: [],
+      total,
+      platformStats,
+      statusStats,
+      typeStats,
+      recentMeetings,
     };
   }
 

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import type { GetMeetingRecordsParams } from '@/meeting/types';
 
-import { MeetingPlatform, Prisma } from '@prisma/client';
+import { MeetingPlatform, Prisma, ProcessingStatus, MeetingType } from '@prisma/client';
+import { PlatformStatsDto, StatusStatsDto, TypeStatsDto } from '../dto/meeting-record-stats.dto';
+import { MeetingRecordResponseDto } from '../dto/meeting-record-response.dto';
 
 type UpdateMeetingRecordData = Prisma.MeetingUncheckedUpdateInput;
 type CreateMeetingRecordData = Omit<
@@ -210,5 +212,87 @@ export class MeetingRepository {
       limit,
       totalPages: Math.ceil(total / limit),
     };
+  }
+
+  /**
+   * Count meetings matching the given filter
+   */
+  async count(where: Prisma.MeetingWhereInput): Promise<number> {
+    return this.prisma.meeting.count({ where });
+  }
+
+  /**
+   * Group meetings by platform and count
+   */
+  async groupByPlatform(where: Prisma.MeetingWhereInput): Promise<PlatformStatsDto[]> {
+    const results = await this.prisma.meeting.groupBy({
+      by: ['platform'],
+      where,
+      _count: {
+        platform: true,
+      },
+    });
+
+    return results.map((item) => ({
+      platform: item.platform as MeetingPlatform,
+      count: item._count.platform,
+    }));
+  }
+
+  /**
+   * Group meetings by processing status and count
+   */
+  async groupByProcessingStatus(where: Prisma.MeetingWhereInput): Promise<StatusStatsDto[]> {
+    const results = await this.prisma.meeting.groupBy({
+      by: ['processingStatus'],
+      where,
+      _count: {
+        processingStatus: true,
+      },
+    });
+
+    return results.map((item) => ({
+      status: item.processingStatus as ProcessingStatus,
+      count: item._count.processingStatus,
+    }));
+  }
+
+  /**
+   * Group meetings by type and count
+   */
+  async groupByType(where: Prisma.MeetingWhereInput): Promise<TypeStatsDto[]> {
+    const results = await this.prisma.meeting.groupBy({
+      by: ['type'],
+      where,
+      _count: {
+        type: true,
+      },
+    });
+
+    return results.map((item) => ({
+      type: item.type as MeetingType,
+      count: item._count.type,
+    }));
+  }
+
+  /**
+   * Find recent meetings matching the given filter
+   */
+  async findRecent(
+    where: Prisma.MeetingWhereInput,
+    limit: number,
+  ): Promise<MeetingRecordResponseDto[]> {
+    const records = await this.prisma.meeting.findMany({
+      where,
+      include: {
+        recordings: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: limit,
+    });
+
+    return records as MeetingRecordResponseDto[];
   }
 }


### PR DESCRIPTION
## 问题描述

修复 Issue #200: 

`getMeetingStats` 方法在 `src/meeting/meeting.service.ts` 中未实现，始终返回硬编码的空数据。

## 修改内容

### 1. 实现统计逻辑 (meeting.service.ts)
- 将 `getMeetingStats` 方法改为异步方法
- 实现实际的统计计算逻辑：
  - 根据日期范围、平台等条件统计会议数据
  - 按平台分组统计
  - 按处理状态分组统计
  - 按会议类型分组统计
  - 获取最近会议记录

### 2. 添加 Repository 方法 (meeting.repository.ts)
- `count()`: 统计符合条件的会议总数
- `groupByPlatform()`: 按平台分组统计
- `groupByProcessingStatus()`: 按处理状态分组统计
- `groupByType()`: 按会议类型分组统计
- `findRecent()`: 获取最近的会议记录

### 3. 更新 Controller (meeting.controller.ts)
- 将 `getMeetingStats` 方法改为异步方法
- 添加 `platform` 查询参数支持

## 关键改动点

- `MeetingService.getMeetingStats()` 现在返回真实的统计数据
- 支持按日期范围、平台筛选
- 返回包含总数、平台统计、状态统计、类型统计和最近会议记录

## 测试说明

- API 端点 `GET /meetings/stats/summary` 现在返回真实的统计数据
- 支持查询参数：`startDate`, `endDate`, `platform`

---

Closes #200