### PR TITLE
fix: mask sensitive user info in MCP UserInfo Tool

### DIFF
--- a/src/mcp-server/tools/user-info.tool.ts
+++ b/src/mcp-server/tools/user-info.tool.ts
@@ -13,6 +13,7 @@ import { Injectable } from '@nestjs/common';
 import { Tool, ToolScopes, Context } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import { PrismaService } from '@/prisma/prisma.service';
+import { DesensitizationUtil } from '@/common/utils/desensitization.util';
 import type { McpRequestWithUser, McpUserPayload } from '@rekog/mcp-nest';
 
 @Injectable()
@@ -49,9 +50,9 @@ export class UserInfoTool {
       data: {
         id: user.id,
         username: user.username,
-        email: user.email,
+        email: DesensitizationUtil.maskEmail(user.email),
         countryCode: user.countryCode,
-        phone: user.phone,
+        phone: DesensitizationUtil.maskPhone(user.phone),
         emailVerified: !!user.emailVerifiedAt,
         phoneVerified: !!user.phoneVerifiedAt,
         active: user.active,
@@ -124,9 +125,9 @@ export class UserInfoTool {
       data: {
         id: dbUser.id,
         username: dbUser.username,
-        email: dbUser.email,
+        email: DesensitizationUtil.maskEmail(dbUser.email),
         countryCode: dbUser.countryCode,
-        phone: dbUser.phone,
+        phone: DesensitizationUtil.maskPhone(dbUser.phone),
         emailVerified: !!dbUser.emailVerifiedAt,
         phoneVerified: !!dbUser.phoneVerifiedAt,
         active: dbUser.active,


### PR DESCRIPTION
## Summary

Closes #197

## Problem

The MCP UserInfo Tool was exposing users complete phone numbers and email addresses without any masking or obfuscation. This creates a significant security and privacy risk:

- Privacy Violation: Complete phone numbers are exposed in API responses
- Data Leakage: Sensitive personal information is accessible through MCP tools
- Compliance Risk: May violate data protection regulations (GDPR, CCPA, etc.)
- Security Risk: Phone numbers and emails can be used for social engineering attacks

## Solution

Applied data masking to sensitive fields in both getUserInfo and getCurrentUserInfo methods:

1. Phone number masking: Using DesensitizationUtil.maskPhone() to mask phone numbers (e.g., 13812345678 -> 138****5678)
2. Email masking: Using DesensitizationUtil.maskEmail() to mask email addresses (e.g., user@example.com -> us***@example.com)

## Changes

- File: src/mcp-server/tools/user-info.tool.ts
  - Imported DesensitizationUtil from @/common/utils/desensitization.util
  - Applied maskPhone() to phone field in getUserInfo() response
  - Applied maskEmail() to email field in getUserInfo() response
  - Applied maskPhone() to phone field in getCurrentUserInfo() response
  - Applied maskEmail() to email field in getCurrentUserInfo() response

## Security Improvements

- Phone numbers are now masked in all MCP tool responses
- Email addresses are now masked for additional privacy protection
- Sensitive information is properly protected
- Consistent with existing desensitization practices in auth controller

## Testing

- ESLint check: Passed
- Code follows existing project patterns for data masking

## Related

- Issue #197: Security: User phone number exposed without masking in MCP UserInfo Tool
- Issue #198: Security: Auth /me endpoint exposes unmasked phone number (similar fix applied there)
