### PR TITLE
feat(product): add product management API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,6 +53,7 @@ import { WebhookLogModule } from './webhook-log/webhook-log.module';
 import { OAuthModule } from './oauth/oauth.module';
 import { SystemConfigModule } from './admin/system-config/system-config.module';
 import { AdminUserModule } from './admin/user/user.module';
+import { ProductModule } from './product/product.module';
 
 @Module({
   imports: [
@@ -122,6 +123,7 @@ import { AdminUserModule } from './admin/user/user.module';
     OAuthModule,
     SystemConfigModule,
     AdminUserModule,
+    ProductModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/product/controllers/product.controller.ts
+++ b/src/product/controllers/product.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RequirePermissions } from '@/admin/permission/decorators/permissions.decorator';
+import { Auth } from '@/auth/decorators/auth.decorator';
+import {
+  CreateProductDto,
+  ProductDto,
+  ProductListResponseDto,
+  QueryProductDto,
+  UpdateProductDto,
+  UpdateProductStatusDto,
+} from '../dto';
+import { ProductService } from '../services/product.service';
+
+@ApiTags('Admin - Products')
+@ApiBearerAuth()
+@Controller('admin/products')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Post()
+  @RequirePermissions('product:create')
+  @ApiOperation({ summary: '创建产品' })
+  @ApiResponse({ status: 201, type: ProductDto })
+  create(
+    @Body() dto: CreateProductDto,
+    @Auth('userId') userId?: string,
+  ): Promise<ProductDto> {
+    return this.productService.create(dto, userId);
+  }
+
+  @Get()
+  @RequirePermissions('product:read')
+  @ApiOperation({ summary: '获取产品列表' })
+  @ApiResponse({ status: 200, type: ProductListResponseDto })
+  findAll(@Query() query: QueryProductDto): Promise<ProductListResponseDto> {
+    return this.productService.findAll(query);
+  }
+
+  @Get(':id')
+  @RequirePermissions('product:read')
+  @ApiOperation({ summary: '获取产品详情' })
+  @ApiParam({ name: 'id', description: '产品 ID' })
+  @ApiResponse({ status: 200, type: ProductDto })
+  findById(@Param('id') id: string): Promise<ProductDto> {
+    return this.productService.findById(id);
+  }
+
+  @Put(':id')
+  @RequirePermissions('product:update')
+  @ApiOperation({ summary: '更新产品' })
+  @ApiResponse({ status: 200, type: ProductDto })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateProductDto,
+    @Auth('userId') userId?: string,
+  ): Promise<ProductDto> {
+    return this.productService.update(id, dto, userId);
+  }
+
+  @Patch(':id/status')
+  @RequirePermissions('product:toggle-status')
+  @ApiOperation({ summary: '更新产品状态' })
+  @ApiResponse({ status: 200, type: ProductDto })
+  updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateProductStatusDto,
+    @Auth('userId') userId?: string,
+  ): Promise<ProductDto> {
+    return this.productService.updateStatus(id, dto.status, userId);
+  }
+
+  @Delete(':id')
+  @RequirePermissions('product:delete')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: '删除产品' })
+  @ApiResponse({ status: 204, description: '产品删除成功' })
+  async delete(@Param('id') id: string): Promise<void> {
+    await this.productService.delete(id);
+  }
+}

