### PR TITLE
fix: prevent verification code replay attack with atomic verification

### DIFF
--- a/src/verification/repositories/verification.repository.ts
+++ b/src/verification/repositories/verification.repository.ts
@@ -45,6 +45,42 @@ export class VerificationRepository {
     });
   }
 
+  /**
+   * 原子性地验证并标记验证码为已使用
+   * 使用数据库事务确保验证和标记为已使用是原子操作，防止重放攻击
+   */
+  async verifyAndMarkCodeUsed(
+    target: string,
+    code: string,
+    type: VerificationCodeType,
+  ): Promise<{ id: string; used: boolean } | null> {
+    return this.prisma.$transaction(async (tx) => {
+      // 1. 查找有效的验证码（未使用且未过期）
+      const verificationCode = await tx.verificationCode.findFirst({
+        where: {
+          target,
+          code,
+          type,
+          used: false,
+          expiresAt: { gt: new Date() },
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+      if (!verificationCode) {
+        return null;
+      }
+
+      // 2. 立即标记为已使用（在同一事务中）
+      await tx.verificationCode.update({
+        where: { id: verificationCode.id },
+        data: { used: true },
+      });
+
+      return { id: verificationCode.id, used: true };
+    });
+  }
+
   async deleteExpiredVerificationCodes(before: Date): Promise<number> {
     const result = await this.prisma.verificationCode.deleteMany({
       where: { expiresAt: { lt: before } },

--- a/src/verification/verification.service.ts
+++ b/src/verification/verification.service.ts
@@ -73,7 +73,9 @@ export class VerificationService {
     type: CodeType,
   ): Promise<{ valid: boolean; message: string }> {
     const codeType = this.convertCodeType(type);
-    const verificationCode = await this.repo.findValidVerificationCode(
+
+    // 使用原子操作验证并标记验证码，防止重放攻击
+    const verificationCode = await this.repo.verifyAndMarkCodeUsed(
       target,
       code,
       codeType,
@@ -83,7 +85,6 @@ export class VerificationService {
       return { valid: false, message: '验证码无效或已过期' };
     }
 
-    await this.repo.markVerificationCodeUsed(verificationCode.id);
     return { valid: true, message: '验证码验证成功' };
   }
 


### PR DESCRIPTION
## Summary

Closes #202

## Problem

The verification code system had a race condition vulnerability. The verification and marking-as-used were two separate operations:

1. `findValidVerificationCode()` - Query the database for a valid code
2. `markVerificationCodeUsed()` - Mark the code as used

Between these two operations, there was a time window where multiple concurrent requests could verify the same code successfully, leading to:
- Replay attacks using the same verification code
- Potential security vulnerability
- Inconsistent verification state

## Solution

Implemented an atomic verification operation using Prisma transactions:

1. **New method** `verifyAndMarkCodeUsed()` in repository:
   - Wraps the query and update in a database transaction
   - Uses `prisma.()` to ensure atomicity
   - Returns the verification result only after successfully marking as used

2. **Updated** `verifyCode()` in service:
   - Uses the new atomic method instead of separate operations
   - Eliminates the race condition window

## Changes

- **File**: `src/verification/repositories/verification.repository.ts`
  - Added `verifyAndMarkCodeUsed()` method with transaction support

- **File**: `src/verification/verification.service.ts`
  - Updated `verifyCode()` to use the new atomic method

## Security Improvements

- Prevents verification code replay attacks
- Ensures each code can only be verified once
- Maintains data consistency under concurrent access

## Testing

- ESLint check: Passed
- Code follows existing project patterns
- Transaction ensures atomicity of verify-and-mark operation