### PR TITLE
refactor(user): improve profile update handling with partial updates

### DIFF
--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -241,7 +241,11 @@ export class UserRepository {
       email?: string;
       phone?: string;
       countryCode?: string;
-      profile?: { displayName?: string; avatar?: string; bio?: string };
+      profile?: Partial<{
+        displayName: string;
+        avatar: string;
+        bio: string;
+      }>;
     },
   ): Promise<User & { profile: UserProfile | null }> {
     const { profile, ...userData } = data;

--- a/src/user/services/profile.service.ts
+++ b/src/user/services/profile.service.ts
@@ -77,16 +77,37 @@ export class ProfileService {
       }
     }
 
+    const profileUpdates: {
+      displayName?: string;
+      avatar?: string;
+      bio?: string;
+    } = {};
+
+    if (displayName !== undefined) {
+      profileUpdates.displayName =
+        displayName ||
+        existingUser.profile?.displayName ||
+        username ||
+        email?.split('@')[0] ||
+        phone;
+    }
+
+    if (avatar !== undefined) {
+      profileUpdates.avatar = avatar;
+    }
+
+    if (bio !== undefined) {
+      profileUpdates.bio = bio;
+    }
+
     const updatedUser = await this.userRepo.updateProfile(userId, {
-      ...(username ? { username } : {}),
-      email,
-      phone,
-      countryCode,
-      profile: {
-        displayName: displayName || username || email?.split('@')[0] || phone,
-        avatar,
-        bio,
-      },
+      ...(username !== undefined ? { username } : {}),
+      ...(email !== undefined ? { email } : {}),
+      ...(phone !== undefined ? { phone } : {}),
+      ...(countryCode !== undefined ? { countryCode } : {}),
+      ...(Object.keys(profileUpdates).length
+        ? { profile: profileUpdates }
+        : {}),
     });
 
     return formatUserResponse(updatedUser);


### PR DESCRIPTION
- change profile type to partial in update query params
- add conditional updates for each profile field instead of overwriting
- only send profile data when there are actual updates
- fix conditional field updates to check for undefined explicitly