### PR TITLE
fix: endDate missing milliseconds precision in getMeetingStats causes data loss

### DIFF
--- a/src/mcp-server/tools/meeting-stats.tool.ts
+++ b/src/mcp-server/tools/meeting-stats.tool.ts
@@ -53,7 +53,7 @@ export class MeetingStatsTool {
     await context.reportProgress({ progress: 10, total: 100 });
 
     const startDateObj = new Date(`${startDate}T00:00:00+08:00`);
-    const endDateObj = new Date(`${endDate}T23:59:59+08:00`);
+    const endDateObj = new Date(`${endDate}T23:59:59.999+08:00`);
 
     this.validateDateRange(startDateObj, endDateObj);
 


### PR DESCRIPTION
Closes #230

## 修改说明
修复了 `getMeetingStats` 中 `endDate` 时间精度不足导致的数据丢失问题。

## 问题分析
在 `src/mcp-server/tools/meeting-stats.tool.ts` 第 56 行，`endDate` 的时间精度只到秒：
```typescript
const endDateObj = new Date(\`${endDate}T23:59:59+08:00\`);
```

当 `createdAt` 字段在数据库中精确到毫秒时，当天最后一秒内（`23:59:59.001` ~ `23:59:59.999`）创建的 `ParticipantSummary` 记录会被 `lte` 条件排除，导致数据遗漏。

## 关键改动点
- 将 `endDate` 时间改为 `23:59:59.999`，确保包含当天最后一毫秒
- 这样可以确保所有当天创建的记录都被正确包含在查询范围内

## 测试说明
- 在当天最后一秒（23:59:59.xxx）创建 ParticipantSummary 记录
- 查询该天的统计数据，应该能够正确包含这些记录
- 验证数据完整性，不再出现边界数据丢失