### PR TITLE
fix(mail): implement actual email sending in mail.processor (#209)

### DIFF
--- a/src/mail/mail.processor.ts
+++ b/src/mail/mail.processor.ts
@@ -2,7 +2,7 @@
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2025-10-03 03:37:31
  * @LastEditors: 杨仕明 shiming.y@qq.com
- * @LastEditTime: 2025-10-03 04:42:44
+ * @LastEditTime: 2026-04-04 02:17:00
  * @FilePath: /lulab_backend/src/mail/mail.processor.ts
  * @Description:
  *
@@ -12,26 +12,34 @@
 import { Processor, WorkerHost, OnWorkerEvent } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import { Logger } from '@nestjs/common';
+import { MailService } from './mail.service';
+import { SendEmailDto } from './dto/send-email.dto';
 
 @Processor('mail')
 export class MailProcessor extends WorkerHost {
   private readonly logger = new Logger(MailProcessor.name);
 
-  async process(
-    job: Job<{ email: string; [key: string]: any }, any, string>,
-  ): Promise<void> {
+  constructor(private readonly mailService: MailService) {
+    super();
+  }
+
+  async process(job: Job<Partial<SendEmailDto>, any, string>): Promise<void> {
     try {
       if (job.name === 'sendMail') {
-        if (!job.data?.email) {
-          throw new Error('Email address is required in job data');
+        if (!job.data?.to) {
+          throw new Error('Email address (to) is required in job data');
         }
-        this.logger.log(`📨 正在发送邮件给: ${job.data.email}`);
-        // TODO: Implement actual mail sending logic here
-        // await this.mailService.send(job.data);
-        this.logger.log(`✅ 邮件发送完成: ${job.data.email}`);
+        this.logger.log(`📨 正在发送邮件给: ${job.data.to}`);
+        const result = await this.mailService.sendEmail(
+          job.data as SendEmailDto,
+        );
+        if (!result.success) {
+          throw new Error(result.error ?? '邮件发送失败');
+        }
+        this.logger.log(
+          `✅ 邮件发送完成: ${job.data.to}, MessageId: ${result.messageId}`,
+        );
       }
-      // Add await to satisfy the async requirement
-      await Promise.resolve();
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -122,12 +122,15 @@ export class MailService {
     await this.sendSimpleEmail({ to: email, subject, html });
   }
 
-  async sendMailLater(email: string, delayMs: number) {
+  async sendMailLater(dto: SendEmailDto | string, delayMs: number) {
+    const payload: Partial<SendEmailDto> =
+      typeof dto === 'string' ? { to: dto, subject: '', text: '' } : dto;
     await this.mailQueue.add(
       'sendMail',
-      { email },
+      payload,
       { delay: delayMs }, // 设置延迟
     );
-    return `已将发送 ${email} 的任务加入队列，延迟 ${delayMs / 1000} 秒执行`;
+    const to = typeof dto === 'string' ? dto : dto.to;
+    return `已将发送 ${to} 的任务加入队列，延迟 ${delayMs / 1000} 秒执行`;
   }
 }


### PR DESCRIPTION
## Summary

Implements the actual email sending logic in `MailProcessor` instead of the TODO placeholder.

## Changes

### `src/mail/mail.processor.ts`
- Injected `MailService` via constructor
- Replaced TODO placeholder with actual `mailService.sendEmail()` call
- Updated job data type from `{ email: string }` to `Partial<SendEmailDto>`
- Changed validation from `job.data.email` to `job.data.to`
- Added error handling for failed email sends
- Removed unnecessary `await Promise.resolve()`

### `src/mail/mail.service.ts`
- Updated `sendMailLater` to accept `SendEmailDto | string` for backward compatibility
- Full email data (to, subject, text, html, cc, bcc) is now passed to the queue job

## Testing

- ✅ TypeScript compilation passes (no errors in mail module)
- ✅ ESLint passes with no errors

Closes #209