### PR TITLE
feat: streamline tracking report subject queries

### DIFF
--- a/src/tracking-report/controllers/tracking-report.controller.ts
+++ b/src/tracking-report/controllers/tracking-report.controller.ts
@@ -30,6 +30,11 @@ import {
   UpdateTrackingReportDto,
 } from '../dto/tracking-report.dto';
 import {
+  TrackingReportDetailDto,
+  TrackingReportListResponseDto,
+  TrackingReportSubjectDto,
+} from '../dto/tracking-report-response.dto';
+import {
   ConflictResponseDto,
   JobStatusResponseDto,
   TriggerResponseDto,
@@ -37,7 +42,7 @@ import {
 import { TrackingReportService } from '../services/tracking-report.service';
 import { ReportGenerationQueueService } from '../queue/report-generation.queue.service';
 
-@ApiTags('User Tracking Reports')
+@ApiTags('用户跟踪报告')
 @ApiBearerAuth()
 @Controller('tracking-reports')
 export class TrackingReportController {
@@ -48,12 +53,15 @@ export class TrackingReportController {
 
   @Post()
   @RequirePermissions('tracking-report:create')
+  @ApiOperation({ summary: '创建跟踪报告' })
   create(@Body(new ValidationPipe()) dto: CreateTrackingReportDto) {
     return this.service.create(dto);
   }
 
   @Get()
   @RequirePermissions('tracking-report:read')
+  @ApiOperation({ summary: '获取跟踪报告列表' })
+  @ApiOkResponse({ type: TrackingReportListResponseDto })
   list(
     @Query(new ValidationPipe({ transform: true }))
     query: QueryTrackingReportDto,
@@ -75,14 +83,25 @@ export class TrackingReportController {
     return this.reportGenerationQueue.getJobStatus(jobId);
   }
 
+  @Get(':id/subject')
+  @RequirePermissions('tracking-report:read')
+  @ApiOperation({ summary: '按需获取跟踪报告对象的完整身份信息' })
+  @ApiOkResponse({ type: TrackingReportSubjectDto })
+  getSubject(@Param('id', CuidPipe) id: string) {
+    return this.service.getSubject(id);
+  }
+
   @Get(':id')
   @RequirePermissions('tracking-report:read')
+  @ApiOperation({ summary: '获取指定跟踪报告详情' })
+  @ApiOkResponse({ type: TrackingReportDetailDto })
   get(@Param('id', CuidPipe) id: string) {
     return this.service.get(id);
   }
 
   @Put(':id')
   @RequirePermissions('tracking-report:update')
+  @ApiOperation({ summary: '更新跟踪报告' })
   update(
     @Param('id', CuidPipe) id: string,
     @Body(new ValidationPipe()) dto: UpdateTrackingReportDto,
@@ -92,6 +111,7 @@ export class TrackingReportController {
 
   @Delete(':id')
   @RequirePermissions('tracking-report:delete')
+  @ApiOperation({ summary: '删除跟踪报告' })
   delete(@Param('id', CuidPipe) id: string) {
     return this.service.delete(id);
   }

--- a/src/tracking-report/dto/tracking-report-response.dto.ts
+++ b/src/tracking-report/dto/tracking-report-response.dto.ts
@@ -1,0 +1,86 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { TrackingCadence, TrackingReportType } from '@prisma/client';
+
+export enum TrackingReportSubjectKind {
+  LOCAL_USER = 'LOCAL_USER',
+  PLATFORM_USER = 'PLATFORM_USER',
+  PROJECT = 'PROJECT',
+}
+
+export class TrackingReportLocalUserDto {
+  @ApiProperty() id: string;
+  @ApiPropertyOptional({ nullable: true }) username: string | null;
+  @ApiPropertyOptional({ nullable: true }) email: string | null;
+  @ApiPropertyOptional({ nullable: true }) countryCode: string | null;
+  @ApiPropertyOptional({ nullable: true }) phone: string | null;
+  @ApiPropertyOptional({ nullable: true }) displayName: string | null;
+  @ApiPropertyOptional({ nullable: true }) avatar: string | null;
+}
+
+export class TrackingReportPlatformUserDto {
+  @ApiProperty() id: string;
+  @ApiProperty() platform: string;
+  @ApiPropertyOptional({ nullable: true }) ptUserId: string | null;
+  @ApiProperty() ptUnionId: string;
+  @ApiPropertyOptional({ nullable: true }) displayName: string | null;
+}
+
+export class TrackingReportProjectDto {
+  @ApiProperty() id: string;
+  @ApiProperty() title: string;
+  @ApiPropertyOptional({ nullable: true }) subtitle: string | null;
+  @ApiPropertyOptional({ nullable: true }) category: string | null;
+  @ApiPropertyOptional({ nullable: true }) image: string | null;
+}
+
+export class TrackingReportSubjectSummaryDto {
+  @ApiProperty({ enum: TrackingReportSubjectKind })
+  kind: TrackingReportSubjectKind;
+
+  @ApiProperty() displayName: string;
+  @ApiPropertyOptional({ nullable: true }) avatar: string | null;
+  @ApiProperty({ description: '是否已关联本地用户' }) isLinked: boolean;
+}
+
+export class TrackingReportSubjectDto extends TrackingReportSubjectSummaryDto {
+  @ApiProperty({ description: '生成报告时保留的历史名称快照' })
+  nameSnapshot: string;
+  @ApiPropertyOptional({ type: TrackingReportLocalUserDto, nullable: true })
+  localUser: TrackingReportLocalUserDto | null;
+  @ApiPropertyOptional({ type: TrackingReportPlatformUserDto, nullable: true })
+  platformUser: TrackingReportPlatformUserDto | null;
+  @ApiPropertyOptional({ type: TrackingReportProjectDto, nullable: true })
+  project: TrackingReportProjectDto | null;
+}
+
+export class TrackingReportListItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty({ type: TrackingReportSubjectSummaryDto })
+  subject: TrackingReportSubjectSummaryDto;
+  @ApiProperty({ enum: TrackingReportType }) trackingType: TrackingReportType;
+  @ApiProperty({ enum: TrackingCadence }) cadence: TrackingCadence;
+  @ApiProperty({ type: String, format: 'date-time' }) periodStart: Date;
+  @ApiProperty({ type: String, format: 'date-time' }) periodEnd: Date;
+  @ApiProperty() isLatest: boolean;
+  @ApiProperty() version: number;
+  @ApiProperty({ type: String, format: 'date-time' }) createdAt: Date;
+}
+
+export class TrackingReportListResponseDto {
+  @ApiProperty({ type: [TrackingReportListItemDto] })
+  data: TrackingReportListItemDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() limit: number;
+  @ApiProperty() totalPages: number;
+}
+
+export class TrackingReportDetailDto extends TrackingReportListItemDto {
+  @ApiProperty() timezone: string;
+  @ApiProperty() content: string;
+  @ApiPropertyOptional({ type: Object, nullable: true })
+  structuredData: Record<string, unknown> | null;
+  @ApiProperty() versionGroupKey: string;
+  @ApiPropertyOptional({ nullable: true }) previousReportId: string | null;
+  @ApiProperty({ type: String, format: 'date-time' }) updatedAt: Date;
+}

--- a/src/tracking-report/repositories/tracking-report.repository.ts
+++ b/src/tracking-report/repositories/tracking-report.repository.ts
@@ -8,6 +8,100 @@ export type TrackingReportCreate = Omit<
   'versionGroupKey' | 'version' | 'isLatest' | 'previousReportId'
 > & { recordingSummaryIds?: string[]; sourceReportIds?: string[] };
 
+const trackingReportSubjectSummarySelect = {
+  subjectUser: {
+    select: {
+      profile: {
+        select: {
+          displayName: true,
+          avatar: true,
+        },
+      },
+    },
+  },
+  platformUser: {
+    select: {
+      displayName: true,
+    },
+  },
+  project: {
+    select: {
+      title: true,
+      image: true,
+    },
+  },
+} satisfies Prisma.UserTrackingReportSelect;
+
+const trackingReportSubjectDetailSelect = {
+  subjectUser: {
+    select: {
+      id: true,
+      username: true,
+      email: true,
+      countryCode: true,
+      phone: true,
+      profile: {
+        select: {
+          displayName: true,
+          avatar: true,
+        },
+      },
+    },
+  },
+  platformUser: {
+    select: {
+      id: true,
+      platform: true,
+      ptUserId: true,
+      ptUnionId: true,
+      displayName: true,
+    },
+  },
+  project: {
+    select: {
+      id: true,
+      title: true,
+      subtitle: true,
+      category: true,
+      image: true,
+    },
+  },
+} satisfies Prisma.UserTrackingReportSelect;
+
+export const trackingReportListSelect = {
+  id: true,
+  subjectUserId: true,
+  platformUserId: true,
+  projectId: true,
+  subjectNameSnapshot: true,
+  trackingType: true,
+  cadence: true,
+  periodStart: true,
+  periodEnd: true,
+  isLatest: true,
+  version: true,
+  createdAt: true,
+  ...trackingReportSubjectSummarySelect,
+} satisfies Prisma.UserTrackingReportSelect;
+
+export type TrackingReportListRecord = Prisma.UserTrackingReportGetPayload<{
+  select: typeof trackingReportListSelect;
+}>;
+
+const trackingReportSubjectDetailRecordSelect = {
+  subjectUserId: true,
+  platformUserId: true,
+  projectId: true,
+  subjectNameSnapshot: true,
+  trackingType: true,
+  ...trackingReportSubjectDetailSelect,
+} satisfies Prisma.UserTrackingReportSelect;
+
+export type TrackingReportSubjectDetailRecord =
+  Prisma.UserTrackingReportGetPayload<{
+    select: typeof trackingReportSubjectDetailRecordSelect;
+  }>;
+
 @Injectable()
 export class TrackingReportRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -93,7 +187,18 @@ export class TrackingReportRepository {
   findById(id: string) {
     return this.prisma.userTrackingReport.findFirst({
       where: { id, deletedAt: null },
-      include: { recordingSummarySources: true, sourceReports: true },
+      include: {
+        recordingSummarySources: true,
+        sourceReports: true,
+        ...trackingReportSubjectDetailSelect,
+      },
+    });
+  }
+
+  findSubjectByReportId(id: string) {
+    return this.prisma.userTrackingReport.findFirst({
+      where: { id, deletedAt: null },
+      select: trackingReportSubjectDetailRecordSelect,
     });
   }
 
@@ -109,6 +214,7 @@ export class TrackingReportRepository {
         skip,
         take,
         orderBy: [{ periodStart: 'desc' }, { createdAt: 'desc' }],
+        select: trackingReportListSelect,
       }),
     ]);
     return { total, data };

--- a/src/tracking-report/services/tracking-report.service.spec.ts
+++ b/src/tracking-report/services/tracking-report.service.spec.ts
@@ -1,10 +1,17 @@
 import { BadRequestException } from '@nestjs/common';
 import { TrackingCadence, TrackingReportType } from '@prisma/client';
-import { TrackingReportRepository } from '../repositories/tracking-report.repository';
+import {
+  trackingReportListSelect,
+  TrackingReportRepository,
+} from '../repositories/tracking-report.repository';
 import { TrackingReportService } from './tracking-report.service';
 
 describe('TrackingReportService', () => {
-  const repository = { saveNewVersion: jest.fn(), findMany: jest.fn() };
+  const repository = {
+    saveNewVersion: jest.fn(),
+    findMany: jest.fn(),
+    findSubjectByReportId: jest.fn(),
+  };
   const service = new TrackingReportService(
     repository as unknown as TrackingReportRepository,
   );
@@ -19,6 +26,23 @@ describe('TrackingReportService', () => {
   };
 
   beforeEach(() => jest.clearAllMocks());
+
+  it('keeps the list database projection limited to subject summary fields', () => {
+    expect(trackingReportListSelect.subjectUser).toEqual({
+      select: {
+        profile: { select: { displayName: true, avatar: true } },
+      },
+    });
+    expect(trackingReportListSelect.platformUser).toEqual({
+      select: { displayName: true },
+    });
+    expect(trackingReportListSelect.project).toEqual({
+      select: { title: true, image: true },
+    });
+    expect(JSON.stringify(trackingReportListSelect)).not.toMatch(
+      /username|email|countryCode|phone|ptUserId|ptUnionId|subtitle|category/,
+    );
+  });
 
   it('requires a user or platform identity', () => {
     expect(() => service.create({ ...base, subjectUserId: undefined })).toThrow(
@@ -44,5 +68,129 @@ describe('TrackingReportService', () => {
     expect(repository.saveNewVersion).toHaveBeenCalledWith(
       expect.objectContaining({ subjectUserId: 'user-1' }),
     );
+  });
+
+  it('prefers the linked local user as the report subject', async () => {
+    repository.findMany.mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          id: 'report-1',
+          subjectUserId: 'user-1',
+          platformUserId: 'platform-1',
+          projectId: null,
+          subjectNameSnapshot: 'Platform Alice',
+          trackingType: TrackingReportType.USER_PROFILE,
+          subjectUser: {
+            profile: { displayName: 'Alice', avatar: 'avatar.png' },
+          },
+          platformUser: {
+            displayName: 'Platform Alice',
+          },
+          project: null,
+        },
+      ],
+    });
+
+    const result = await service.list({ page: 1, limit: 20, isLatest: true });
+
+    expect(result.data[0]?.subject.kind).toBe('LOCAL_USER');
+    expect(result.data[0]?.subject.displayName).toBe('Alice');
+    expect(result.data[0]?.subject.isLinked).toBe(true);
+    expect(result.data[0]?.subject).not.toHaveProperty('localUserId');
+    expect(result.data[0]?.subject).not.toHaveProperty('localUser');
+    expect(result.data[0]?.subject).not.toHaveProperty('nameSnapshot');
+  });
+
+  it('falls back to the platform identity when no local user is linked', async () => {
+    repository.findMany.mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          id: 'report-2',
+          subjectUserId: null,
+          platformUserId: 'platform-2',
+          projectId: null,
+          subjectNameSnapshot: 'Historical Cecilia',
+          trackingType: TrackingReportType.PERIODIC_MEETING_SUMMARY,
+          subjectUser: null,
+          platformUser: {
+            displayName: 'Cecilia',
+          },
+          project: null,
+        },
+      ],
+    });
+
+    const result = await service.list({ page: 1, limit: 20, isLatest: true });
+
+    expect(result.data[0]?.subject).toEqual(
+      expect.objectContaining({
+        kind: 'PLATFORM_USER',
+        displayName: 'Cecilia',
+        isLinked: false,
+      }),
+    );
+  });
+
+  it('uses the project as the subject for project progress reports', async () => {
+    repository.findMany.mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          id: 'report-3',
+          subjectUserId: null,
+          platformUserId: null,
+          projectId: 'project-1',
+          subjectNameSnapshot: 'Alice',
+          trackingType: TrackingReportType.PROJECT_PROGRESS,
+          subjectUser: null,
+          platformUser: null,
+          project: {
+            title: 'AI 课程项目',
+            image: 'project.png',
+          },
+        },
+      ],
+    });
+
+    const result = await service.list({ page: 1, limit: 20, isLatest: true });
+
+    expect(result.data[0]?.subject.kind).toBe('PROJECT');
+    expect(result.data[0]?.subject.displayName).toBe('AI 课程项目');
+    expect(result.data[0]?.subject).not.toHaveProperty('projectId');
+    expect(result.data[0]?.subject).not.toHaveProperty('project');
+  });
+
+  it('loads complete identity details only on demand', async () => {
+    repository.findSubjectByReportId.mockResolvedValue({
+      subjectUserId: 'user-1',
+      platformUserId: 'platform-1',
+      projectId: null,
+      subjectNameSnapshot: 'Platform Alice',
+      trackingType: TrackingReportType.USER_PROFILE,
+      subjectUser: {
+        id: 'user-1',
+        username: 'alice',
+        email: 'alice@example.com',
+        countryCode: '+86',
+        phone: '13800138000',
+        profile: { displayName: 'Alice', avatar: 'avatar.png' },
+      },
+      platformUser: {
+        id: 'platform-1',
+        platform: 'TENCENT_MEETING',
+        ptUserId: 'meeting-user-1',
+        ptUnionId: 'union-1',
+        displayName: 'Platform Alice',
+      },
+      project: null,
+    });
+
+    const subject = await service.getSubject('report-1');
+
+    expect(repository.findSubjectByReportId).toHaveBeenCalledWith('report-1');
+    expect(subject.localUser?.email).toBe('alice@example.com');
+    expect(subject.platformUser?.ptUnionId).toBe('union-1');
   });
 });

