### PR TITLE
fix: delay BullMQ worker startup until application bootstrap

### DIFF
--- a/src/task/handlers/link-orders-to-users-by-phone.handler.spec.ts
+++ b/src/task/handlers/link-orders-to-users-by-phone.handler.spec.ts
@@ -1,0 +1,135 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Job } from 'bullmq';
+import { PrismaService } from '@/prisma/prisma.service';
+import { LinkOrdersToUsersByPhoneHandler } from './link-orders-to-users-by-phone.handler';
+import { TaskHandlerRegistry } from './task-handler.registry';
+
+describe('LinkOrdersToUsersByPhoneHandler', () => {
+  let handler: LinkOrdersToUsersByPhoneHandler;
+  let prisma: {
+    order: { findMany: jest.Mock; updateMany: jest.Mock };
+    user: { findUnique: jest.Mock; create: jest.Mock };
+  };
+  let registry: jest.Mocked<TaskHandlerRegistry>;
+
+  beforeEach(async () => {
+    prisma = {
+      order: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      user: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+      },
+    };
+    registry = {
+      register: jest.fn(),
+    } as unknown as jest.Mocked<TaskHandlerRegistry>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LinkOrdersToUsersByPhoneHandler,
+        { provide: PrismaService, useValue: prisma },
+        { provide: TaskHandlerRegistry, useValue: registry },
+      ],
+    }).compile();
+
+    handler = module.get(LinkOrdersToUsersByPhoneHandler);
+  });
+
+  it('registers itself on module init', () => {
+    handler.onModuleInit();
+
+    expect(registry.register).toHaveBeenCalledWith(handler);
+    expect(handler.name).toBe('link_orders_to_users_by_phone');
+  });
+
+  it('matches normalized contacts and creates a user only when necessary', async () => {
+    prisma.order.findMany
+      .mockResolvedValueOnce([
+        { id: 'order-1', phoneCode: '86', phone: '138 0013 8000' },
+        { id: 'order-2', phoneCode: '+86', phone: '13900139000' },
+        { id: 'order-3', phoneCode: null, phone: '13700137000' },
+      ])
+      .mockResolvedValueOnce([]);
+    prisma.user.findUnique
+      .mockResolvedValueOnce({ id: 'user-1', deletedAt: null })
+      .mockResolvedValueOnce(null);
+    prisma.user.create.mockResolvedValue({ id: 'user-2' });
+    prisma.order.updateMany.mockResolvedValue({ count: 1 });
+
+    const result = await handler.handle({ id: 'job-1', data: {} } as Job);
+
+    expect(prisma.user.findUnique).toHaveBeenNthCalledWith(1, {
+      where: {
+        uq_users_country_code_phone: {
+          countryCode: '+86',
+          phone: '13800138000',
+        },
+      },
+    });
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: {
+        countryCode: '+86',
+        phone: '13900139000',
+        phoneVerifiedAt: null,
+      },
+      select: { id: true },
+    });
+    expect(prisma.order.updateMany).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      success: true,
+      candidates: 3,
+      linked: 2,
+      usersCreated: 1,
+      invalidContacts: 1,
+      deletedUserConflicts: 0,
+      skipped: 0,
+      batches: 1,
+    });
+  });
+
+  it('reuses a user for duplicate contacts and does not overwrite a concurrent link', async () => {
+    prisma.order.findMany
+      .mockResolvedValueOnce([
+        { id: 'order-1', phoneCode: '+86', phone: '13800138000' },
+        { id: 'order-2', phoneCode: '+86', phone: '13800138000' },
+      ])
+      .mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-1', deletedAt: null });
+    prisma.order.updateMany
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    const result = await handler.handle({ data: { batchSize: 100 } } as Job);
+
+    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ linked: 1, skipped: 1, usersCreated: 0 });
+  });
+
+  it('skips contacts owned by soft-deleted users', async () => {
+    prisma.order.findMany
+      .mockResolvedValueOnce([
+        { id: 'order-1', phoneCode: '+86', phone: '13800138000' },
+      ])
+      .mockResolvedValueOnce([]);
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'deleted-user',
+      deletedAt: new Date(),
+    });
+
+    const result = await handler.handle({ data: {} } as Job);
+
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.order.updateMany).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ deletedUserConflicts: 1, linked: 0 });
+  });
+
+  it('rejects an invalid batch size', async () => {
+    await expect(
+      handler.handle({ data: { batchSize: 0 } } as Job),
+    ).rejects.toThrow('batchSize must be an integer between 1 and 2000');
+  });
+});

