### PR TITLE
fix: implement email sending logic in MailProcessor (#209)

### DIFF
--- a/src/mail/mail.processor.ts
+++ b/src/mail/mail.processor.ts
@@ -11,27 +11,39 @@
 
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
-import { Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { MailService } from './mail.service';
 
+@Injectable()
 @Processor('mail')
 export class MailProcessor extends WorkerHost {
   private readonly logger = new Logger(MailProcessor.name);
 
+  constructor(private readonly mailService: MailService) {
+    super();
+  }
+
   async process(
-    job: Job<{ email: string; [key: string]: any }, any, string>,
+    job: Job<{ email: string; subject?: string; text?: string; html?: string; [key: string]: any }, any, string>,
   ): Promise<void> {
     try {
       if (job.name === 'sendMail') {
         if (!job.data?.email) {
           throw new Error('Email address is required in job data');
         }
+
         this.logger.log(`📨 正在发送邮件给: ${job.data.email}`);
-        // TODO: Implement actual mail sending logic here
-        // await this.mailService.send(job.data);
+
+        // 使用 MailService 发送邮件
+        await this.mailService.sendSimpleEmail({
+          to: job.data.email,
+          subject: job.data.subject || '通知邮件',
+          text: job.data.text,
+          html: job.data.html,
+        });
+
         this.logger.log(`✅ 邮件发送完成: ${job.data.email}`);
       }
-      // Add await to satisfy the async requirement
-      await Promise.resolve();
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
@@ -43,6 +55,6 @@ export class MailProcessor extends WorkerHost {
 
   @OnWorkerEvent('completed')
   onCompleted(job: Job) {
-    console.log(`🎉 任务完成: ${job.id}`);
+    this.logger.log(`🎉 任务完成: ${job.id}`);
   }
 }


### PR DESCRIPTION
Closes #209

## 修改说明
实现了 mail.processor.ts 中缺失的邮件发送逻辑。

## 关键改动点
1. 在 MailProcessor 中注入 MailService
2. 使用 MailService.sendSimpleEmail() 发送邮件
3. 支持自定义 subject、text、html 参数
4. 将 console.log 替换为 logger.log，保持代码风格一致

## 测试说明
- 邮件队列任务会自动调用 MailService 发送邮件
- 建议通过添加邮件队列任务进行集成测试