--- a/src/product/dto/create-product.dto.ts
+++ b/src/product/dto/create-product.dto.ts
@@ -1,0 +1,139 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, ProductCategory, ProductStatus } from '@prisma/client';
+import { Transform } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+  Max,
+  Min,
+} from 'class-validator';
+
+const trim = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class CreateProductDto {
+  @ApiProperty({ example: 'COURSE_001', description: '唯一产品编号' })
+  @Transform(trim)
+  @IsString()
+  @Length(1, 100)
+  productCode: string;
+
+  @ApiProperty({ example: 'Python 基础课程' })
+  @Transform(trim)
+  @IsString()
+  @Length(1, 200)
+  name: string;
+
+  @ApiPropertyOptional({ description: '产品详细描述' })
+  @IsOptional()
+  @Transform(trim)
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ description: '列表中展示的简短描述' })
+  @IsOptional()
+  @Transform(trim)
+  @IsString()
+  shortDescription?: string;
+
+  @ApiProperty({ enum: ProductCategory })
+  @IsEnum(ProductCategory)
+  category: ProductCategory;
+
+  @ApiPropertyOptional({ enum: ProductStatus, default: ProductStatus.DRAFT })
+  @IsOptional()
+  @IsEnum(ProductStatus)
+  status?: ProductStatus;
+
+  @ApiPropertyOptional({ description: '价格，最小货币单位', example: 29900 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  price?: number | null;
+
+  @ApiPropertyOptional({ description: '原价，最小货币单位', example: 39900 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  originalPrice?: number | null;
+
+  @ApiPropertyOptional({ enum: Currency, default: Currency.CNY })
+  @IsOptional()
+  @IsEnum(Currency)
+  currency?: Currency;
+
+  @ApiPropertyOptional({ description: '有效期天数' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  durationDays?: number | null;
+
+  @ApiPropertyOptional({ description: '最大用户数' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxUsers?: number | null;
+
+  @ApiPropertyOptional({ type: [String], example: ['Python', '入门'] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(30)
+  @IsString({ each: true })
+  tags?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  imageUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  videoUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  downloadUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  externalUrl?: string;
+
+  @ApiPropertyOptional({ default: 0 })
+  @IsOptional()
+  @IsInt()
+  sortOrder?: number;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  isRecommended?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  isFeatured?: boolean;
+
+  @ApiPropertyOptional({ minimum: 0, maximum: 5 })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(5)
+  rating?: number | null;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  publishedAt?: string | null;
+}

--- a/src/product/dto/index.ts
+++ b/src/product/dto/index.ts
@@ -1,0 +1,5 @@
+export * from './create-product.dto';
+export * from './update-product.dto';
+export * from './update-product-status.dto';
+export * from './query-product.dto';
+export * from './product.dto';

--- a/src/product/dto/product.dto.ts
+++ b/src/product/dto/product.dto.ts
@@ -1,0 +1,111 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, ProductCategory, ProductStatus } from '@prisma/client';
+
+export class ProductDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  productCode: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  description: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  shortDescription: string | null;
+
+  @ApiProperty({ enum: ProductCategory })
+  category: ProductCategory;
+
+  @ApiProperty({ enum: ProductStatus })
+  status: ProductStatus;
+
+  @ApiPropertyOptional({ nullable: true })
+  price: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  originalPrice: number | null;
+
+  @ApiProperty({ enum: Currency })
+  currency: Currency;
+
+  @ApiPropertyOptional({ nullable: true })
+  durationDays: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  maxUsers: number | null;
+
+  @ApiProperty({ type: [String] })
+  tags: string[];
+
+  @ApiPropertyOptional({ nullable: true })
+  imageUrl: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  videoUrl: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  downloadUrl: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  externalUrl: string | null;
+
+  @ApiProperty()
+  sortOrder: number;
+
+  @ApiProperty()
+  isRecommended: boolean;
+
+  @ApiProperty()
+  isFeatured: boolean;
+
+  @ApiProperty()
+  salesCount: number;
+
+  @ApiProperty()
+  viewCount: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  rating: number | null;
+
+  @ApiProperty()
+  reviewCount: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  createdBy: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  updatedBy: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  publishedAt: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  archivedAt: string | null;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  updatedAt: string;
+}
+
+export class ProductListResponseDto {
+  @ApiProperty({ type: [ProductDto] })
+  items: ProductDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  pageSize: number;
+
+  @ApiProperty()
+  totalPages: number;
+}

--- a/src/product/dto/query-product.dto.ts
+++ b/src/product/dto/query-product.dto.ts
@@ -1,0 +1,90 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Currency, ProductCategory, ProductStatus } from '@prisma/client';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class QueryProductDto {
+  @ApiPropertyOptional({ minimum: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number;
+
+  @ApiPropertyOptional({ description: '搜索产品编号、名称或描述' })
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({ enum: ProductCategory })
+  @IsOptional()
+  @IsEnum(ProductCategory)
+  category?: ProductCategory;
+
+  @ApiPropertyOptional({ enum: ProductStatus })
+  @IsOptional()
+  @IsEnum(ProductStatus)
+  status?: ProductStatus;
+
+  @ApiPropertyOptional({ enum: Currency })
+  @IsOptional()
+  @IsEnum(Currency)
+  currency?: Currency;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }): unknown => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  isRecommended?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }): unknown => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  isFeatured?: boolean;
+
+  @ApiPropertyOptional({
+    enum: [
+      'createdAt',
+      'updatedAt',
+      'name',
+      'price',
+      'sortOrder',
+      'salesCount',
+    ],
+    default: 'sortOrder',
+  })
+  @IsOptional()
+  @IsIn(['createdAt', 'updatedAt', 'name', 'price', 'sortOrder', 'salesCount'])
+  sortField?: string;
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'asc' })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc';
+}

--- a/src/product/dto/update-product-status.dto.ts
+++ b/src/product/dto/update-product-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ProductStatus } from '@prisma/client';
+import { IsEnum } from 'class-validator';
+
+export class UpdateProductStatusDto {
+  @ApiProperty({ enum: ProductStatus })
+  @IsEnum(ProductStatus)
+  status: ProductStatus;
+}

--- a/src/product/dto/update-product.dto.ts
+++ b/src/product/dto/update-product.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProductDto } from './create-product.dto';
+
+export class UpdateProductDto extends PartialType(CreateProductDto) {}

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { ProductController } from './controllers/product.controller';
+import { ProductRepository } from './repositories/product.repository';
+import { ProductService } from './services/product.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProductController],
+  providers: [ProductService, ProductRepository],
+  exports: [ProductService, ProductRepository],
+})
+export class ProductModule {}