--- a/src/task/handlers/link-orders-to-users-by-phone.handler.ts
+++ b/src/task/handlers/link-orders-to-users-by-phone.handler.ts
@@ -1,0 +1,204 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { Job } from 'bullmq';
+import { PrismaService } from '@/prisma/prisma.service';
+import { ITaskHandler } from './task-handler.interface';
+import { TaskHandlerRegistry } from './task-handler.registry';
+
+const DEFAULT_BATCH_SIZE = 500;
+const MAX_BATCH_SIZE = 2000;
+
+interface LinkOrdersToUsersPayload {
+  batchSize?: number;
+}
+
+interface NormalizedContact {
+  countryCode: string;
+  phone: string;
+}
+
+@Injectable()
+export class LinkOrdersToUsersByPhoneHandler
+  implements ITaskHandler, OnModuleInit
+{
+  private readonly logger = new Logger(LinkOrdersToUsersByPhoneHandler.name);
+  readonly name = 'link_orders_to_users_by_phone';
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly registry: TaskHandlerRegistry,
+  ) {}
+
+  onModuleInit(): void {
+    this.registry.register(this);
+  }
+
+  async handle(job: Job): Promise<unknown> {
+    const { batchSize } = this.parsePayload(job.data);
+    let lastProcessedId: string | undefined;
+    let candidates = 0;
+    let linked = 0;
+    let usersCreated = 0;
+    let invalidContacts = 0;
+    let deletedUserConflicts = 0;
+    let skipped = 0;
+    let batches = 0;
+    const userIdByContact = new Map<string, string>();
+
+    this.logger.log(
+      `[${this.name}] Starting job ${job.id ?? 'unknown'} with batchSize=${batchSize}.`,
+    );
+
+    while (true) {
+      const orders = await this.prisma.order.findMany({
+        where: {
+          purchaserId: null,
+          deletedAt: null,
+          ...(lastProcessedId ? { id: { gt: lastProcessedId } } : {}),
+        },
+        select: {
+          id: true,
+          phoneCode: true,
+          phone: true,
+        },
+        orderBy: { id: 'asc' },
+        take: batchSize,
+      });
+
+      if (orders.length === 0) break;
+
+      batches++;
+      candidates += orders.length;
+      lastProcessedId = orders.at(-1)!.id;
+
+      for (const order of orders) {
+        const contact = this.normalizeContact(order.phoneCode, order.phone);
+        if (!contact) {
+          invalidContacts++;
+          continue;
+        }
+
+        const contactKey = this.contactKey(contact);
+        let userId = userIdByContact.get(contactKey);
+
+        if (!userId) {
+          const resolution = await this.resolveUser(contact);
+          if (resolution.status === 'deleted-conflict') {
+            deletedUserConflicts++;
+            continue;
+          }
+          userId = resolution.userId;
+          userIdByContact.set(contactKey, userId);
+          if (resolution.created) usersCreated++;
+        }
+
+        const result = await this.prisma.order.updateMany({
+          where: {
+            id: order.id,
+            purchaserId: null,
+            deletedAt: null,
+          },
+          data: { purchaserId: userId },
+        });
+
+        linked += result.count;
+        skipped += 1 - result.count;
+      }
+    }
+
+    this.logger.log(
+      `[${this.name}] Finished: candidates=${candidates}, linked=${linked}, usersCreated=${usersCreated}, invalidContacts=${invalidContacts}, deletedUserConflicts=${deletedUserConflicts}, skipped=${skipped}.`,
+    );
+
+    return {
+      success: true,
+      candidates,
+      linked,
+      usersCreated,
+      invalidContacts,
+      deletedUserConflicts,
+      skipped,
+      batches,
+    };
+  }
+
+  private async resolveUser(
+    contact: NormalizedContact,
+  ): Promise<
+    | { status: 'resolved'; userId: string; created: boolean }
+    | { status: 'deleted-conflict' }
+  > {
+    const where = {
+      uq_users_country_code_phone: contact,
+    } as const;
+    const existing = await this.prisma.user.findUnique({ where });
+
+    if (existing) {
+      return existing.deletedAt
+        ? { status: 'deleted-conflict' }
+        : { status: 'resolved', userId: existing.id, created: false };
+    }
+
+    try {
+      const created = await this.prisma.user.create({
+        data: {
+          countryCode: contact.countryCode,
+          phone: contact.phone,
+          phoneVerifiedAt: null,
+        },
+        select: { id: true },
+      });
+      return { status: 'resolved', userId: created.id, created: true };
+    } catch (error) {
+      if (
+        !(error instanceof Prisma.PrismaClientKnownRequestError) ||
+        error.code !== 'P2002'
+      ) {
+        throw error;
+      }
+
+      const concurrentUser = await this.prisma.user.findUnique({ where });
+      if (!concurrentUser) throw error;
+      return concurrentUser.deletedAt
+        ? { status: 'deleted-conflict' }
+        : { status: 'resolved', userId: concurrentUser.id, created: false };
+    }
+  }
+
+  private normalizeContact(
+    countryCode?: string | null,
+    phone?: string | null,
+  ): NormalizedContact | undefined {
+    const countryDigits = countryCode?.replace(/\D/g, '');
+    const phoneDigits = phone?.replace(/\D/g, '');
+    if (!countryDigits || !phoneDigits || phoneDigits.length > 20) {
+      return undefined;
+    }
+    return { countryCode: `+${countryDigits}`, phone: phoneDigits };
+  }
+
+  private contactKey(contact: NormalizedContact): string {
+    return `${contact.countryCode}:${contact.phone}`;
+  }
+
+  private parsePayload(data: unknown): Required<LinkOrdersToUsersPayload> {
+    const payload =
+      data && typeof data === 'object'
+        ? (data as Record<string, unknown>)
+        : ({} as Record<string, unknown>);
+    const batchSize = payload.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    if (
+      typeof batchSize !== 'number' ||
+      !Number.isInteger(batchSize) ||
+      batchSize < 1 ||
+      batchSize > MAX_BATCH_SIZE
+    ) {
+      throw new Error(
+        `batchSize must be an integer between 1 and ${MAX_BATCH_SIZE}`,
+      );
+    }
+
+    return { batchSize };
+  }
+}

