### PR TITLE
Fix user-platform error handling and tighten Nest build inputs

### DIFF
--- a/src/user-platform/services/platform-user.service.spec.ts
+++ b/src/user-platform/services/platform-user.service.spec.ts
@@ -65,22 +65,35 @@ describe('PlatformUserService', () => {
     ['activate', (id: string) => service.activate(id)],
     ['deactivate', (id: string) => service.deactivate(id)],
     ['deleteById', (id: string) => service.deleteById(id)],
-  ])('throws NotFoundException when %s targets a missing record', async (_, fn) => {
-    repository.findById.mockResolvedValue(null);
+  ])(
+    'throws NotFoundException when %s targets a missing record',
+    async (_, fn) => {
+      repository.findById.mockResolvedValue(null);
 
-    await expect(fn('missing-id')).rejects.toBeInstanceOf(NotFoundException);
-    expect(repository.findById).toHaveBeenCalledWith('missing-id');
-  });
+      await expect(fn('missing-id')).rejects.toBeInstanceOf(NotFoundException);
+      expect(repository.findById).toHaveBeenCalledWith('missing-id');
+    },
+  );
 
   it.each([
-    ['update', 'update', (id: string) => service.update(id, { displayName: 'next' })],
-    ['updateLastSeen', 'updateLastSeen', (id: string) => service.updateLastSeen(id)],
+    [
+      'update',
+      'update',
+      (id: string) => service.update(id, { displayName: 'next' }),
+    ],
+    [
+      'updateLastSeen',
+      'updateLastSeen',
+      (id: string) => service.updateLastSeen(id),
+    ],
     ['activate', 'activate', (id: string) => service.activate(id)],
     ['deactivate', 'deactivate', (id: string) => service.deactivate(id)],
     ['deleteById', 'deleteById', (id: string) => service.deleteById(id)],
   ])('calls repository.%s after existence check', async (_, method, fn) => {
     repository.findById.mockResolvedValue(platformUser);
-    repository[method as keyof typeof repository].mockResolvedValue(platformUser);
+    repository[method as keyof typeof repository].mockResolvedValue(
+      platformUser,
+    );
 
     await expect(fn(platformUser.id)).resolves.toEqual(platformUser);
     expect(repository.findById).toHaveBeenCalledWith(platformUser.id);

--- a/src/user-platform/services/platform-user.service.spec.ts
+++ b/src/user-platform/services/platform-user.service.spec.ts
@@ -1,0 +1,89 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PlatformUserService } from './platform-user.service';
+import { PlatformUserRepository } from '../repositories/platform-user.repository';
+
+describe('PlatformUserService', () => {
+  let service: PlatformUserService;
+  let repository: {
+    findById: jest.Mock;
+    update: jest.Mock;
+    updateLastSeen: jest.Mock;
+    activate: jest.Mock;
+    deactivate: jest.Mock;
+    deleteById: jest.Mock;
+  };
+
+  const platformUser = {
+    id: 'platform-user-id',
+    platform: 'FEISHU',
+    ptUnionId: 'union-id',
+    active: true,
+  };
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findById: jest.fn(),
+      update: jest.fn(),
+      updateLastSeen: jest.fn(),
+      activate: jest.fn(),
+      deactivate: jest.fn(),
+      deleteById: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlatformUserService,
+        {
+          provide: PlatformUserRepository,
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PlatformUserService>(PlatformUserService);
+    repository = module.get(PlatformUserRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a platform user when findById succeeds', async () => {
+    repository.findById.mockResolvedValue(platformUser);
+
+    await expect(service.findById(platformUser.id)).resolves.toEqual(
+      platformUser,
+    );
+    expect(repository.findById).toHaveBeenCalledWith(platformUser.id);
+  });
+
+  it.each([
+    ['update', (id: string) => service.update(id, { displayName: 'next' })],
+    ['updateLastSeen', (id: string) => service.updateLastSeen(id)],
+    ['activate', (id: string) => service.activate(id)],
+    ['deactivate', (id: string) => service.deactivate(id)],
+    ['deleteById', (id: string) => service.deleteById(id)],
+  ])('throws NotFoundException when %s targets a missing record', async (_, fn) => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(fn('missing-id')).rejects.toBeInstanceOf(NotFoundException);
+    expect(repository.findById).toHaveBeenCalledWith('missing-id');
+  });
+
+  it.each([
+    ['update', 'update', (id: string) => service.update(id, { displayName: 'next' })],
+    ['updateLastSeen', 'updateLastSeen', (id: string) => service.updateLastSeen(id)],
+    ['activate', 'activate', (id: string) => service.activate(id)],
+    ['deactivate', 'deactivate', (id: string) => service.deactivate(id)],
+    ['deleteById', 'deleteById', (id: string) => service.deleteById(id)],
+  ])('calls repository.%s after existence check', async (_, method, fn) => {
+    repository.findById.mockResolvedValue(platformUser);
+    repository[method as keyof typeof repository].mockResolvedValue(platformUser);
+
+    await expect(fn(platformUser.id)).resolves.toEqual(platformUser);
+    expect(repository.findById).toHaveBeenCalledWith(platformUser.id);
+    expect(repository[method as keyof typeof repository]).toHaveBeenCalled();
+  });
+});