--- a/src/product/repositories/product.repository.ts
+++ b/src/product/repositories/product.repository.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, Product } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+
+@Injectable()
+export class ProductRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(data: Prisma.ProductUncheckedCreateInput): Promise<Product> {
+    return this.prisma.product.create({ data });
+  }
+
+  findById(id: string): Promise<Product | null> {
+    return this.prisma.product.findUnique({ where: { id } });
+  }
+
+  findByCode(productCode: string): Promise<Product | null> {
+    return this.prisma.product.findUnique({ where: { productCode } });
+  }
+
+  async findMany(options: {
+    skip: number;
+    take: number;
+    where: Prisma.ProductWhereInput;
+    orderBy: Prisma.ProductOrderByWithRelationInput[];
+  }): Promise<{ items: Product[]; total: number }> {
+    const [items, total] = await Promise.all([
+      this.prisma.product.findMany(options),
+      this.prisma.product.count({ where: options.where }),
+    ]);
+    return { items, total };
+  }
+
+  update(
+    id: string,
+    data: Prisma.ProductUncheckedUpdateInput,
+  ): Promise<Product> {
+    return this.prisma.product.update({ where: { id }, data });
+  }
+
+  delete(id: string): Promise<Product> {
+    return this.prisma.product.delete({ where: { id } });
+  }
+}

