### PR TITLE
fix: remove unnecessary 500ms sleep delay in task.processor

### DIFF
--- a/src/task/processors/task.processor.ts
+++ b/src/task/processors/task.processor.ts
@@ -142,9 +142,6 @@ export class TaskProcessor extends WorkerHost {
         this.logger.warn(`Unknown job type: ${JSON.stringify(taskName)}`);
     }
 
-    // 模拟：sleep 500ms
-    await new Promise((r) => setTimeout(r, 500));
-
     return { ok: true, at: new Date().toISOString() };
   }
 


### PR DESCRIPTION
## Summary

Closes #238

## Problem

The task.processor.ts file had an unconditional 500ms sleep delay after the switch statement, applied to every task execution including personalMeetingSummary and unknown task types.

This adds unnecessary latency to all task processing without any apparent purpose (the comment says "模拟：sleep 500ms" — simulate 500ms sleep).

## Solution

Removed the unnecessary sleep delay from the default code path.

## Changes

- Removed the unconditional await new Promise((r) => setTimeout(r, 500)) sleep
- File: src/task/processors/task.processor.ts

## Impact

- Performance improvement: All task executions complete faster without artificial delay
- No breaking changes

## Testing

- ESLint check: Passed
- Code follows existing project patterns