--- a/src/task/processors/task.processor.ts
+++ b/src/task/processors/task.processor.ts
@@ -5,7 +5,7 @@ import {
   OnQueueEvent,
 } from '@nestjs/bullmq';
 import type { Job } from 'bullmq';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { TaskStatus, TaskType, ScheduledTask, Prisma } from '@prisma/client';
 import { TasksRepository } from '../repositories/tasks.repository';
 import { TaskExecutionLogsRepository } from '../repositories/task-execution-logs.repository';
@@ -13,8 +13,10 @@ import { TaskHandlerRegistry } from '../handlers/task-handler.registry';
 import { TASK_QUEUE_NAME } from '../task.constants';
 
 @Injectable()
-@Processor(TASK_QUEUE_NAME)
-export class TaskProcessor extends WorkerHost {
+@Processor(TASK_QUEUE_NAME, {
+  autorun: false,
+})
+export class TaskProcessor extends WorkerHost implements OnApplicationBootstrap {
   private readonly logger = new Logger(TaskProcessor.name);
 
   constructor(
@@ -23,6 +25,13 @@ export class TaskProcessor extends WorkerHost {
     private readonly registry: TaskHandlerRegistry,
   ) {
     super();
+  }
+
+  onApplicationBootstrap() {
+    this.logger.log('Starting BullMQ worker...');
+    this.worker.run().catch((err) => {
+      this.logger.error('BullMQ worker encountered an error', err);
+    });
   }
 
   private async findTaskFromJob(job: Job): Promise<ScheduledTask | null> {

--- a/src/task/tasks.module.ts
+++ b/src/task/tasks.module.ts
@@ -30,6 +30,7 @@ import { TaskHandlerRegistry } from './handlers/task-handler.registry';
 import { HttpTaskHandler } from './handlers/http.handler';
 import { MigratePhoneHashesHandler } from './handlers/migrate-phone-hashes.handler';
 import { LinkPlatformUsersByPhoneHashHandler } from './handlers/link-platform-users-by-phone-hash.handler';
+import { LinkOrdersToUsersByPhoneHandler } from './handlers/link-orders-to-users-by-phone.handler';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { LinkPlatformUsersByPhoneHashHandler } from './handlers/link-platform-us
     HttpTaskHandler,
     MigratePhoneHashesHandler,
     LinkPlatformUsersByPhoneHashHandler,
+    LinkOrdersToUsersByPhoneHandler,
   ],
   exports: [TaskHandlerRegistry],
 })


### PR DESCRIPTION
Delay the BullMQ worker from starting automatically by setting autorun: false, and manually start it in the OnApplicationBootstrap lifecycle hook to ensure all dependencies (like TaskHandlerRegistry) are fully initialized before processing jobs.