### PR TITLE
feat(order): add complete order management module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { DepartmentModule } from './dept/department.module';
 import { OrgMemberModule } from './org-member/org-member.module';
 import { MeetAiModule } from './meet-ai/meet-ai.module';
 import { WechatShopModule } from './wechat-shop/wechat-shop.module';
+import { OrderModule } from './order/order.module';
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { WechatShopModule } from './wechat-shop/wechat-shop.module';
     OrgMemberModule,
     MeetAiModule,
     WechatShopModule,
+    OrderModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/order/controllers/index.ts
+++ b/src/order/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './order.controller';

--- a/src/order/controllers/order.controller.ts
+++ b/src/order/controllers/order.controller.ts
@@ -1,0 +1,135 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '@/auth/guards/jwt-auth.guard';
+import { PermissionGuard } from '@/common/guards';
+import { RequirePermissions } from '@/common/decorators';
+import {
+  CreateOrderDto,
+  OrderDto,
+  OrderListResponse,
+  QueryOrderDto,
+  UpdateOrderDto,
+  UpdateOrderStatusDto,
+} from '../dto';
+import { OrderService } from '../services/order.service';
+
+@ApiTags('Admin - Orders')
+@Controller('admin/orders')
+@UseGuards(JwtAuthGuard, PermissionGuard)
+@ApiBearerAuth()
+export class OrderController {
+  constructor(private readonly orderService: OrderService) {}
+
+  @Post()
+  @RequirePermissions('order:create')
+  @ApiOperation({
+    summary: '创建订单',
+    description: '创建新的订单记录',
+  })
+  @ApiResponse({ status: 201, description: '订单创建成功', type: OrderDto })
+  @ApiResponse({ status: 400, description: '请求参数无效' })
+  @ApiResponse({ status: 401, description: '未授权' })
+  async create(@Body() dto: CreateOrderDto): Promise<OrderDto> {
+    return this.orderService.create(dto);
+  }
+
+  @Get()
+  @RequirePermissions('order:read')
+  @ApiOperation({
+    summary: '订单列表',
+    description: '获取订单列表，支持分页、关键词、状态、渠道和时间筛选',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '订单列表',
+    type: OrderListResponse,
+  })
+  @ApiResponse({ status: 401, description: '未授权' })
+  async findAll(@Query() query: QueryOrderDto): Promise<OrderListResponse> {
+    return this.orderService.findAll(query);
+  }
+
+  @Get(':id')
+  @RequirePermissions('order:read')
+  @ApiOperation({
+    summary: '订单详情',
+    description: '根据 ID 获取订单详情',
+  })
+  @ApiParam({ name: 'id', description: '订单 ID' })
+  @ApiResponse({ status: 200, description: '订单详情', type: OrderDto })
+  @ApiResponse({ status: 401, description: '未授权' })
+  @ApiResponse({ status: 404, description: '订单不存在' })
+  async findById(@Param('id') id: string): Promise<OrderDto> {
+    return this.orderService.findById(id);
+  }
+
+  @Put(':id')
+  @RequirePermissions('order:update')
+  @ApiOperation({
+    summary: '更新订单',
+    description: '更新订单基础信息、金额、状态、支付信息和关联信息',
+  })
+  @ApiParam({ name: 'id', description: '订单 ID' })
+  @ApiResponse({ status: 200, description: '订单更新成功', type: OrderDto })
+  @ApiResponse({ status: 400, description: '请求参数无效' })
+  @ApiResponse({ status: 401, description: '未授权' })
+  @ApiResponse({ status: 404, description: '订单不存在' })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateOrderDto,
+  ): Promise<OrderDto> {
+    return this.orderService.update(id, dto);
+  }
+
+  @Patch(':id/status')
+  @RequirePermissions('order:status')
+  @ApiOperation({
+    summary: '更新订单状态',
+    description: '单独更新订单状态',
+  })
+  @ApiParam({ name: 'id', description: '订单 ID' })
+  @ApiResponse({ status: 200, description: '订单状态更新成功', type: OrderDto })
+  @ApiResponse({ status: 400, description: '请求参数无效' })
+  @ApiResponse({ status: 401, description: '未授权' })
+  @ApiResponse({ status: 404, description: '订单不存在' })
+  async updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateOrderStatusDto,
+  ): Promise<OrderDto> {
+    return this.orderService.updateStatus(id, dto.status);
+  }
+
+  @Delete(':id')
+  @RequirePermissions('order:delete')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: '删除订单',
+    description: '软删除订单',
+  })
+  @ApiParam({ name: 'id', description: '订单 ID' })
+  @ApiResponse({ status: 204, description: '订单删除成功' })
+  @ApiResponse({ status: 401, description: '未授权' })
+  @ApiResponse({ status: 404, description: '订单不存在' })
+  async delete(@Param('id') id: string): Promise<void> {
+    return this.orderService.delete(id);
+  }
+}

