### PR TITLE
fix: disable unauthenticated access in MCP Server

### DIFF
--- a/src/mcp-server/mcp-server.module.ts
+++ b/src/mcp-server/mcp-server.module.ts
@@ -35,7 +35,7 @@ import { SseController, StreamableHttpController } from './controllers';
         level: ['error', 'warn'], // Only show errors and warnings
       },
       transport: [],
-      allowUnauthenticatedAccess: true,
+      allowUnauthenticatedAccess: false,
       // decorators: [Public()],
       // guards: [McpAuthJwtGuard], // 保护所有 MCP 端点
     }),


### PR DESCRIPTION
## Summary

Closes #196

## Problem

The MCP Server was configured with `allowUnauthenticatedAccess: true`, allowing anyone to access MCP tools without authentication. This created a critical security vulnerability:

- Unauthorized users could access sensitive MCP tools (user-info, meeting-stats, etc.)
- Potential data breach and privacy violation
- No authentication layer for external API access

## Solution

Changed `allowUnauthenticatedAccess` from `true` to `false` in `src/mcp-server/mcp-server.module.ts`.

## Changes

- **File**: `src/mcp-server/mcp-server.module.ts`
  - Line 38: Changed `allowUnauthenticatedAccess: true` to `allowUnauthenticatedAccess: false`

## Security Improvements

- MCP endpoints now require authentication
- Prevents unauthorized access to sensitive tools
- Aligns with security best practices

## Testing

- ESLint check: Passed
- Code follows existing project patterns

## Related

- Issue #196: Security: MCP Server allows unauthenticated access (allowUnauthenticatedAccess: true)
