### PR TITLE
fix: close WSClient connection on module destroy to prevent connection leaks (#203)

### DIFF
--- a/src/integrations/lark/lark.client.spec.ts
+++ b/src/integrations/lark/lark.client.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * @Author: AI Agent
+ * @Date: 2026-03-26
+ * @FilePath: /lulab_backend/src/integrations/lark/lark.client.spec.ts
+ * @Description: Unit tests for LarkClient, specifically the WSClient lifecycle management.
+ *
+ * Copyright (c) 2025 by LuLab-Team, All Rights Reserved.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { LarkClient } from './lark.client';
+import { larkConfig } from '../../configs/lark.config';
+
+describe('LarkClient', () => {
+  let larkClient: LarkClient;
+  let mockWsClientClose: jest.Mock;
+
+  beforeEach(async () => {
+    // Mock the wsClient close method
+    mockWsClientClose = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LarkClient,
+        {
+          provide: larkConfig.KEY,
+          useValue: {
+            appId: 'test-app-id',
+            appSecret: 'test-app-secret',
+            logLevel: 'error',
+          },
+        },
+      ],
+    }).compile();
+
+    larkClient = module.get<LarkClient>(LarkClient);
+
+    // Replace the wsClient with our mock (already initialized in constructor)
+    (larkClient as any).wsClient = {
+      close: mockWsClientClose,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close the WSClient when onModuleDestroy is called', async () => {
+      await larkClient.onModuleDestroy();
+      expect(mockWsClientClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when wsClient is already closed', async () => {
+      mockWsClientClose.mockImplementation(() => {
+        // Simulate close throwing no error
+      });
+      await expect(larkClient.onModuleDestroy()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/integrations/lark/lark.client.ts
+++ b/src/integrations/lark/lark.client.ts
@@ -1,11 +1,11 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { LarkClientConfig } from './types/lark-bitable.types';
 import { larkConfig } from '../../configs/lark.config';
 
 @Injectable()
-export class LarkClient {
+export class LarkClient implements OnModuleDestroy {
   private readonly logger = new Logger(LarkClient.name);
   private client: lark.Client;
 
@@ -89,6 +89,13 @@ export class LarkClient {
     });
 
     this.logger.log('Lark client initialized successfully');
+  }
+
+  async onModuleDestroy() {
+    if (this.wsClient) {
+      this.wsClient.close();
+      this.logger.log('Lark WSClient connection closed');
+    }
   }
 
   /**

--- a/src/lark-meeting/service/lark-event-ws.service.spec.ts
+++ b/src/lark-meeting/service/lark-event-ws.service.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * @Author: AI Agent
+ * @Date: 2026-03-26
+ * @FilePath: /lulab_backend/src/lark-meeting/service/lark-event-ws.service.spec.ts
+ * @Description: Unit tests for LarkEventWsService, specifically the WSClient lifecycle management.
+ *
+ * Copyright (c) 2025 by LuLab-Team, All Rights Reserved.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { LarkEventWsService } from './lark-event-ws.service';
+import { LarkClient } from '@/integrations/lark/lark.client';
+import { LarkMeetingService } from './lark-meeting.service';
+
+describe('LarkEventWsService', () => {
+  let service: LarkEventWsService;
+  let mockWsClientClose: jest.Mock;
+  let mockWsClientStart: jest.Mock;
+
+  beforeEach(async () => {
+    mockWsClientClose = jest.fn();
+    mockWsClientStart = jest.fn().mockReturnValue(undefined);
+
+    const mockLarkClient = {
+      wsClient: {
+        start: mockWsClientStart,
+        close: mockWsClientClose,
+      },
+    };
+
+    const mockLarkMeetingService = {
+      enqueueMeetingEnded: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LarkEventWsService,
+        { provide: LarkClient, useValue: mockLarkClient },
+        { provide: LarkMeetingService, useValue: mockLarkMeetingService },
+      ],
+    }).compile();
+
+    service = module.get<LarkEventWsService>(LarkEventWsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close the WSClient when onModuleDestroy is called', () => {
+      service.onModuleDestroy();
+      expect(mockWsClientClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onModuleInit', () => {
+    it('should start the WSClient when onModuleInit is called', () => {
+      service.onModuleInit();
+      expect(mockWsClientStart).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lark-meeting/service/lark-event-ws.service.ts
+++ b/src/lark-meeting/service/lark-event-ws.service.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2025 by LuLab-Team, All Rights Reserved.
  */
 
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import * as Lark from '@larksuiteoapi/node-sdk';
 import { LarkClient } from '@/integrations/lark/lark.client';
 import { LarkMeetingService } from './lark-meeting.service';
@@ -17,7 +17,7 @@ import { MeetingEndedEventData } from '../types/lark-meeting.types';
 import { LarkEvent } from '../enums/lark-event.enum';
 
 @Injectable()
-export class LarkEventWsService implements OnModuleInit {
+export class LarkEventWsService implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly larkClient: LarkClient,
     private readonly larkMeetingService: LarkMeetingService,
@@ -37,5 +37,9 @@ export class LarkEventWsService implements OnModuleInit {
       '*': () => undefined,
     });
     void this.larkClient.wsClient.start({ eventDispatcher: dispatcher });
+  }
+
+  onModuleDestroy() {
+    this.larkClient.wsClient.close();
   }
 }


### PR DESCRIPTION
## Summary

Closes #203

## Problem

The `LarkClient` in `src/integrations/lark/lark.client.ts` creates a `WSClient` instance in the constructor, but it is never properly closed when the module is destroyed. This causes:

- **Connection leaks**: WebSocket connections accumulate over time
- **Memory leaks**: Old WSClient instances remain in memory
- **Resource exhaustion**: System may run out of available connections
- **No cleanup on application shutdown**: Background connections remain open

## Solution

Implemented `OnModuleDestroy` lifecycle hook in both affected classes to properly close the WebSocket connection:

### 1. LarkClient (`src/integrations/lark/lark.client.ts`)
- Implemented `OnModuleDestroy` interface
- Added `onModuleDestroy()` method that calls `this.wsClient.close()`
- Logs successful connection closure

### 2. LarkEventWsService (`src/lark-meeting/service/lark-event-ws.service.ts`)
- Implemented `OnModuleDestroy` interface
- Added `onModuleDestroy()` method that calls `this.larkClient.wsClient.close()`
- Ensures WSClient is stopped when the service is destroyed

## Key Changes

- **src/integrations/lark/lark.client.ts**
  - Added `OnModuleDestroy` to class declaration
  - Added `async onModuleDestroy()` method with graceful close

- **src/lark-meeting/service/lark-event-ws.service.ts**
  - Added `OnModuleDestroy` to imports and class declaration
  - Added `onModuleDestroy()` method to stop WSClient

## Testing

- Added unit tests for `LarkClient.onModuleDestroy()` (`lark.client.spec.ts`)
- Added unit tests for `LarkEventWsService.onModuleInit()` and `onModuleDestroy()` (`lark-event-ws.service.spec.ts`)
- Tests verify that `wsClient.close()` is called exactly once when `onModuleDestroy()` is invoked

## Related

- Issue #203: Bug: LarkClient WSClient created in constructor causes connection leak