--- a/src/order/dto/create-order.dto.ts
+++ b/src/order/dto/create-order.dto.ts
@@ -1,0 +1,227 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, OrderStatus, PaymentProvider } from '@prisma/client';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class CreateOrderDto {
+  @ApiPropertyOptional({
+    description: '内部订单号，不传则由系统生成',
+    example: 'ORD202606150001',
+  })
+  @IsOptional()
+  @IsString()
+  orderCode?: string;
+
+  @ApiPropertyOptional({
+    description: '对外展示订单号，不传则由系统生成',
+    example: '202606151030001',
+  })
+  @IsOptional()
+  @IsString()
+  orderNumber?: string;
+
+  @ApiPropertyOptional({
+    description: '外部平台订单号',
+    example: 'WX_20260615_001',
+  })
+  @IsOptional()
+  @IsString()
+  externalId?: string;
+
+  @ApiPropertyOptional({
+    description: '扩展元数据',
+    example: { source: 'manual' },
+  })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description: '产品 ID',
+    example: 'clx1234567890abcdef',
+  })
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @ApiPropertyOptional({
+    description: '产品名称快照',
+    example: 'NOVE 年度会员',
+  })
+  @IsOptional()
+  @IsString()
+  productName?: string;
+
+  @ApiPropertyOptional({
+    description: '购买者用户 ID',
+    example: 'clx1234567890abcdef',
+  })
+  @IsOptional()
+  @IsString()
+  purchaserId?: string;
+
+  @ApiPropertyOptional({
+    description: '渠道 ID',
+    example: 1,
+  })
+  @IsOptional()
+  @IsInt()
+  channelId?: number;
+
+  @ApiPropertyOptional({
+    description: '客户邮箱',
+    example: 'customer@example.com',
+  })
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @ApiPropertyOptional({
+    description: '客户手机号',
+    example: '13800138000',
+  })
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @ApiPropertyOptional({
+    description: '手机号区号',
+    example: '+86',
+  })
+  @IsOptional()
+  @IsString()
+  phoneCode?: string;
+
+  @ApiPropertyOptional({
+    description: '当前负责人用户 ID',
+    example: 'clx1234567890abcdef',
+  })
+  @IsOptional()
+  @IsString()
+  currentOwnerId?: string;
+
+  @ApiPropertyOptional({
+    description: '财务结单人用户 ID',
+    example: 'clx1234567890abcdef',
+  })
+  @IsOptional()
+  @IsString()
+  financialCloserId?: string;
+
+  @ApiPropertyOptional({
+    description: '财务结单时间',
+    example: '2026-06-15T10:30:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  financialClosedAt?: string;
+
+  @ApiProperty({
+    description: '订单金额，最小货币单位',
+    example: 29900,
+  })
+  @IsInt()
+  @Min(0)
+  amount: number;
+
+  @ApiPropertyOptional({
+    description: '币种',
+    enum: Currency,
+    default: Currency.CNY,
+  })
+  @IsOptional()
+  @IsEnum(Currency)
+  currency?: Currency;
+
+  @ApiPropertyOptional({
+    description: '人民币金额，最小单位分',
+    example: 29900,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  amountCny?: number;
+
+  @ApiPropertyOptional({
+    description: '兑人民币汇率',
+    example: '7.20000000',
+  })
+  @IsOptional()
+  @IsString()
+  fxRateToCny?: string;
+
+  @ApiPropertyOptional({
+    description: '锁汇时间',
+    example: '2026-06-15T10:30:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  fxLockedAt?: string;
+
+  @ApiPropertyOptional({
+    description: '订单状态',
+    enum: OrderStatus,
+    default: OrderStatus.UNPAID,
+  })
+  @IsOptional()
+  @IsEnum(OrderStatus)
+  status?: OrderStatus;
+
+  @ApiPropertyOptional({ description: '支付时间' })
+  @IsOptional()
+  @IsDateString()
+  paidAt?: string;
+
+  @ApiPropertyOptional({ description: '取消时间' })
+  @IsOptional()
+  @IsDateString()
+  cancelledAt?: string;
+
+  @ApiPropertyOptional({ description: '退款时间' })
+  @IsOptional()
+  @IsDateString()
+  refundedAt?: string;
+
+  @ApiPropertyOptional({ description: '完成时间' })
+  @IsOptional()
+  @IsDateString()
+  completedAt?: string;
+
+  @ApiPropertyOptional({ description: '生效时间' })
+  @IsOptional()
+  @IsDateString()
+  effectiveAt?: string;
+
+  @ApiPropertyOptional({ description: '权益开始时间' })
+  @IsOptional()
+  @IsDateString()
+  benefitStart?: string;
+
+  @ApiPropertyOptional({ description: '权益结束时间' })
+  @IsOptional()
+  @IsDateString()
+  benefitEnd?: string;
+
+  @ApiPropertyOptional({
+    description: '支付提供方',
+    enum: PaymentProvider,
+  })
+  @IsOptional()
+  @IsEnum(PaymentProvider)
+  paymentProvider?: PaymentProvider;
+
+  @ApiPropertyOptional({
+    description: '支付平台流水号',
+    example: '4200000000000000000',
+  })
+  @IsOptional()
+  @IsString()
+  providerTradeNo?: string;
+}

--- a/src/order/dto/index.ts
+++ b/src/order/dto/index.ts
@@ -1,0 +1,5 @@
+export * from './create-order.dto';
+export * from './update-order.dto';
+export * from './query-order.dto';
+export * from './update-order-status.dto';
+export * from './order.dto';

--- a/src/order/dto/order.dto.ts
+++ b/src/order/dto/order.dto.ts
@@ -1,0 +1,176 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, OrderStatus, PaymentProvider, Prisma } from '@prisma/client';
+
+export class OrderRelationDto {
+  @ApiProperty({ description: '关联对象 ID' })
+  id: string | number;
+
+  @ApiPropertyOptional({ description: '关联对象编码', nullable: true })
+  code?: string | null;
+
+  @ApiPropertyOptional({ description: '关联对象名称', nullable: true })
+  name?: string | null;
+
+  @ApiPropertyOptional({ description: '关联邮箱', nullable: true })
+  email?: string | null;
+}
+
+export class OrderDto {
+  @ApiProperty({ description: '订单 ID' })
+  id: string;
+
+  @ApiProperty({ description: '内部订单号' })
+  orderCode: string;
+
+  @ApiProperty({ description: '对外展示订单号' })
+  orderNumber: string;
+
+  @ApiPropertyOptional({ description: '外部平台订单号', nullable: true })
+  externalId: string | null;
+
+  @ApiPropertyOptional({ description: '扩展元数据', nullable: true })
+  metadata: Prisma.JsonValue | null;
+
+  @ApiPropertyOptional({ description: '产品 ID', nullable: true })
+  productId: string | null;
+
+  @ApiPropertyOptional({ description: '产品名称快照', nullable: true })
+  productName: string | null;
+
+  @ApiPropertyOptional({ description: '购买者用户 ID', nullable: true })
+  purchaserId: string | null;
+
+  @ApiPropertyOptional({ description: '渠道 ID', nullable: true })
+  channelId: number | null;
+
+  @ApiPropertyOptional({ description: '客户邮箱', nullable: true })
+  email: string | null;
+
+  @ApiPropertyOptional({ description: '客户手机号', nullable: true })
+  phone: string | null;
+
+  @ApiPropertyOptional({ description: '手机号区号', nullable: true })
+  phoneCode: string | null;
+
+  @ApiPropertyOptional({ description: '当前负责人用户 ID', nullable: true })
+  currentOwnerId: string | null;
+
+  @ApiPropertyOptional({ description: '财务结单人用户 ID', nullable: true })
+  financialCloserId: string | null;
+
+  @ApiPropertyOptional({ description: '财务结单时间', nullable: true })
+  financialClosedAt: Date | null;
+
+  @ApiProperty({ description: '订单金额，最小货币单位' })
+  amount: number;
+
+  @ApiProperty({ description: '币种', enum: Currency })
+  currency: Currency;
+
+  @ApiPropertyOptional({
+    description: '人民币金额，最小单位分',
+    nullable: true,
+  })
+  amountCny: number | null;
+
+  @ApiPropertyOptional({ description: '兑人民币汇率', nullable: true })
+  fxRateToCny: string | null;
+
+  @ApiPropertyOptional({ description: '锁汇时间', nullable: true })
+  fxLockedAt: Date | null;
+
+  @ApiProperty({ description: '订单状态', enum: OrderStatus })
+  status: OrderStatus;
+
+  @ApiPropertyOptional({ description: '支付时间', nullable: true })
+  paidAt: Date | null;
+
+  @ApiPropertyOptional({ description: '取消时间', nullable: true })
+  cancelledAt: Date | null;
+
+  @ApiPropertyOptional({ description: '退款时间', nullable: true })
+  refundedAt: Date | null;
+
+  @ApiPropertyOptional({ description: '完成时间', nullable: true })
+  completedAt: Date | null;
+
+  @ApiPropertyOptional({ description: '生效时间', nullable: true })
+  effectiveAt: Date | null;
+
+  @ApiPropertyOptional({ description: '权益开始时间', nullable: true })
+  benefitStart: Date | null;
+
+  @ApiPropertyOptional({ description: '权益结束时间', nullable: true })
+  benefitEnd: Date | null;
+
+  @ApiPropertyOptional({
+    description: '支付提供方',
+    enum: PaymentProvider,
+    nullable: true,
+  })
+  paymentProvider: PaymentProvider | null;
+
+  @ApiPropertyOptional({ description: '支付平台流水号', nullable: true })
+  providerTradeNo: string | null;
+
+  @ApiPropertyOptional({
+    description: '产品信息',
+    type: OrderRelationDto,
+    nullable: true,
+  })
+  product: OrderRelationDto | null;
+
+  @ApiPropertyOptional({
+    description: '购买者信息',
+    type: OrderRelationDto,
+    nullable: true,
+  })
+  purchaser: OrderRelationDto | null;
+
+  @ApiPropertyOptional({
+    description: '渠道信息',
+    type: OrderRelationDto,
+    nullable: true,
+  })
+  channel: OrderRelationDto | null;
+
+  @ApiPropertyOptional({
+    description: '负责人信息',
+    type: OrderRelationDto,
+    nullable: true,
+  })
+  currentOwner: OrderRelationDto | null;
+
+  @ApiPropertyOptional({
+    description: '财务结单人信息',
+    type: OrderRelationDto,
+    nullable: true,
+  })
+  financialCloser: OrderRelationDto | null;
+
+  @ApiProperty({ description: '创建时间' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '更新时间' })
+  updatedAt: Date;
+
+  @ApiPropertyOptional({ description: '删除时间', nullable: true })
+  deletedAt: Date | null;
+}
+
+export class OrderListResponse {
+  @ApiProperty({ description: '订单列表', type: [OrderDto] })
+  items: OrderDto[];
+
+  @ApiProperty({ description: '总数' })
+  total: number;
+
+  @ApiProperty({ description: '当前页码' })
+  page: number;
+
+  @ApiProperty({ description: '每页数量' })
+  pageSize: number;
+
+  @ApiProperty({ description: '总页数' })
+  totalPages: number;
+}

--- a/src/order/dto/query-order.dto.ts
+++ b/src/order/dto/query-order.dto.ts
@@ -1,0 +1,114 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, OrderStatus, PaymentProvider } from '@prisma/client';
+import {
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+
+export class QueryOrderDto {
+  @ApiPropertyOptional({ description: '页码', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: '每页数量', example: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageSize?: number;
+
+  @ApiPropertyOptional({
+    description: '关键词，匹配订单号、外部订单号、商品名、邮箱、手机号或流水号',
+    example: 'ORD2026',
+  })
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({ description: '订单状态', enum: OrderStatus })
+  @IsOptional()
+  @IsEnum(OrderStatus)
+  status?: OrderStatus;
+
+  @ApiPropertyOptional({ description: '币种', enum: Currency })
+  @IsOptional()
+  @IsEnum(Currency)
+  currency?: Currency;
+
+  @ApiPropertyOptional({ description: '支付提供方', enum: PaymentProvider })
+  @IsOptional()
+  @IsEnum(PaymentProvider)
+  paymentProvider?: PaymentProvider;
+
+  @ApiPropertyOptional({ description: '渠道 ID', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  channelId?: number;
+
+  @ApiPropertyOptional({ description: '产品 ID' })
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @ApiPropertyOptional({ description: '购买者用户 ID' })
+  @IsOptional()
+  @IsString()
+  purchaserId?: string;
+
+  @ApiPropertyOptional({ description: '负责人用户 ID' })
+  @IsOptional()
+  @IsString()
+  currentOwnerId?: string;
+
+  @ApiPropertyOptional({ description: '支付开始时间' })
+  @IsOptional()
+  @IsDateString()
+  paidFrom?: string;
+
+  @ApiPropertyOptional({ description: '支付结束时间' })
+  @IsOptional()
+  @IsDateString()
+  paidTo?: string;
+
+  @ApiPropertyOptional({ description: '创建开始时间' })
+  @IsOptional()
+  @IsDateString()
+  createdFrom?: string;
+
+  @ApiPropertyOptional({ description: '创建结束时间' })
+  @IsOptional()
+  @IsDateString()
+  createdTo?: string;
+
+  @ApiPropertyOptional({ description: '是否包含已删除订单', example: false })
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  includeDeleted?: boolean;
+
+  @ApiPropertyOptional({
+    description: '排序字段',
+    example: 'createdAt',
+  })
+  @IsOptional()
+  @IsString()
+  sortField?: string;
+
+  @ApiPropertyOptional({
+    description: '排序方向',
+    example: 'descend',
+  })
+  @IsOptional()
+  @IsString()
+  sortOrder?: 'ascend' | 'descend' | 'asc' | 'desc';
+}

--- a/src/order/dto/update-order-status.dto.ts
+++ b/src/order/dto/update-order-status.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OrderStatus } from '@prisma/client';
+import { IsEnum } from 'class-validator';
+
+export class UpdateOrderStatusDto {
+  @ApiProperty({
+    description: '订单状态',
+    enum: OrderStatus,
+  })
+  @IsEnum(OrderStatus)
+  status: OrderStatus;
+}

--- a/src/order/dto/update-order.dto.ts
+++ b/src/order/dto/update-order.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateOrderDto } from './create-order.dto';
+
+export class UpdateOrderDto extends PartialType(CreateOrderDto) {}

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -1,0 +1,4 @@
+export * from './order.module';
+export * from './services';
+export * from './repositories';
+export * from './dto';

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { PermissionGuard } from '@/common/guards';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { OrderController } from './controllers/order.controller';
+import { OrderRepository } from './repositories/order.repository';
+import { OrderService } from './services/order.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [OrderController],
+  providers: [OrderService, OrderRepository, PermissionGuard],
+  exports: [OrderService, OrderRepository],
+})
+export class OrderModule {}

--- a/src/order/repositories/index.ts
+++ b/src/order/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './order.repository';

--- a/src/order/repositories/order.repository.ts
+++ b/src/order/repositories/order.repository.ts
@@ -1,0 +1,177 @@
+import { Injectable } from '@nestjs/common';
+import { Order, Prisma } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+
+const orderInclude = {
+  product: {
+    select: {
+      id: true,
+      productCode: true,
+      name: true,
+    },
+  },
+  purchaser: {
+    select: {
+      id: true,
+      username: true,
+      email: true,
+      profile: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  },
+  channel: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  currentOwner: {
+    select: {
+      id: true,
+      username: true,
+      email: true,
+      profile: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  },
+  financialCloser: {
+    select: {
+      id: true,
+      username: true,
+      email: true,
+      profile: {
+        select: {
+          displayName: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.OrderInclude;
+
+export type OrderWithRelations = Prisma.OrderGetPayload<{
+  include: typeof orderInclude;
+}>;
+
+@Injectable()
+export class OrderRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: Prisma.OrderCreateInput): Promise<OrderWithRelations> {
+    return this.prisma.order.create({
+      data,
+      include: orderInclude,
+    });
+  }
+
+  async findById(id: string): Promise<OrderWithRelations | null> {
+    return this.prisma.order.findUnique({
+      where: { id },
+      include: orderInclude,
+    });
+  }
+
+  async findByOrderCode(orderCode: string): Promise<Order | null> {
+    return this.prisma.order.findUnique({
+      where: { orderCode },
+    });
+  }
+
+  async findByOrderNumber(orderNumber: string): Promise<Order | null> {
+    return this.prisma.order.findUnique({
+      where: { orderNumber },
+    });
+  }
+
+  async findByChannelIdAndExternalId(
+    channelId: number,
+    externalId: string,
+  ): Promise<Order | null> {
+    return this.prisma.order.findUnique({
+      where: {
+        channelId_externalId: {
+          channelId,
+          externalId,
+        },
+      },
+    });
+  }
+
+  async findMany(options: {
+    skip: number;
+    take: number;
+    where: Prisma.OrderWhereInput;
+    orderBy: Prisma.OrderOrderByWithRelationInput;
+  }): Promise<{ items: OrderWithRelations[]; total: number }> {
+    const [items, total] = await Promise.all([
+      this.prisma.order.findMany({
+        where: options.where,
+        skip: options.skip,
+        take: options.take,
+        orderBy: options.orderBy,
+        include: orderInclude,
+      }),
+      this.prisma.order.count({ where: options.where }),
+    ]);
+
+    return { items, total };
+  }
+
+  async update(
+    id: string,
+    data: Prisma.OrderUpdateInput,
+  ): Promise<OrderWithRelations> {
+    return this.prisma.order.update({
+      where: { id },
+      data,
+      include: orderInclude,
+    });
+  }
+
+  async softDelete(id: string): Promise<OrderWithRelations> {
+    return this.prisma.order.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+      include: orderInclude,
+    });
+  }
+
+  async productExists(id: string): Promise<boolean> {
+    const product = await this.prisma.product.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return !!product;
+  }
+
+  async findProductById(
+    id: string,
+  ): Promise<{ id: string; name: string } | null> {
+    return this.prisma.product.findUnique({
+      where: { id },
+      select: { id: true, name: true },
+    });
+  }
+
+  async userExists(id: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return !!user;
+  }
+
+  async channelExists(id: number): Promise<boolean> {
+    const channel = await this.prisma.channel.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return !!channel;
+  }
+}

--- a/src/order/services/index.ts
+++ b/src/order/services/index.ts
@@ -1,0 +1,1 @@
+export * from './order.service';

--- a/src/order/services/order.service.ts
+++ b/src/order/services/order.service.ts
@@ -1,0 +1,498 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Currency, OrderStatus, Prisma } from '@prisma/client';
+import {
+  CreateOrderDto,
+  OrderDto,
+  OrderListResponse,
+  OrderRelationDto,
+  QueryOrderDto,
+  UpdateOrderDto,
+} from '../dto';
+import {
+  OrderRepository,
+  OrderWithRelations,
+} from '../repositories/order.repository';
+
+const SORT_FIELD_MAP: Record<
+  string,
+  keyof Prisma.OrderOrderByWithRelationInput
+> = {
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
+  paidAt: 'paidAt',
+  amount: 'amount',
+  status: 'status',
+  orderCode: 'orderCode',
+  orderNumber: 'orderNumber',
+  financialClosedAt: 'financialClosedAt',
+};
+
+@Injectable()
+export class OrderService {
+  constructor(private readonly orderRepository: OrderRepository) {}
+
+  async create(dto: CreateOrderDto): Promise<OrderDto> {
+    const { orderCode, orderNumber } = await this.resolveOrderNumbers(dto);
+
+    await this.ensureOrderNumberAvailable(orderCode, orderNumber);
+    await this.ensureExternalIdAvailable(dto.channelId, dto.externalId);
+    await this.ensureRelationsExist(dto);
+
+    const productName = await this.resolveProductName(
+      dto.productId,
+      dto.productName,
+    );
+
+    const order = await this.orderRepository.create({
+      orderCode,
+      orderNumber,
+      externalId: this.trimNullable(dto.externalId),
+      metadata: dto.metadata as Prisma.InputJsonValue | undefined,
+      productName,
+      email: this.trimNullable(dto.email),
+      phone: this.trimNullable(dto.phone),
+      phoneCode: this.trimNullable(dto.phoneCode),
+      financialClosedAt: this.toDate(dto.financialClosedAt),
+      amount: dto.amount,
+      currency: dto.currency ?? Currency.CNY,
+      amountCny: dto.amountCny,
+      fxRateToCny: dto.fxRateToCny,
+      fxLockedAt: this.toDate(dto.fxLockedAt),
+      status: dto.status ?? OrderStatus.UNPAID,
+      paidAt: this.toDate(dto.paidAt),
+      cancelledAt: this.toDate(dto.cancelledAt),
+      refundedAt: this.toDate(dto.refundedAt),
+      completedAt: this.toDate(dto.completedAt),
+      effectiveAt: this.toDate(dto.effectiveAt),
+      benefitStart: this.toDate(dto.benefitStart),
+      benefitEnd: this.toDate(dto.benefitEnd),
+      paymentProvider: dto.paymentProvider,
+      providerTradeNo: this.trimNullable(dto.providerTradeNo),
+      product: dto.productId ? { connect: { id: dto.productId } } : undefined,
+      purchaser: dto.purchaserId
+        ? { connect: { id: dto.purchaserId } }
+        : undefined,
+      channel:
+        dto.channelId !== undefined
+          ? { connect: { id: dto.channelId } }
+          : undefined,
+      currentOwner: dto.currentOwnerId
+        ? { connect: { id: dto.currentOwnerId } }
+        : undefined,
+      financialCloser: dto.financialCloserId
+        ? { connect: { id: dto.financialCloserId } }
+        : undefined,
+    });
+
+    return this.toDto(order);
+  }
+
+  async findAll(query: QueryOrderDto): Promise<OrderListResponse> {
+    const page = query.page || 1;
+    const pageSize = query.pageSize || 10;
+    const skip = (page - 1) * pageSize;
+    const where = this.buildWhere(query);
+    const orderBy = this.buildOrderBy(query);
+
+    const { items, total } = await this.orderRepository.findMany({
+      skip,
+      take: pageSize,
+      where,
+      orderBy,
+    });
+
+    return {
+      items: items.map((item) => this.toDto(item)),
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async findById(id: string): Promise<OrderDto> {
+    const order = await this.findActiveOrder(id);
+    return this.toDto(order);
+  }
+
+  async update(id: string, dto: UpdateOrderDto): Promise<OrderDto> {
+    const existing = await this.findActiveOrder(id);
+
+    if (dto.orderCode && dto.orderCode !== existing.orderCode) {
+      const order = await this.orderRepository.findByOrderCode(dto.orderCode);
+      if (order) {
+        throw new BadRequestException('Order code already exists');
+      }
+    }
+
+    if (dto.orderNumber && dto.orderNumber !== existing.orderNumber) {
+      const order = await this.orderRepository.findByOrderNumber(
+        dto.orderNumber,
+      );
+      if (order) {
+        throw new BadRequestException('Order number already exists');
+      }
+    }
+
+    const nextChannelId =
+      dto.channelId !== undefined ? dto.channelId : existing.channelId;
+    const nextExternalId =
+      dto.externalId !== undefined ? dto.externalId : existing.externalId;
+
+    if (
+      nextChannelId !== null &&
+      nextExternalId &&
+      (nextChannelId !== existing.channelId ||
+        nextExternalId !== existing.externalId)
+    ) {
+      await this.ensureExternalIdAvailable(nextChannelId, nextExternalId, id);
+    }
+
+    await this.ensureRelationsExist(dto);
+
+    const productName =
+      dto.productId !== undefined || dto.productName !== undefined
+        ? await this.resolveProductName(dto.productId, dto.productName)
+        : undefined;
+
+    const order = await this.orderRepository.update(id, {
+      orderCode: this.trimNullable(dto.orderCode),
+      orderNumber: this.trimNullable(dto.orderNumber),
+      externalId: this.trimNullable(dto.externalId),
+      metadata: dto.metadata as Prisma.InputJsonValue | undefined,
+      productName,
+      email: this.trimNullable(dto.email),
+      phone: this.trimNullable(dto.phone),
+      phoneCode: this.trimNullable(dto.phoneCode),
+      financialClosedAt: this.toDate(dto.financialClosedAt),
+      amount: dto.amount,
+      currency: dto.currency,
+      amountCny: dto.amountCny,
+      fxRateToCny: dto.fxRateToCny,
+      fxLockedAt: this.toDate(dto.fxLockedAt),
+      status: dto.status,
+      paidAt: this.toDate(dto.paidAt),
+      cancelledAt: this.toDate(dto.cancelledAt),
+      refundedAt: this.toDate(dto.refundedAt),
+      completedAt: this.toDate(dto.completedAt),
+      effectiveAt: this.toDate(dto.effectiveAt),
+      benefitStart: this.toDate(dto.benefitStart),
+      benefitEnd: this.toDate(dto.benefitEnd),
+      paymentProvider: dto.paymentProvider,
+      providerTradeNo: this.trimNullable(dto.providerTradeNo),
+      product:
+        dto.productId === undefined
+          ? undefined
+          : dto.productId
+            ? { connect: { id: dto.productId } }
+            : { disconnect: true },
+      purchaser:
+        dto.purchaserId === undefined
+          ? undefined
+          : dto.purchaserId
+            ? { connect: { id: dto.purchaserId } }
+            : { disconnect: true },
+      channel:
+        dto.channelId === undefined
+          ? undefined
+          : dto.channelId
+            ? { connect: { id: dto.channelId } }
+            : { disconnect: true },
+      currentOwner:
+        dto.currentOwnerId === undefined
+          ? undefined
+          : dto.currentOwnerId
+            ? { connect: { id: dto.currentOwnerId } }
+            : { disconnect: true },
+      financialCloser:
+        dto.financialCloserId === undefined
+          ? undefined
+          : dto.financialCloserId
+            ? { connect: { id: dto.financialCloserId } }
+            : { disconnect: true },
+    });
+
+    return this.toDto(order);
+  }
+
+  async updateStatus(id: string, status: OrderStatus): Promise<OrderDto> {
+    await this.findActiveOrder(id);
+    const order = await this.orderRepository.update(id, { status });
+    return this.toDto(order);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findActiveOrder(id);
+    await this.orderRepository.softDelete(id);
+  }
+
+  private async findActiveOrder(id: string): Promise<OrderWithRelations> {
+    const order = await this.orderRepository.findById(id);
+    if (!order || order.deletedAt) {
+      throw new NotFoundException('Order not found');
+    }
+    return order;
+  }
+
+  private async resolveOrderNumbers(dto: CreateOrderDto) {
+    const inputOrderCode = dto.orderCode?.trim();
+    const inputOrderNumber = dto.orderNumber?.trim();
+
+    if (inputOrderCode && inputOrderNumber) {
+      return { orderCode: inputOrderCode, orderNumber: inputOrderNumber };
+    }
+
+    for (let index = 0; index < 5; index += 1) {
+      const orderCode = inputOrderCode || this.generateOrderCode();
+      const orderNumber = inputOrderNumber || this.generateOrderNumber();
+      const codeExists = await this.orderRepository.findByOrderCode(orderCode);
+      const numberExists =
+        await this.orderRepository.findByOrderNumber(orderNumber);
+
+      if (!codeExists && !numberExists) {
+        return { orderCode, orderNumber };
+      }
+    }
+
+    throw new BadRequestException('Unable to generate unique order numbers');
+  }
+
+  private async ensureOrderNumberAvailable(
+    orderCode: string,
+    orderNumber: string,
+  ) {
+    const existingCode = await this.orderRepository.findByOrderCode(orderCode);
+    if (existingCode) {
+      throw new BadRequestException('Order code already exists');
+    }
+
+    const existingNumber =
+      await this.orderRepository.findByOrderNumber(orderNumber);
+    if (existingNumber) {
+      throw new BadRequestException('Order number already exists');
+    }
+  }
+
+  private async ensureExternalIdAvailable(
+    channelId?: number | null,
+    externalId?: string | null,
+    excludeOrderId?: string,
+  ) {
+    if (!channelId || !externalId) return;
+
+    const order = await this.orderRepository.findByChannelIdAndExternalId(
+      channelId,
+      externalId,
+    );
+
+    if (order && order.id !== excludeOrderId) {
+      throw new BadRequestException(
+        'External order id already exists in this channel',
+      );
+    }
+  }
+
+  private async ensureRelationsExist(dto: Partial<CreateOrderDto>) {
+    if (dto.productId) {
+      const exists = await this.orderRepository.productExists(dto.productId);
+      if (!exists) throw new NotFoundException('Product not found');
+    }
+
+    if (dto.channelId !== undefined && dto.channelId !== null) {
+      const exists = await this.orderRepository.channelExists(dto.channelId);
+      if (!exists) throw new NotFoundException('Channel not found');
+    }
+
+    await this.ensureUserExists(dto.purchaserId, 'Purchaser not found');
+    await this.ensureUserExists(dto.currentOwnerId, 'Current owner not found');
+    await this.ensureUserExists(
+      dto.financialCloserId,
+      'Financial closer not found',
+    );
+  }
+
+  private async ensureUserExists(userId: string | undefined, message: string) {
+    if (!userId) return;
+    const exists = await this.orderRepository.userExists(userId);
+    if (!exists) throw new NotFoundException(message);
+  }
+
+  private async resolveProductName(
+    productId?: string,
+    productName?: string,
+  ): Promise<string | undefined> {
+    const trimmedName = productName?.trim();
+    if (trimmedName) return trimmedName;
+    if (!productId) return undefined;
+
+    const product = await this.orderRepository.findProductById(productId);
+    return product?.name;
+  }
+
+  private buildWhere(query: QueryOrderDto): Prisma.OrderWhereInput {
+    const where: Prisma.OrderWhereInput = {};
+
+    if (!query.includeDeleted) {
+      where.deletedAt = null;
+    }
+
+    const keyword = query.keyword?.trim();
+    if (keyword) {
+      where.OR = [
+        { orderCode: { contains: keyword, mode: 'insensitive' } },
+        { orderNumber: { contains: keyword, mode: 'insensitive' } },
+        { externalId: { contains: keyword, mode: 'insensitive' } },
+        { productName: { contains: keyword, mode: 'insensitive' } },
+        { email: { contains: keyword, mode: 'insensitive' } },
+        { phone: { contains: keyword, mode: 'insensitive' } },
+        { providerTradeNo: { contains: keyword, mode: 'insensitive' } },
+      ];
+    }
+
+    if (query.status) where.status = query.status;
+    if (query.currency) where.currency = query.currency;
+    if (query.paymentProvider) where.paymentProvider = query.paymentProvider;
+    if (query.channelId !== undefined) where.channelId = query.channelId;
+    if (query.productId) where.productId = query.productId;
+    if (query.purchaserId) where.purchaserId = query.purchaserId;
+    if (query.currentOwnerId) where.currentOwnerId = query.currentOwnerId;
+
+    if (query.paidFrom || query.paidTo) {
+      where.paidAt = {
+        gte: query.paidFrom ? new Date(query.paidFrom) : undefined,
+        lte: query.paidTo ? new Date(query.paidTo) : undefined,
+      };
+    }
+
+    if (query.createdFrom || query.createdTo) {
+      where.createdAt = {
+        gte: query.createdFrom ? new Date(query.createdFrom) : undefined,
+        lte: query.createdTo ? new Date(query.createdTo) : undefined,
+      };
+    }
+
+    return where;
+  }
+
+  private buildOrderBy(
+    query: QueryOrderDto,
+  ): Prisma.OrderOrderByWithRelationInput {
+    const sortField = query.sortField
+      ? SORT_FIELD_MAP[query.sortField]
+      : undefined;
+    const direction =
+      query.sortOrder === 'ascend' || query.sortOrder === 'asc'
+        ? 'asc'
+        : 'desc';
+
+    return sortField ? { [sortField]: direction } : { createdAt: 'desc' };
+  }
+
+  private trimNullable(value?: string | null): string | undefined {
+    if (value === undefined || value === null) return undefined;
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  private toDate(value?: string | null): Date | undefined {
+    if (!value) return undefined;
+    return new Date(value);
+  }
+
+  private generateOrderCode(): string {
+    return `ORD${this.timestamp()}${this.randomSuffix()}`;
+  }
+
+  private generateOrderNumber(): string {
+    return `${this.timestamp()}${this.randomSuffix()}`;
+  }
+
+  private timestamp(): string {
+    const now = new Date();
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return [
+      now.getFullYear(),
+      pad(now.getMonth() + 1),
+      pad(now.getDate()),
+      pad(now.getHours()),
+      pad(now.getMinutes()),
+      pad(now.getSeconds()),
+    ].join('');
+  }
+
+  private randomSuffix(): string {
+    return String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+  }
+
+  private toDto(order: OrderWithRelations): OrderDto {
+    return {
+      id: order.id,
+      orderCode: order.orderCode,
+      orderNumber: order.orderNumber,
+      externalId: order.externalId,
+      metadata: order.metadata,
+      productId: order.productId,
+      productName: order.productName,
+      purchaserId: order.purchaserId,
+      channelId: order.channelId,
+      email: order.email,
+      phone: order.phone,
+      phoneCode: order.phoneCode,
+      currentOwnerId: order.currentOwnerId,
+      financialCloserId: order.financialCloserId,
+      financialClosedAt: order.financialClosedAt,
+      amount: order.amount,
+      currency: order.currency,
+      amountCny: order.amountCny,
+      fxRateToCny: order.fxRateToCny?.toString() ?? null,
+      fxLockedAt: order.fxLockedAt,
+      status: order.status,
+      paidAt: order.paidAt,
+      cancelledAt: order.cancelledAt,
+      refundedAt: order.refundedAt,
+      completedAt: order.completedAt,
+      effectiveAt: order.effectiveAt,
+      benefitStart: order.benefitStart,
+      benefitEnd: order.benefitEnd,
+      paymentProvider: order.paymentProvider,
+      providerTradeNo: order.providerTradeNo,
+      product: order.product
+        ? {
+            id: order.product.id,
+            code: order.product.productCode,
+            name: order.product.name,
+          }
+        : null,
+      purchaser: this.toUserRelation(order.purchaser),
+      channel: order.channel
+        ? {
+            id: order.channel.id,
+            code: order.channel.code,
+            name: order.channel.name,
+          }
+        : null,
+      currentOwner: this.toUserRelation(order.currentOwner),
+      financialCloser: this.toUserRelation(order.financialCloser),
+      createdAt: order.createdAt,
+      updatedAt: order.updatedAt,
+      deletedAt: order.deletedAt,
+    };
+  }
+
+  private toUserRelation(
+    user: OrderWithRelations['purchaser'],
+  ): OrderRelationDto | null {
+    if (!user) return null;
+
+    return {
+      id: user.id,
+      code: user.username,
+      name: user.profile?.displayName || user.username || user.email,
+      email: user.email,
+    };
+  }
+}


### PR DESCRIPTION
This commit adds a full order management feature set including:
- Core order module with dependency injection setup
- RESTful admin API endpoints for CRUD operations on orders
- Complete DTOs for order creation, update, status change, querying and response serialization
- Order repository with Prisma integration and relation handling
- Pagination, filtering and sorting support for order listing
- Validation and permission guards for API security
- Automatic order number generation and uniqueness checks
- Soft delete support for orders