### PR TITLE
test(mail): add regression coverage for issue #214

### DIFF
--- a/src/mail/mail.processor.spec.ts
+++ b/src/mail/mail.processor.spec.ts
@@ -1,0 +1,22 @@
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { MailProcessor } from './mail.processor';
+
+describe('MailProcessor', () => {
+  describe('onCompleted', () => {
+    it('logs completed jobs through Nest Logger instead of console.log', () => {
+      const processor = new MailProcessor();
+      const loggerLogSpy = jest
+        .spyOn(Logger.prototype, 'log')
+        .mockImplementation(() => undefined);
+      const consoleLogSpy = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => undefined);
+
+      processor.onCompleted({ id: 'job-123' } as Job);
+
+      expect(loggerLogSpy).toHaveBeenCalledWith('🎉 任务完成: job-123');
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test for MailProcessor.onCompleted
- verify completed jobs are logged through Nest Logger
- guard against regressions back to console.log usage

## Notes
- `develop` already contains the logger-based implementation for `onCompleted`
- this PR adds regression coverage so issue #214 stays fixed

## Test Plan
- pnpm test:unit -- --runTestsByPath src/mail/mail.processor.spec.ts
- npx eslint src/mail/mail.processor.ts src/mail/mail.processor.spec.ts

Refs #214
