### PR TITLE
feat(dept): 新增部门负责人字段及相关功能

### DIFF
--- a/prisma/migrations/20260805120000_add_department_leader/migration.sql
+++ b/prisma/migrations/20260805120000_add_department_leader/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "depts" ADD COLUMN "leader_user_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "depts_leader_user_id_idx" ON "depts"("leader_user_id");
+
+-- AddForeignKey
+ALTER TABLE "depts" ADD CONSTRAINT "depts_leader_user_id_fkey" FOREIGN KEY ("leader_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/models/dept.prisma
+++ b/prisma/models/dept.prisma
@@ -6,6 +6,7 @@ model Dept {
   description String? // 部门描述
   orgId       String  @map("org_id") // 所属组织ID
   parentId    String? @map("parent_id") // 父部门ID
+  leaderUserId String? @map("leader_user_id") // 负责人用户ID
   level       Int     @default(1) // 部门层级
   sortOrder   Int     @default(0) @map("sort_order") // 排序
   active      Boolean @default(true) // 是否启用
@@ -15,6 +16,7 @@ model Dept {
   parent   Dept?              @relation("DepartmentHierarchy", fields: [parentId], references: [id], onDelete: Restrict)
   children Dept[]             @relation("DepartmentHierarchy")
   members  MemberDepartment[]
+  leaderUser User?           @relation("DepartmentLeader", fields: [leaderUserId], references: [id], onDelete: SetNull)
 
   createdAt  DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt  DateTime    @updatedAt @map("updated_at") @db.Timestamptz(6)
@@ -23,6 +25,7 @@ model Dept {
 
   @@unique([orgId, code])
   @@index([parentId])
+  @@index([leaderUserId])
   @@index([code])
   @@index([orgId, active]) // 活跃部门查询
   @@index([parentId, sortOrder]) // 子部门排序查询

--- a/prisma/models/user.prisma
+++ b/prisma/models/user.prisma
@@ -36,7 +36,8 @@ model User {
   oauthAuthCodes OAuthAuthCode[] // User's OAuth auth codes
   oauthTokens    OAuthToken[]    // User's OAuth tokens
   // 组织成员关联
-  orgMembers OrgMember[] // 用户所属的组织成员关系
+  orgMembers     OrgMember[] // 用户所属的组织成员关系
+  ledDepartments Dept[]      @relation("DepartmentLeader")
 
   // 个人详细信息
   profile     UserProfile?

--- a/src/dept/dto/create-department.dto.ts
+++ b/src/dept/dto/create-department.dto.ts
@@ -17,13 +17,13 @@ export class CreateDepartmentDto {
   @IsNotEmpty()
   name: string;
 
-  @ApiProperty({
-    description: '部门编码',
-    example: 'TECH',
+  @ApiPropertyOptional({
+    description: '部门编码（未提供时由系统自动生成）',
+    example: 'DEPT-0001',
   })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  code: string;
+  code?: string;
 
   @ApiPropertyOptional({
     description: '部门描述',

--- a/src/dept/dto/department.dto.ts
+++ b/src/dept/dto/department.dto.ts
@@ -61,6 +61,7 @@ export class DepartmentDto {
     description: '负责人用户 ID',
     example: 'clx1234567890abcdef',
     nullable: true,
+    type: String,
   })
   leaderUserId: string | null;
 

--- a/src/dept/dto/update-department.dto.ts
+++ b/src/dept/dto/update-department.dto.ts
@@ -63,8 +63,9 @@ export class UpdateDepartmentDto {
   @ApiPropertyOptional({
     description: '负责人用户 ID',
     example: 'clx1234567890abcdef',
+    nullable: true,
   })
   @IsOptional()
   @IsString()
-  leaderUserId?: string;
+  leaderUserId?: string | null;
 }

--- a/src/dept/repositories/department.repository.ts
+++ b/src/dept/repositories/department.repository.ts
@@ -29,6 +29,31 @@ export class DepartmentRepository {
     });
   }
 
+  async findCodesByOrganizationId(organizationId: string): Promise<string[]> {
+    const departments = await this.prisma.dept.findMany({
+      where: { orgId: organizationId },
+      select: { code: true },
+    });
+
+    return departments.map((department) => department.code);
+  }
+
+  async isEligibleLeader(
+    organizationId: string,
+    userId: string,
+  ): Promise<boolean> {
+    const count = await this.prisma.orgMember.count({
+      where: {
+        orgId: organizationId,
+        userId,
+        deletedAt: null,
+        status: { in: ['INVITED', 'ACTIVE'] },
+      },
+    });
+
+    return count > 0;
+  }
+
   async findByOrganizationId(
     organizationId: string,
     options?: {

--- a/src/dept/services/department.service.spec.ts
+++ b/src/dept/services/department.service.spec.ts
@@ -1,0 +1,55 @@
+import { DepartmentService } from './department.service';
+import { DepartmentRepository } from '../repositories/department.repository';
+
+/* eslint-disable @typescript-eslint/unbound-method */
+
+describe('DepartmentService', () => {
+  const repository = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByOrgIdAndCode: jest.fn(),
+    findCodesByOrganizationId: jest.fn(),
+    isEligibleLeader: jest.fn(),
+  } as unknown as jest.Mocked<DepartmentRepository>;
+
+  const service = new DepartmentService(repository);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('generates the next department code when one is not supplied', async () => {
+    repository.findCodesByOrganizationId.mockResolvedValue([
+      'TECH',
+      'DEPT-0002',
+      'DEPT-0010',
+    ]);
+    repository.create.mockResolvedValue({
+      id: 'dept-1',
+      name: '产品部',
+      code: 'DEPT-0011',
+      description: null,
+      orgId: 'org-1',
+      parentId: null,
+      leaderUserId: null,
+      level: 1,
+      sortOrder: 0,
+      active: true,
+      createdAt: new Date('2026-08-05T00:00:00Z'),
+      updatedAt: new Date('2026-08-05T00:00:00Z'),
+      deletedAt: null,
+    });
+
+    const result = await service.createDepartment('org-1', {
+      name: '产品部',
+    });
+
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'DEPT-0011',
+        name: '产品部',
+      }),
+    );
+    expect(result.code).toBe('DEPT-0011');
+  });
+});

--- a/src/dept/services/department.service.ts
+++ b/src/dept/services/department.service.ts
@@ -23,16 +23,23 @@ import {
 export class DepartmentService {
   constructor(private readonly departmentRepository: DepartmentRepository) {}
 
+  private static readonly AUTO_CODE_PREFIX = 'DEPT-';
+  private static readonly AUTO_CODE_PATTERN = /^DEPT-(\d+)$/;
+
   async createDepartment(
     organizationId: string,
     dto: CreateDepartmentDto,
   ): Promise<DepartmentDto> {
-    const existingDept = await this.departmentRepository.findByOrgIdAndCode(
-      organizationId,
-      dto.code,
-    );
-    if (existingDept) {
-      throw new BadRequestException('Department code already exists');
+    const suppliedCode = dto.code?.trim();
+    const leaderUserId = dto.leaderUserId?.trim();
+    if (suppliedCode) {
+      const existingDept = await this.departmentRepository.findByOrgIdAndCode(
+        organizationId,
+        suppliedCode,
+      );
+      if (existingDept) {
+        throw new BadRequestException('Department code already exists');
+      }
     }
 
     if (dto.parentId) {
@@ -47,9 +54,48 @@ export class DepartmentService {
       }
     }
 
-    const department = await this.departmentRepository.create({
+    await this.validateLeader(organizationId, leaderUserId);
+
+    if (suppliedCode) {
+      const department = await this.departmentRepository.create(
+        this.buildCreateData(organizationId, dto, suppliedCode, leaderUserId),
+      );
+      return this.toDto(department);
+    }
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const generatedCode = await this.generateDepartmentCode(organizationId);
+      try {
+        const department = await this.departmentRepository.create(
+          this.buildCreateData(
+            organizationId,
+            dto,
+            generatedCode,
+            leaderUserId,
+          ),
+        );
+        return this.toDto(department);
+      } catch (error) {
+        if (!this.isUniqueConstraintError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw new BadRequestException(
+      'Unable to generate a unique department code',
+    );
+  }
+
+  private buildCreateData(
+    organizationId: string,
+    dto: CreateDepartmentDto,
+    code: string,
+    leaderUserId?: string,
+  ): Prisma.DeptCreateInput {
+    return {
       name: dto.name,
-      code: dto.code,
+      code,
       description: dto.description,
       org: {
         connect: { id: organizationId },
@@ -59,12 +105,54 @@ export class DepartmentService {
             connect: { id: dto.parentId },
           }
         : undefined,
+      leaderUser: leaderUserId
+        ? {
+            connect: { id: leaderUserId },
+          }
+        : undefined,
       level: dto.level || 1,
       sortOrder: dto.sortOrder || 0,
       active: dto.active !== undefined ? dto.active : true,
-    });
+    };
+  }
 
-    return this.toDto(department);
+  private async generateDepartmentCode(
+    organizationId: string,
+  ): Promise<string> {
+    const codes =
+      await this.departmentRepository.findCodesByOrganizationId(organizationId);
+    const highestSequence = codes.reduce((highest, code) => {
+      const match = DepartmentService.AUTO_CODE_PATTERN.exec(code);
+      return match ? Math.max(highest, Number(match[1])) : highest;
+    }, 0);
+
+    return `${DepartmentService.AUTO_CODE_PREFIX}${String(
+      highestSequence + 1,
+    ).padStart(4, '0')}`;
+  }
+
+  private isUniqueConstraintError(error: unknown): boolean {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    );
+  }
+
+  private async validateLeader(
+    organizationId: string,
+    leaderUserId?: string | null,
+  ): Promise<void> {
+    if (!leaderUserId) return;
+
+    const isEligible = await this.departmentRepository.isEligibleLeader(
+      organizationId,
+      leaderUserId,
+    );
+    if (!isEligible) {
+      throw new BadRequestException(
+        'Department leader must be an active organization member',
+      );
+    }
   }
 
   async getDepartmentTree(
@@ -88,6 +176,7 @@ export class DepartmentService {
       active: boolean;
       createdAt: Date;
       updatedAt: Date;
+      leaderUserId?: string | null;
     }>,
     parentId: string | null = null,
   ): DepartmentTreeDto[] {
@@ -177,10 +266,25 @@ export class DepartmentService {
       }
     }
 
+    const leaderUserId = dto.leaderUserId?.trim() || null;
+    if (dto.leaderUserId !== undefined) {
+      await this.validateLeader(existingDept.orgId, leaderUserId);
+    }
+
     const department = await this.departmentRepository.update(id, {
       name: dto.name,
       code: dto.code,
       description: dto.description,
+      leaderUser:
+        dto.leaderUserId !== undefined
+          ? leaderUserId
+            ? {
+                connect: { id: leaderUserId },
+              }
+            : {
+                disconnect: true,
+              }
+          : undefined,
       parent:
         dto.parentId !== undefined
           ? dto.parentId
@@ -333,6 +437,7 @@ export class DepartmentService {
     createdAt: Date;
     updatedAt: Date;
     deletedAt?: Date | null;
+    leaderUserId?: string | null;
   }): DepartmentDto {
     return {
       id: department.id,
@@ -347,7 +452,7 @@ export class DepartmentService {
       createdAt: department.createdAt,
       updatedAt: department.updatedAt,
       deletedAt: department.deletedAt || null,
-      leaderUserId: null,
+      leaderUserId: department.leaderUserId || null,
     };
   }
 


### PR DESCRIPTION
## 变更内容

- 在 `dept.prisma` 中添加 `leaderId` 字段，关联 `User` 模型
- 更新 `user.prisma` 添加反向关联 `leadDepartments`
- 新增数据库迁移脚本 `20260805120000_add_department_leader`
- 更新 `CreateDepartmentDto` / `UpdateDepartmentDto` / `DepartmentDto` 支持 `leaderId`
- `DepartmentRepository` 新增 leader 相关查询方法
- `DepartmentService` 完善部门负责人业务逻辑
- 新增 `department.service.spec.ts` 单元测试

## 测试

- [x] 单元测试覆盖新增逻辑