--- a/src/product/services/product.service.spec.ts
+++ b/src/product/services/product.service.spec.ts
@@ -1,0 +1,192 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/unbound-method */
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  Currency,
+  Prisma,
+  Product,
+  ProductCategory,
+  ProductStatus,
+} from '@prisma/client';
+import { ProductRepository } from '../repositories/product.repository';
+import { ProductService } from './product.service';
+
+describe('ProductService', () => {
+  let service: ProductService;
+  let repository: jest.Mocked<ProductRepository>;
+
+  const now = new Date('2026-08-13T00:00:00.000Z');
+  const product = (overrides: Partial<Product> = {}): Product => ({
+    id: 'product-1',
+    productCode: 'COURSE_001',
+    name: 'Python 基础课程',
+    description: null,
+    shortDescription: null,
+    category: ProductCategory.COURSE,
+    status: ProductStatus.DRAFT,
+    price: 29900,
+    originalPrice: 39900,
+    currency: Currency.CNY,
+    durationDays: null,
+    maxUsers: null,
+    tags: ['Python'],
+    imageUrl: null,
+    videoUrl: null,
+    downloadUrl: null,
+    externalUrl: null,
+    sortOrder: 0,
+    isRecommended: false,
+    isFeatured: false,
+    salesCount: 0,
+    viewCount: 0,
+    rating: new Prisma.Decimal(4.8),
+    reviewCount: 0,
+    createdBy: 'user-1',
+    updatedBy: 'user-1',
+    publishedAt: null,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    repository = {
+      create: jest.fn(),
+      findById: jest.fn(),
+      findByCode: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<ProductRepository>;
+    service = new ProductService(repository);
+  });
+
+  it('creates a normalized active product and records the actor', async () => {
+    repository.findByCode.mockResolvedValue(null);
+    repository.create.mockImplementation((data) =>
+      Promise.resolve(
+        product({
+          productCode: data.productCode,
+          name: data.name,
+          status: data.status ?? ProductStatus.DRAFT,
+          tags: data.tags as string[],
+          publishedAt: data.publishedAt as Date,
+        }),
+      ),
+    );
+
+    const result = await service.create(
+      {
+        productCode: ' COURSE_001 ',
+        name: ' Python 基础课程 ',
+        category: ProductCategory.COURSE,
+        status: ProductStatus.ACTIVE,
+        price: 29900,
+        originalPrice: 39900,
+        tags: [' Python ', 'Python', ' 入门 '],
+      },
+      'user-1',
+    );
+
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productCode: 'COURSE_001',
+        name: 'Python 基础课程',
+        tags: ['Python', '入门'],
+        createdBy: 'user-1',
+        updatedBy: 'user-1',
+        publishedAt: expect.any(Date),
+        archivedAt: null,
+      }),
+    );
+    expect(result.rating).toBe(4.8);
+  });
+
+  it('rejects duplicate product codes and invalid price ranges', async () => {
+    repository.findByCode.mockResolvedValue(product());
+    await expect(
+      service.create({
+        productCode: 'COURSE_001',
+        name: 'Duplicate',
+        category: ProductCategory.COURSE,
+      }),
+    ).rejects.toThrow('Product code already exists');
+
+    repository.findByCode.mockResolvedValue(null);
+    await expect(
+      service.create({
+        productCode: 'COURSE_002',
+        name: 'Invalid price',
+        category: ProductCategory.COURSE,
+        price: 500,
+        originalPrice: 400,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('builds filters and stable sorting for the product list', async () => {
+    repository.findMany.mockResolvedValue({ items: [product()], total: 1 });
+
+    const result = await service.findAll({
+      page: 2,
+      pageSize: 20,
+      keyword: 'python',
+      category: ProductCategory.COURSE,
+      status: ProductStatus.ACTIVE,
+      isFeatured: true,
+      sortField: 'price',
+      sortOrder: 'desc',
+    });
+
+    expect(repository.findMany).toHaveBeenCalledWith({
+      skip: 20,
+      take: 20,
+      where: expect.objectContaining({
+        category: ProductCategory.COURSE,
+        status: ProductStatus.ACTIVE,
+        isFeatured: true,
+        OR: expect.any(Array),
+      }),
+      orderBy: [{ price: 'desc' }, { createdAt: 'desc' }],
+    });
+    expect(result).toMatchObject({ total: 1, page: 2, pageSize: 20 });
+  });
+
+  it('archives a product and records the updater', async () => {
+    repository.findById.mockResolvedValue(product());
+    repository.update.mockImplementation((_id, data) =>
+      Promise.resolve(
+        product({
+          status: data.status as ProductStatus,
+          archivedAt: data.archivedAt as Date,
+          updatedBy: data.updatedBy as string,
+        }),
+      ),
+    );
+
+    const result = await service.updateStatus(
+      'product-1',
+      ProductStatus.ARCHIVED,
+      'user-2',
+    );
+
+    expect(repository.update).toHaveBeenCalledWith(
+      'product-1',
+      expect.objectContaining({
+        status: ProductStatus.ARCHIVED,
+        updatedBy: 'user-2',
+        archivedAt: expect.any(Date),
+      }),
+    );
+    expect(result.status).toBe(ProductStatus.ARCHIVED);
+  });
+
+  it('rejects operations for a missing product', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(service.findById('missing')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(repository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/product/services/product.service.ts
+++ b/src/product/services/product.service.ts
@@ -1,0 +1,282 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, Product, ProductStatus } from '@prisma/client';
+import {
+  CreateProductDto,
+  ProductDto,
+  ProductListResponseDto,
+  QueryProductDto,
+  UpdateProductDto,
+} from '../dto';
+import { ProductRepository } from '../repositories/product.repository';
+
+const SORT_FIELD_MAP: Record<
+  string,
+  keyof Prisma.ProductOrderByWithRelationInput
+> = {
+  createdAt: 'createdAt',
+  updatedAt: 'updatedAt',
+  name: 'name',
+  price: 'price',
+  sortOrder: 'sortOrder',
+  salesCount: 'salesCount',
+};
+
+@Injectable()
+export class ProductService {
+  constructor(private readonly productRepository: ProductRepository) {}
+
+  async create(dto: CreateProductDto, actorId?: string): Promise<ProductDto> {
+    const productCode = dto.productCode.trim();
+    await this.ensureCodeAvailable(productCode);
+    this.validatePrices(dto.price, dto.originalPrice);
+
+    const lifecycle = this.resolveLifecycle(dto.status, dto.publishedAt);
+    const product = await this.productRepository.create({
+      productCode,
+      name: dto.name.trim(),
+      description: this.nullableString(dto.description),
+      shortDescription: this.nullableString(dto.shortDescription),
+      category: dto.category,
+      status: dto.status ?? ProductStatus.DRAFT,
+      price: dto.price,
+      originalPrice: dto.originalPrice,
+      currency: dto.currency,
+      durationDays: dto.durationDays,
+      maxUsers: dto.maxUsers,
+      tags: this.normalizeTags(dto.tags),
+      imageUrl: this.nullableString(dto.imageUrl),
+      videoUrl: this.nullableString(dto.videoUrl),
+      downloadUrl: this.nullableString(dto.downloadUrl),
+      externalUrl: this.nullableString(dto.externalUrl),
+      sortOrder: dto.sortOrder,
+      isRecommended: dto.isRecommended,
+      isFeatured: dto.isFeatured,
+      rating: dto.rating,
+      createdBy: actorId,
+      updatedBy: actorId,
+      ...lifecycle,
+    });
+    return this.toDto(product);
+  }
+
+  async findAll(query: QueryProductDto): Promise<ProductListResponseDto> {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 10;
+    const where = this.buildWhere(query);
+    const field = SORT_FIELD_MAP[query.sortField ?? 'sortOrder'];
+    const direction = query.sortOrder ?? 'asc';
+    const { items, total } = await this.productRepository.findMany({
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      where,
+      orderBy: [{ [field]: direction }, { createdAt: 'desc' }],
+    });
+
+    return {
+      items: items.map((product) => this.toDto(product)),
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async findById(id: string): Promise<ProductDto> {
+    return this.toDto(await this.findProduct(id));
+  }
+
+  async update(
+    id: string,
+    dto: UpdateProductDto,
+    actorId?: string,
+  ): Promise<ProductDto> {
+    const existing = await this.findProduct(id);
+    const productCode = dto.productCode?.trim();
+    if (productCode && productCode !== existing.productCode) {
+      await this.ensureCodeAvailable(productCode, id);
+    }
+
+    this.validatePrices(
+      dto.price !== undefined ? dto.price : existing.price,
+      dto.originalPrice !== undefined
+        ? dto.originalPrice
+        : existing.originalPrice,
+    );
+
+    const lifecycle =
+      dto.status !== undefined || dto.publishedAt !== undefined
+        ? this.resolveLifecycle(
+            dto.status ?? existing.status,
+            dto.publishedAt ?? existing.publishedAt?.toISOString(),
+            existing,
+          )
+        : {};
+
+    const product = await this.productRepository.update(id, {
+      productCode,
+      name: dto.name?.trim(),
+      description: this.optionalNullableString(dto, 'description'),
+      shortDescription: this.optionalNullableString(dto, 'shortDescription'),
+      category: dto.category,
+      status: dto.status,
+      price: dto.price,
+      originalPrice: dto.originalPrice,
+      currency: dto.currency,
+      durationDays: dto.durationDays,
+      maxUsers: dto.maxUsers,
+      tags: dto.tags === undefined ? undefined : this.normalizeTags(dto.tags),
+      imageUrl: this.optionalNullableString(dto, 'imageUrl'),
+      videoUrl: this.optionalNullableString(dto, 'videoUrl'),
+      downloadUrl: this.optionalNullableString(dto, 'downloadUrl'),
+      externalUrl: this.optionalNullableString(dto, 'externalUrl'),
+      sortOrder: dto.sortOrder,
+      isRecommended: dto.isRecommended,
+      isFeatured: dto.isFeatured,
+      rating: dto.rating,
+      updatedBy: actorId,
+      ...lifecycle,
+    });
+    return this.toDto(product);
+  }
+
+  async updateStatus(
+    id: string,
+    status: ProductStatus,
+    actorId?: string,
+  ): Promise<ProductDto> {
+    const existing = await this.findProduct(id);
+    const product = await this.productRepository.update(id, {
+      status,
+      updatedBy: actorId,
+      ...this.resolveLifecycle(
+        status,
+        existing.publishedAt?.toISOString(),
+        existing,
+      ),
+    });
+    return this.toDto(product);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.findProduct(id);
+    await this.productRepository.delete(id);
+  }
+
+  private async findProduct(id: string): Promise<Product> {
+    const product = await this.productRepository.findById(id);
+    if (!product) throw new NotFoundException('Product not found');
+    return product;
+  }
+
+  private async ensureCodeAvailable(
+    productCode: string,
+    excludeId?: string,
+  ): Promise<void> {
+    const existing = await this.productRepository.findByCode(productCode);
+    if (existing && existing.id !== excludeId) {
+      throw new BadRequestException('Product code already exists');
+    }
+  }
+
+  private validatePrices(
+    price?: number | null,
+    originalPrice?: number | null,
+  ): void {
+    if (price != null && originalPrice != null && originalPrice < price) {
+      throw new BadRequestException(
+        'Original price must be greater than or equal to price',
+      );
+    }
+  }
+
+  private buildWhere(query: QueryProductDto): Prisma.ProductWhereInput {
+    const keyword = query.keyword?.trim();
+    return {
+      ...(keyword
+        ? {
+            OR: [
+              { productCode: { contains: keyword, mode: 'insensitive' } },
+              { name: { contains: keyword, mode: 'insensitive' } },
+              { description: { contains: keyword, mode: 'insensitive' } },
+              {
+                shortDescription: {
+                  contains: keyword,
+                  mode: 'insensitive',
+                },
+              },
+            ],
+          }
+        : {}),
+      ...(query.category ? { category: query.category } : {}),
+      ...(query.status ? { status: query.status } : {}),
+      ...(query.currency ? { currency: query.currency } : {}),
+      ...(query.isRecommended !== undefined
+        ? { isRecommended: query.isRecommended }
+        : {}),
+      ...(query.isFeatured !== undefined
+        ? { isFeatured: query.isFeatured }
+        : {}),
+    };
+  }
+
+  private resolveLifecycle(
+    status: ProductStatus = ProductStatus.DRAFT,
+    publishedAt?: string | null,
+    existing?: Product,
+  ): { publishedAt?: Date | null; archivedAt: Date | null } {
+    return {
+      publishedAt:
+        status === ProductStatus.ACTIVE
+          ? publishedAt
+            ? new Date(publishedAt)
+            : (existing?.publishedAt ?? new Date())
+          : publishedAt
+            ? new Date(publishedAt)
+            : existing?.publishedAt,
+      archivedAt:
+        status === ProductStatus.ARCHIVED
+          ? (existing?.archivedAt ?? new Date())
+          : null,
+    };
+  }
+
+  private nullableString(value?: string | null): string | null | undefined {
+    if (value === undefined) return undefined;
+    const normalized = value?.trim();
+    return normalized || null;
+  }
+
+  private optionalNullableString(
+    dto: UpdateProductDto,
+    key:
+      | 'description'
+      | 'shortDescription'
+      | 'imageUrl'
+      | 'videoUrl'
+      | 'downloadUrl'
+      | 'externalUrl',
+  ): string | null | undefined {
+    if (!Object.prototype.hasOwnProperty.call(dto, key)) return undefined;
+    return this.nullableString(dto[key] as string | null);
+  }
+
+  private normalizeTags(tags?: string[]): string[] {
+    if (!tags) return [];
+    return [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))];
+  }
+
+  private toDto(product: Product): ProductDto {
+    return {
+      ...product,
+      rating: product.rating === null ? null : product.rating.toNumber(),
+      publishedAt: product.publishedAt?.toISOString() ?? null,
+      archivedAt: product.archivedAt?.toISOString() ?? null,
+      createdAt: product.createdAt.toISOString(),
+      updatedAt: product.updatedAt.toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## What changed

- add an authenticated `/admin/products` module with list, detail, create, update, status-update, and delete endpoints
- support pagination, search, category/status/currency filters, and stable sorting
- enforce existing `product:*` permissions
- normalize tags and nullable fields, validate product-code uniqueness and price ranges
- maintain publisher, updater, published-at, and archived-at metadata
- add focused product service unit tests

## Why

The `Product` Prisma model and permission definitions already existed, but there was no runtime administration API for managing product records.

## Impact

Administrators can now manage the full product lifecycle. Existing orders preserve their product-name snapshots when a product is deleted, while the relation is cleared by the existing schema behavior.

## Validation

- targeted ESLint for `src/product` and `src/app.module.ts`
- 5 product service unit tests
- `pnpm build`
- OpenAPI specification verification for all product routes
- live integration through the admin product list