--- a/src/tracking-report/services/tracking-report.service.ts
+++ b/src/tracking-report/services/tracking-report.service.ts
@@ -9,11 +9,201 @@ import {
   QueryTrackingReportDto,
   UpdateTrackingReportDto,
 } from '../dto/tracking-report.dto';
-import { TrackingReportRepository } from '../repositories/tracking-report.repository';
+import {
+  TrackingReportListRecord,
+  TrackingReportRepository,
+  TrackingReportSubjectDetailRecord,
+} from '../repositories/tracking-report.repository';
+
+type TrackingReportSubjectSummarySource = Pick<
+  TrackingReportListRecord,
+  | 'subjectUserId'
+  | 'platformUserId'
+  | 'projectId'
+  | 'subjectNameSnapshot'
+  | 'subjectUser'
+  | 'platformUser'
+  | 'project'
+  | 'trackingType'
+>;
+
+type TrackingReportSubjectDetailSource = TrackingReportSubjectDetailRecord;
 
 @Injectable()
 export class TrackingReportService {
   constructor(private readonly reports: TrackingReportRepository) {}
+
+  private toSubjectSummary(report: TrackingReportSubjectSummarySource) {
+    const localProfile = report.subjectUser?.profile;
+    const project = report.project;
+
+    if (
+      report.trackingType === TrackingReportType.PROJECT_PROGRESS &&
+      project
+    ) {
+      return {
+        kind: 'PROJECT' as const,
+        displayName: project.title,
+        avatar: project.image,
+        isLinked: Boolean(report.subjectUserId),
+      };
+    }
+
+    if (report.subjectUserId) {
+      return {
+        kind: 'LOCAL_USER' as const,
+        displayName: localProfile?.displayName ?? report.subjectNameSnapshot,
+        avatar: localProfile?.avatar ?? null,
+        isLinked: true,
+      };
+    }
+
+    return {
+      kind: 'PLATFORM_USER' as const,
+      displayName:
+        report.platformUser?.displayName ?? report.subjectNameSnapshot,
+      avatar: null,
+      isLinked: false,
+    };
+  }
+
+  private toSubject(report: TrackingReportSubjectDetailSource) {
+    const localUser = report.subjectUser
+      ? {
+          id: report.subjectUser.id,
+          username: report.subjectUser.username,
+          email: report.subjectUser.email,
+          countryCode: report.subjectUser.countryCode,
+          phone: report.subjectUser.phone,
+          displayName: report.subjectUser.profile?.displayName ?? null,
+          avatar: report.subjectUser.profile?.avatar ?? null,
+        }
+      : null;
+    const platformUser = report.platformUser
+      ? {
+          id: report.platformUser.id,
+          platform: report.platformUser.platform,
+          ptUserId: report.platformUser.ptUserId,
+          ptUnionId: report.platformUser.ptUnionId,
+          displayName: report.platformUser.displayName,
+        }
+      : null;
+    const project = report.project
+      ? {
+          id: report.project.id,
+          title: report.project.title,
+          subtitle: report.project.subtitle,
+          category: report.project.category,
+          image: report.project.image,
+        }
+      : null;
+
+    if (
+      report.trackingType === TrackingReportType.PROJECT_PROGRESS &&
+      project
+    ) {
+      return {
+        kind: 'PROJECT' as const,
+        displayName: project.title,
+        avatar: project.image,
+        isLinked: Boolean(localUser),
+        nameSnapshot: report.subjectNameSnapshot,
+        localUser,
+        platformUser,
+        project,
+      };
+    }
+
+    if (localUser) {
+      const phone = localUser.phone
+        ? `${localUser.countryCode ?? ''} ${localUser.phone}`.trim()
+        : null;
+      return {
+        kind: 'LOCAL_USER' as const,
+        displayName:
+          localUser.displayName ??
+          localUser.username ??
+          localUser.email ??
+          phone ??
+          report.subjectNameSnapshot,
+        avatar: localUser.avatar,
+        isLinked: true,
+        nameSnapshot: report.subjectNameSnapshot,
+        localUser,
+        platformUser,
+        project,
+      };
+    }
+
+    return {
+      kind: 'PLATFORM_USER' as const,
+      displayName: platformUser?.displayName ?? report.subjectNameSnapshot,
+      avatar: null,
+      isLinked: false,
+      nameSnapshot: report.subjectNameSnapshot,
+      localUser,
+      platformUser,
+      project,
+    };
+  }
+
+  private mapListReport(report: TrackingReportListRecord) {
+    const {
+      subjectNameSnapshot,
+      subjectUserId,
+      platformUserId,
+      projectId,
+      subjectUser,
+      platformUser,
+      project,
+      ...data
+    } = report;
+    return {
+      ...data,
+      subject: this.toSubjectSummary({
+        subjectNameSnapshot,
+        subjectUserId,
+        platformUserId,
+        projectId,
+        trackingType: report.trackingType,
+        subjectUser,
+        platformUser,
+        project,
+      }),
+    };
+  }
+
+  private mapReport<T extends TrackingReportSubjectDetailSource>(report: T) {
+    const {
+      subjectNameSnapshot,
+      subjectUserId,
+      platformUserId,
+      projectId,
+      subjectUser,
+      platformUser,
+      project,
+      ...data
+    } = report;
+    return {
+      ...data,
+      subject: this.toSubject({
+        subjectNameSnapshot,
+        subjectUserId,
+        platformUserId,
+        projectId,
+        trackingType: report.trackingType,
+        subjectUser,
+        platformUser,
+        project,
+      }),
+    };
+  }
+
+  private async getRecord(id: string) {
+    const report = await this.reports.findById(id);
+    if (!report) throw new NotFoundException(`Tracking report ${id} not found`);
+    return report;
+  }
 
   private validate(data: CreateTrackingReportDto) {
     if (!data.subjectUserId && !data.platformUserId)
@@ -47,9 +237,13 @@ export class TrackingReportService {
   }
 
   async get(id: string) {
-    const report = await this.reports.findById(id);
+    return this.mapReport(await this.getRecord(id));
+  }
+
+  async getSubject(id: string) {
+    const report = await this.reports.findSubjectByReportId(id);
     if (!report) throw new NotFoundException(`Tracking report ${id} not found`);
-    return report;
+    return this.toSubject(report);
   }
 
   async list(query: QueryTrackingReportDto) {
@@ -70,7 +264,8 @@ export class TrackingReportService {
       query.limit,
     );
     return {
-      ...result,
+      total: result.total,
+      data: result.data.map((report) => this.mapListReport(report)),
       page: query.page,
       limit: query.limit,
       totalPages: Math.ceil(result.total / query.limit),
@@ -78,7 +273,7 @@ export class TrackingReportService {
   }
 
   async update(id: string, dto: UpdateTrackingReportDto) {
-    const current = await this.get(id);
+    const current = await this.getRecord(id);
     const merged: CreateTrackingReportDto = {
       subjectUserId: current.subjectUserId ?? undefined,
       platformUserId: current.platformUserId ?? undefined,
@@ -108,7 +303,7 @@ export class TrackingReportService {
   }
 
   async delete(id: string) {
-    await this.get(id);
+    await this.getRecord(id);
     return { success: true, data: await this.reports.softDelete(id) };
   }
 }

--- a/src/user-platform/repositories/platform-user.repository.ts
+++ b/src/user-platform/repositories/platform-user.repository.ts
@@ -269,8 +269,31 @@ export class PlatformUserRepository {
       ...(keyword
         ? {
             OR: [
+              { id: keyword },
               { displayName: { contains: keyword, mode: 'insensitive' } },
               { phone: { contains: keyword } },
+              { ptUserId: { contains: keyword, mode: 'insensitive' } },
+              { ptUnionId: { contains: keyword, mode: 'insensitive' } },
+              {
+                user: {
+                  is: {
+                    OR: [
+                      { id: keyword },
+                      { username: { contains: keyword, mode: 'insensitive' } },
+                      { email: { contains: keyword, mode: 'insensitive' } },
+                      { phone: { contains: keyword } },
+                      {
+                        profile: {
+                          displayName: {
+                            contains: keyword,
+                            mode: 'insensitive',
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
             ],
           }
         : {}),
@@ -294,6 +317,7 @@ export class PlatformUserRepository {
       where: {
         deletedAt: null,
         OR: [
+          { id: keyword },
           { username: { contains: keyword, mode: 'insensitive' } },
           { email: { contains: keyword, mode: 'insensitive' } },
           { phone: { contains: keyword } },


### PR DESCRIPTION
## What changed

- add explicit tracking-report list and detail response DTOs
- reduce list projections to a compact report-subject summary
- add `GET /tracking-reports/:id/subject` for on-demand identity details
- preserve local-user-first, platform-user fallback, and project subject resolution
- expand platform-user keyword search across linked local-user and platform identity fields

## Why

The tracking-report list previously loaded and returned full local-user, platform-user, and project identity objects for every row. The list now returns only the data needed for recognition; complete identity information is queried only when requested.

## Impact

- smaller list payloads and database projections
- clearer list/detail API boundary
- no change to persisted report data or report generation behavior

## Validation

- `pnpm exec jest src/tracking-report/services/tracking-report.service.spec.ts --runInBand` (8 tests)
- `pnpm run build`
- ESLint, Prettier, and `git diff --check`

## Related

- Admin UI: https://github.com/lulabs-org/nove-admin/pull/93