### PR TITLE
feat(meeting): expose host info and derive hasRecording from recordings

### DIFF
--- a/src/meeting/dto/meeting-record-response.dto.ts
+++ b/src/meeting/dto/meeting-record-response.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
 
+export class MeetingHostResponseDto {
+  @ApiProperty({ description: '平台用户 ID' })
+  id: string;
+
+  @ApiPropertyOptional({ description: '主持人显示名称', nullable: true })
+  displayName?: string | null;
+}
+
 export class MeetingRecordResponseDto {
   @ApiProperty({ description: '会议记录ID' })
   id: string;
@@ -37,6 +45,13 @@ export class MeetingRecordResponseDto {
 
   @ApiPropertyOptional({ description: '主持人平台用户ID' })
   hostPlatformUserId?: string | null;
+
+  @ApiPropertyOptional({
+    description: '主持人信息',
+    type: MeetingHostResponseDto,
+    nullable: true,
+  })
+  host?: MeetingHostResponseDto | null;
 
   @ApiPropertyOptional({ description: '参会人数' })
   participantCount?: number | null;

--- a/src/meeting/repositories/meeting.repository.spec.ts
+++ b/src/meeting/repositories/meeting.repository.spec.ts
@@ -301,4 +301,74 @@ describe('MeetingRepository', () => {
       expect(result).toEqual(mockMinimalMeeting);
     });
   });
+
+  describe('get', () => {
+    it('should expose the host under the API contract field name', async () => {
+      (prismaService.meeting.findUnique as jest.Mock).mockResolvedValue({
+        id: 'meeting-with-host',
+        hostId: 'platform-user-1',
+        host: { id: 'platform-user-1', displayName: '杨仕明' },
+        recordings: [],
+      });
+
+      const result = await repository.findById('meeting-with-host');
+
+      expect(result).toEqual({
+        id: 'meeting-with-host',
+        hostPlatformUserId: 'platform-user-1',
+        host: { id: 'platform-user-1', displayName: '杨仕明' },
+        recordings: [],
+      });
+    });
+
+    it('should derive hasRecording from active recording records', async () => {
+      (prismaService.meeting.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'meeting-with-recording',
+          hostId: 'platform-user-1',
+          host: { id: 'platform-user-1', displayName: '杨仕明' },
+          hasRecording: false,
+          recordings: [{ id: 'recording-1' }],
+        },
+        {
+          id: 'meeting-without-recording',
+          hostId: null,
+          host: null,
+          hasRecording: true,
+          recordings: [],
+        },
+      ]);
+      (prismaService.meeting.count as jest.Mock).mockResolvedValue(2);
+
+      const result = await repository.get({ page: 1, limit: 10 });
+
+      expect(result.records).toEqual([
+        {
+          id: 'meeting-with-recording',
+          hostPlatformUserId: 'platform-user-1',
+          host: { id: 'platform-user-1', displayName: '杨仕明' },
+          hasRecording: true,
+        },
+        {
+          id: 'meeting-without-recording',
+          host: null,
+          hostPlatformUserId: null,
+          hasRecording: false,
+        },
+      ]);
+      expect(prismaService.meeting.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            recordings: {
+              where: { deletedAt: null },
+              select: { id: true },
+            },
+            host: {
+              select: { id: true, displayName: true },
+            },
+          },
+        }),
+      );
+    });
+  });
 });

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -14,6 +14,19 @@ type CreateMeetingRecordData = Omit<
 export class MeetingRepository {
   constructor(private prisma: PrismaService) {}
 
+  private toResponseRecord<
+    T extends {
+      hostId: string | null;
+      host?: { id: string; displayName: string | null } | null;
+    },
+  >(record: T) {
+    const { hostId, ...responseRecord } = record;
+    return {
+      ...responseRecord,
+      hostPlatformUserId: hostId,
+    };
+  }
+
   /**
    * Find meeting record by platform and meeting ID
    */
@@ -38,12 +51,17 @@ export class MeetingRepository {
    * Find meeting record by ID
    */
   async findById(id: string) {
-    return this.prisma.meeting.findUnique({
+    const record = await this.prisma.meeting.findUnique({
       where: { id, deletedAt: null },
       include: {
         recordings: true,
+        host: {
+          select: { id: true, displayName: true },
+        },
       },
     });
+
+    return record ? this.toResponseRecord(record) : null;
   }
 
   /**
@@ -194,6 +212,15 @@ export class MeetingRepository {
         omit: {
           metadata: true,
         },
+        include: {
+          recordings: {
+            where: { deletedAt: null },
+            select: { id: true },
+          },
+          host: {
+            select: { id: true, displayName: true },
+          },
+        },
         orderBy: {
           createdAt: 'desc',
         },
@@ -203,8 +230,15 @@ export class MeetingRepository {
       this.prisma.meeting.count({ where }),
     ]);
 
+    const recordsWithRecordingFlag = records.map(
+      ({ recordings, ...record }) => ({
+        ...this.toResponseRecord(record),
+        hasRecording: recordings.length > 0,
+      }),
+    );
+
     return {
-      records,
+      records: recordsWithRecordingFlag,
       total,
       page,
       limit,


### PR DESCRIPTION
## 变更内容

### 新增 `MeetingHostResponseDto`
- 新增 `MeetingHostResponseDto` 类，包含 `id` 和 `displayName` 字段
- 在 `MeetingRecordResponseDto` 中新增 `host` 字段，关联主持人信息

### 重构 `MeetingRepository`
- 新增私有方法 `toResponseRecord`，将 Prisma 的 `hostId` 映射为 API 响应中的 `hostPlatformUserId`，同时透传 `host` 关联对象
- `findById`：增加 `host` 关联查询（select `id` 和 `displayName`）
- `get`（列表查询）：
  - 增加 `host` 关联查询
  - 增加 `recordings` 关联查询（仅 `id`，过滤已删除），并由此动态计算 `hasRecording` 字段，替代原来依赖数据库字段的方式

### 新增测试用例 (`meeting.repository.spec.ts`)
- 验证 `findById` 正确映射 `host` 字段
- 验证 `get` 列表方法正确计算 `hasRecording` 并透传 `host` 信息
- 验证 `get` 方法携带正确的 `include` 参数（`recordings` 和 `host`）