### PR TITLE
fix(repository): ensure soft delete consistency in platform user repo…

### DIFF
--- a/src/user-platform/repositories/platform-user.repository.ts
+++ b/src/user-platform/repositories/platform-user.repository.ts
@@ -43,7 +43,7 @@ export class PlatformUserRepository {
     >,
   ): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
-      where: { id },
+      where: { id, deletedAt: null },
       data,
     });
   }
@@ -60,7 +60,7 @@ export class PlatformUserRepository {
     return this.prisma.platformUser.upsert({
       where: { unique_platform_union_user: { platform, ptUnionId } },
       create: { ...data, platform, ptUnionId, lastSeenAt: now },
-      update: { ...data, lastSeenAt: now },
+      update: { ...data, lastSeenAt: now, deletedAt: null },
     });
   }
 
@@ -86,7 +86,7 @@ export class PlatformUserRepository {
         return this.prisma.platformUser.upsert({
           where: { unique_platform_union_user: { platform, ptUnionId } },
           create: { ...data, platform, ptUnionId, lastSeenAt: now },
-          update: { ...data, lastSeenAt: now },
+          update: { ...data, lastSeenAt: now, deletedAt: null },
         });
       }),
     );
@@ -96,19 +96,18 @@ export class PlatformUserRepository {
     platform: Platform,
     ptUnionId: string,
   ): Promise<PlatformUser | null> {
-    return this.prisma.platformUser.findUnique({
+    return this.prisma.platformUser.findFirst({
       where: {
-        unique_platform_union_user: {
-          platform,
-          ptUnionId,
-        },
+        platform,
+        ptUnionId,
+        deletedAt: null,
       },
     });
   }
 
   async findById(id: string): Promise<PlatformUserWithProfile | null> {
-    return this.prisma.platformUser.findUnique({
-      where: { id },
+    return this.prisma.platformUser.findFirst({
+      where: { id, deletedAt: null },
       include: {
         user: {
           include: {
@@ -121,7 +120,10 @@ export class PlatformUserRepository {
 
   async findByUserId(userId: string): Promise<PlatformUser[]> {
     return this.prisma.platformUser.findMany({
-      where: { user: { id: userId } },
+      where: {
+        user: { id: userId },
+        deletedAt: null,
+      },
     });
   }
 
@@ -130,6 +132,7 @@ export class PlatformUserRepository {
       where: {
         platform,
         active: true,
+        deletedAt: null,
       },
     });
   }
@@ -143,6 +146,7 @@ export class PlatformUserRepository {
         platform,
         ptUserId,
         active: true,
+        deletedAt: null,
       },
     });
   }
@@ -156,6 +160,7 @@ export class PlatformUserRepository {
         platform,
         displayName,
         active: true,
+        deletedAt: null,
       },
     });
   }
@@ -172,6 +177,7 @@ export class PlatformUserRepository {
         phoneHash,
         localUserId: null,
         active: true,
+        deletedAt: null,
       },
     });
   }
@@ -187,27 +193,28 @@ export class PlatformUserRepository {
         countryCode,
         phoneHash,
         active: true,
+        deletedAt: null,
       },
     });
   }
 
   async updateLastSeen(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
-      where: { id },
+      where: { id, deletedAt: null },
       data: { lastSeenAt: new Date() },
     });
   }
 
   async deactivate(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
-      where: { id },
+      where: { id, deletedAt: null },
       data: { active: false },
     });
   }
 
   async activate(id: string): Promise<PlatformUser> {
     return this.prisma.platformUser.update({
-      where: { id },
+      where: { id, deletedAt: null },
       data: { active: true },
     });
   }
@@ -216,17 +223,24 @@ export class PlatformUserRepository {
     countryCode: string,
     phone: string,
   ): Promise<{ count: number }> {
-    return this.prisma.platformUser.deleteMany({
+    return this.prisma.platformUser.updateMany({
       where: {
         countryCode,
         phone,
+        deletedAt: null,
+      },
+      data: {
+        deletedAt: new Date(),
       },
     });
   }
 
   async deleteById(id: string): Promise<PlatformUser> {
-    return this.prisma.platformUser.delete({
-      where: { id },
+    return this.prisma.platformUser.update({
+      where: { id, deletedAt: null },
+      data: {
+        deletedAt: new Date(),
+      },
     });
   }
 }


### PR DESCRIPTION
…sitory

Modify all repository methods to filter out soft-deleted records by adding `deletedAt: null` to where clauses. Change delete operations to soft deletes by setting `deletedAt` instead of removing records. This prevents accidental data loss and maintains referential integrity.