### PR TITLE
refactor(admin): group API tags

### DIFF
--- a/src/admin/api-key/controllers/api-key.controller.ts
+++ b/src/admin/api-key/controllers/api-key.controller.ts
@@ -36,7 +36,7 @@ import {
  * API Key 管理控制器（管理端）
  * 需要 JWT 认证和 api_keys:manage 权限
  */
-@ApiTags('Admin - API Keys')
+@ApiTags('Admin / API Keys')
 @Controller('admin/api-keys')
 @RequireAuth('jwt')
 @ApiBearerAuth()

--- a/src/admin/dept/controllers/department.controller.ts
+++ b/src/admin/dept/controllers/department.controller.ts
@@ -35,7 +35,7 @@ import {
   DepartmentAncestorsResponse,
 } from '../dto';
 
-@ApiTags('Admin - Departments')
+@ApiTags('Admin / Departments')
 @Controller('admin')
 @ApiBearerAuth()
 export class DepartmentController {

--- a/src/admin/org-member/controllers/org-member.controller.ts
+++ b/src/admin/org-member/controllers/org-member.controller.ts
@@ -33,7 +33,7 @@ import {
   BatchImportResponse,
 } from '../dto';
 
-@ApiTags('Admin - OrgMembers')
+@ApiTags('Admin / OrgMembers')
 @Controller('admin')
 @ApiBearerAuth()
 export class OrgMemberController {

--- a/src/admin/org/controllers/organization.controller.ts
+++ b/src/admin/org/controllers/organization.controller.ts
@@ -31,7 +31,7 @@ import {
   OrganizationStatsDto,
 } from '../dto';
 
-@ApiTags('Admin - Organizations')
+@ApiTags('Admin / Organizations')
 @Controller('admin/orgs')
 @ApiBearerAuth()
 export class OrganizationController {

--- a/src/admin/permission/controllers/data-permission-rule.controller.ts
+++ b/src/admin/permission/controllers/data-permission-rule.controller.ts
@@ -28,7 +28,7 @@ import {
   DataPermissionRuleListResponse,
 } from '../dto';
 
-@ApiTags('Admin - Data Permission Rules')
+@ApiTags('Admin / Data Permission Rules')
 @Controller('admin/data-permission-rules')
 @ApiBearerAuth()
 export class DataPermRuleController {

--- a/src/admin/permission/controllers/permission.controller.ts
+++ b/src/admin/permission/controllers/permission.controller.ts
@@ -29,7 +29,7 @@ import {
   PermissionListResponse,
 } from '../dto';
 
-@ApiTags('Admin - Permissions')
+@ApiTags('Admin / Permissions')
 @Controller('admin/permissions')
 @ApiBearerAuth()
 export class PermController {

--- a/src/admin/role/controllers/role.controller.ts
+++ b/src/admin/role/controllers/role.controller.ts
@@ -32,7 +32,7 @@ import {
 } from '../dto';
 import { PermissionDto } from '@/admin/permission/dto';
 
-@ApiTags('Admin - Roles')
+@ApiTags('Admin / Roles')
 @Controller('admin/roles')
 @ApiBearerAuth()
 export class RoleController {


### PR DESCRIPTION
## What changed

- rename seven admin Swagger tags from `Admin - …` to `Admin / …`
- cover API keys, departments, organization members, organizations, data-permission rules, permissions, and roles

## Why

The slash-based tag naming gives generated API documentation and clients a consistent admin-module hierarchy.

## Impact

This changes OpenAPI grouping metadata only. Endpoint paths, request handling, permissions, and response contracts remain unchanged.

## Validation

- targeted ESLint for all seven changed controllers
- `pnpm build`
- `git diff --check`