### PR TITLE
fix(meeting): add snake_case mappings to meeting model columns

### DIFF
--- a/prisma/migrations/20260812042348_rename_meet_columns/migration.sql
+++ b/prisma/migrations/20260812042348_rename_meet_columns/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "meetings" RENAME COLUMN "hasRecording" TO "has_recording";
+ALTER TABLE "meetings" RENAME COLUMN "recordingStatus" TO "recording_status";
+ALTER TABLE "meetings" RENAME COLUMN "processingStatus" TO "processing_status";
+ALTER TABLE "meetings" RENAME COLUMN "participantCount" TO "participant_count";
+
+ALTER INDEX "meetings_recordingStatus_idx" RENAME TO "meetings_recording_status_idx";
+ALTER INDEX "meetings_processingStatus_idx" RENAME TO "meetings_processing_status_idx";

--- a/prisma/models/meet.prisma
+++ b/prisma/models/meet.prisma
@@ -20,7 +20,7 @@ model Meeting {
   createdBy        PlatformUser? @relation("MeetingCreator", fields: [createdById], references: [id], onDelete: SetNull)
   hostId           String?       @map("host_id") // Host's platform user ID
   host             PlatformUser? @relation("HostedMeetings", fields: [hostId], references: [id], onDelete: SetNull)
-  participantCount Int? // 参与人数
+  participantCount Int? @map("participant_count") // 参与人数
 
   // 时间信息
   scheduledStartAt DateTime? @map("scheduled_start_at") @db.Timestamptz(6) // 预定开始时间
@@ -31,9 +31,9 @@ model Meeting {
   timezone         String?   @db.VarChar(50) // 时区
 
   // 录制和处理状态
-  hasRecording     Boolean          @default(false)
-  recordingStatus  ProcessingStatus @default(PENDING) // Status for recording processing (e.g. video/audio file generation)
-  processingStatus ProcessingStatus @default(PENDING) // Status for overall meeting processing (e.g. transcription, summary generation)
+  hasRecording     Boolean          @default(false) @map("has_recording")
+  recordingStatus  ProcessingStatus @default(PENDING) @map("recording_status") // Status for recording processing (e.g. video/audio file generation)
+  processingStatus ProcessingStatus @default(PENDING) @map("processing_status") // Status for overall meeting processing (e.g. transcription, summary generation)
 
   // 元数据
   metadata Json @default("{}") @db.JsonB // 平台特定的元数据


### PR DESCRIPTION
Added @map to meeting model fields to ensure they use snake_case in the database schema (e.g. participant_count instead of participantCount). Included the corresponding Prisma migration.