### PR TITLE
fix: /me/permissions 接口 name 字段使用脱敏手机号

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -373,7 +373,7 @@ export class AuthController {
         (user.profile?.displayName as string) ||
         user.username ||
         user.email ||
-        user.phone ||
+        DesensitizationUtil.maskPhone(user.phone) ||
         'Unknown',
       roles,
       perm,


### PR DESCRIPTION
## 修改说明

修复 Issue #222：/me/permissions 接口在返回用户信息时，name 字段 fallback 链中直接使用原始 user.phone，导致用户手机号以明文形式暴露。

## 关键改动点

- src/auth/auth.controller.ts 第 376 行：将 user.phone 替换为 DesensitizationUtil.maskPhone(user.phone)

## 修改对比

将：
```typescript
user.phone ||
```
替换为：
```typescript
DesensitizationUtil.maskPhone(user.phone) ||
```

## 测试说明

- 代码审查：确认 DesensitizationUtil.maskPhone() 已在此文件第 54 行导入，与 /me 接口（commit 2f4ed40）保持一致
- 构建检查：TypeScript 编译通过
- 逻辑验证：手机号将从 13812345678 格式脱敏为 138****5678

## 关联 Issue

Closes #222