--- a/src/user-platform/services/platform-user.service.ts
+++ b/src/user-platform/services/platform-user.service.ts
@@ -6,6 +6,14 @@ import type { PlatformUser, Platform } from '@prisma/client';
 export class PlatformUserService {
   constructor(private readonly platformUserRepo: PlatformUserRepository) {}
 
+  private async ensureExists(id: string) {
+    const platformUser = await this.platformUserRepo.findById(id);
+    if (!platformUser) {
+      throw new NotFoundException('Platform user not found');
+    }
+    return platformUser;
+  }
+
   async create(data: {
     platform: Platform;
     ptUnionId: string;
@@ -21,11 +29,7 @@ export class PlatformUserService {
   }
 
   async findById(id: string) {
-    const platformUser = await this.platformUserRepo.findById(id);
-    if (!platformUser) {
-      throw new NotFoundException('Platform user not found');
-    }
-    return platformUser;
+    return this.ensureExists(id);
   }
 
   async findByUnionId(platform: Platform, ptUnionId: string) {
@@ -120,22 +124,27 @@ export class PlatformUserService {
       active?: boolean;
     },
   ): Promise<PlatformUser> {
+    await this.ensureExists(id);
     return this.platformUserRepo.update(id, data);
   }
 
   async updateLastSeen(id: string): Promise<PlatformUser> {
+    await this.ensureExists(id);
     return this.platformUserRepo.updateLastSeen(id);
   }
 
   async activate(id: string): Promise<PlatformUser> {
+    await this.ensureExists(id);
     return this.platformUserRepo.activate(id);
   }
 
   async deactivate(id: string): Promise<PlatformUser> {
+    await this.ensureExists(id);
     return this.platformUserRepo.deactivate(id);
   }
 
   async deleteById(id: string): Promise<PlatformUser> {
+    await this.ensureExists(id);
     return this.platformUserRepo.deleteById(id);
   }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "coverage",
+    "test",
+    "docs",
+    "documentation",
+    "**/*.spec.ts",
+    "jest.config.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,16 @@
       "@/*": ["src/*"],
       "@common/*": ["src/common/*"]
     }
-  }
+  },
+  "include": ["src/**/*.ts", "prisma/**/*.ts", "scripts/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "coverage",
+    "test",
+    "docs",
+    "documentation",
+    "**/*.spec.ts",
+    "jest.config.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,15 +22,18 @@
       "@common/*": ["src/common/*"]
     }
   },
-  "include": ["src/**/*.ts", "prisma/**/*.ts", "scripts/**/*.ts"],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "prisma/**/*.ts",
+    "scripts/**/*.ts",
+    "jest.config.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",
     "coverage",
-    "test",
     "docs",
-    "documentation",
-    "**/*.spec.ts",
-    "jest.config.ts"
+    "documentation"
   ]
 }


### PR DESCRIPTION
**Summary**
- return `404` instead of `500` for missing `platform-users` records on update, activate/deactivate, last-seen, and delete flows
- add focused unit coverage for `PlatformUserService` missing-record behavior and guarded write operations
- restrict TypeScript/Nest build inputs to app source paths so documentation playground files are excluded from backend builds

**Testing**
- `pnpm test -- --runInBand src/user-platform/services/platform-user.service.spec.ts`
- `pnpm build`
- verified `platform-users` endpoints with `curl` for create, query, update, upsert, activation state changes, and delete flows