### PR TITLE
optimize organization member lists

### DIFF
--- a/src/admin/org-member/controllers/org-member.controller.ts
+++ b/src/admin/org-member/controllers/org-member.controller.ts
@@ -30,6 +30,8 @@ import {
   PaginationDto,
   OrgMemberDetailDto,
   OrgMemberListResponse,
+  MemberRoleOptionQueryDto,
+  MemberRoleOptionListResponse,
   BatchImportResponse,
 } from '../dto';
 
@@ -100,6 +102,21 @@ export class OrgMemberController {
     @Query() pagination: PaginationDto,
   ): Promise<OrgMemberListResponse> {
     return this.orgMemberService.listMembers(orgId, pagination);
+  }
+
+  @Get('orgs/:orgId/member-role-options')
+  @ApiOperation({
+    summary: '角色成员选项',
+    description: '分页获取角色管理所需的轻量成员与角色关联数据',
+  })
+  @ApiParam({ name: 'orgId', description: '组织 ID' })
+  @ApiResponse({ status: 200, type: MemberRoleOptionListResponse })
+  @RequirePermissions('org-member:read')
+  async listMemberRoleOptions(
+    @Param('orgId') orgId: string,
+    @Query() query: MemberRoleOptionQueryDto,
+  ): Promise<MemberRoleOptionListResponse> {
+    return this.orgMemberService.listMemberRoleOptions(orgId, query);
   }
 
   @Post('orgs/:orgId/members/batch')

--- a/src/admin/org-member/dto/org-member.dto.ts
+++ b/src/admin/org-member/dto/org-member.dto.ts
@@ -177,6 +177,70 @@ export class OrgMemberDto {
   primaryDept?: OrgMemberPrimaryDeptInfo | null;
 }
 
+export class OrgMemberListUserProfileInfo {
+  @ApiPropertyOptional({ type: String, nullable: true }) displayName:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) avatar: string | null;
+}
+
+export class OrgMemberListUserInfo {
+  @ApiPropertyOptional({ type: String, nullable: true }) username:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) email: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) countryCode:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) phone: string | null;
+  @ApiPropertyOptional({ type: OrgMemberListUserProfileInfo, nullable: true })
+  profile: OrgMemberListUserProfileInfo | null;
+}
+
+export class OrgMemberListPrimaryDeptInfo {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+}
+
+export class OrgMemberListItemDto {
+  @ApiProperty() id: string;
+  @ApiProperty() userId: string;
+  @ApiProperty({ enum: MemberType }) type: MemberType;
+  @ApiProperty({ enum: MemberStatus }) status: MemberStatus;
+  @ApiPropertyOptional({ type: String, nullable: true }) orgDisplayName:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) employeeNo:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) title: string | null;
+  @ApiProperty() joinedAt: Date;
+  @ApiPropertyOptional({ type: OrgMemberListUserInfo, nullable: true })
+  user: OrgMemberListUserInfo | null;
+  @ApiPropertyOptional({ type: OrgMemberListPrimaryDeptInfo, nullable: true })
+  primaryDept: OrgMemberListPrimaryDeptInfo | null;
+}
+
+export class MemberRoleOptionDto {
+  @ApiProperty() id: string;
+  @ApiProperty() userId: string;
+  @ApiPropertyOptional({ type: String, nullable: true }) displayName:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) email: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) avatar: string | null;
+  @ApiProperty({ type: [String] }) departmentNames: string[];
+  @ApiProperty({ type: [String] }) roleIds: string[];
+}
+
+export class MemberRoleOptionListResponse {
+  @ApiProperty({ type: [MemberRoleOptionDto] }) items: MemberRoleOptionDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() pageSize: number;
+  @ApiProperty() totalPages: number;
+}
+
 export class OrgMemberDepartmentInfo {
   @ApiProperty({
     description: '部门 ID',
@@ -240,9 +304,9 @@ export class OrgMemberDetailDto extends OrgMemberDto {
 export class OrgMemberListResponse {
   @ApiProperty({
     description: '成员列表',
-    type: [OrgMemberDto],
+    type: [OrgMemberListItemDto],
   })
-  items: OrgMemberDto[];
+  items: OrgMemberListItemDto[];
 
   @ApiProperty({
     description: '总数',

--- a/src/admin/org-member/dto/pagination.dto.spec.ts
+++ b/src/admin/org-member/dto/pagination.dto.spec.ts
@@ -1,0 +1,71 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { MemberRoleOptionQueryDto, PaginationDto } from './pagination.dto';
+
+describe('organization member pagination DTOs', () => {
+  it('treats blank member filters as omitted query parameters', async () => {
+    const input = plainToInstance(PaginationDto, {
+      page: '1',
+      pageSize: '100',
+      keyword: '',
+      deptId: '   ',
+      type: '',
+      status: '',
+      includeChildren: '',
+    });
+
+    await expect(validate(input)).resolves.toEqual([]);
+    expect(input).toEqual(
+      expect.objectContaining({
+        page: 1,
+        pageSize: 100,
+        keyword: undefined,
+        deptId: undefined,
+        type: undefined,
+        status: undefined,
+        includeChildren: undefined,
+      }),
+    );
+  });
+
+  it.each([
+    ['true', true],
+    ['false', false],
+  ])('parses includeChildren=%s as %s', async (value, expected) => {
+    const input = plainToInstance(PaginationDto, { includeChildren: value });
+
+    await expect(validate(input)).resolves.toEqual([]);
+    expect(input.includeChildren).toBe(expected);
+  });
+
+  it('treats blank member role option filters as omitted', async () => {
+    const input = plainToInstance(MemberRoleOptionQueryDto, {
+      keyword: '',
+      roleId: ' ',
+      assignment: '',
+    });
+
+    await expect(validate(input)).resolves.toEqual([]);
+    expect(input).toEqual(
+      expect.objectContaining({
+        keyword: undefined,
+        roleId: undefined,
+        assignment: undefined,
+      }),
+    );
+  });
+
+  it.each([PaginationDto, MemberRoleOptionQueryDto])(
+    'rejects page sizes above 100 for %p',
+    async (Dto) => {
+      const input = plainToInstance(Dto, { pageSize: 101 });
+      const errors = await validate(input);
+
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ property: 'pageSize' }),
+        ]),
+      );
+    },
+  );
+});

--- a/src/admin/org-member/dto/pagination.dto.ts
+++ b/src/admin/org-member/dto/pagination.dto.ts
@@ -17,9 +17,21 @@ import {
   Min,
   IsEnum,
   IsBoolean,
+  Max,
+  IsIn,
 } from 'class-validator';
 import { MemberType, MemberStatus } from '@prisma/client';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
+
+const blankStringToUndefined = ({ value }: { value: unknown }) =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value;
+
+const queryBoolean = ({ value }: { value: unknown }) => {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+  return value;
+};
 
 export class PaginationDto {
   @ApiPropertyOptional({
@@ -40,12 +52,14 @@ export class PaginationDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100)
   pageSize?: number;
 
   @ApiPropertyOptional({
     description: '搜索关键字（姓名、工号、邮箱）',
     example: '张三',
   })
+  @Transform(blankStringToUndefined)
   @IsOptional()
   @IsString()
   keyword?: string;
@@ -54,6 +68,7 @@ export class PaginationDto {
     description: '部门 ID 筛选',
     example: 'clx0987654321fedcba',
   })
+  @Transform(blankStringToUndefined)
   @IsOptional()
   @IsString()
   deptId?: string;
@@ -63,6 +78,7 @@ export class PaginationDto {
     enum: MemberType,
     example: MemberType.INTERNAL,
   })
+  @Transform(blankStringToUndefined)
   @IsOptional()
   @IsEnum(MemberType)
   type?: MemberType;
@@ -72,6 +88,7 @@ export class PaginationDto {
     enum: MemberStatus,
     example: MemberStatus.ACTIVE,
   })
+  @Transform(blankStringToUndefined)
   @IsOptional()
   @IsEnum(MemberStatus)
   status?: MemberStatus;
@@ -80,8 +97,43 @@ export class PaginationDto {
     description: '是否包含子部门成员',
     example: false,
   })
+  @Transform(queryBoolean)
   @IsOptional()
-  @Type(() => Boolean)
   @IsBoolean()
   includeChildren?: boolean;
+}
+
+export class MemberRoleOptionQueryDto {
+  @ApiPropertyOptional({ description: '页码', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: '每页数量', example: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number;
+
+  @ApiPropertyOptional({ description: '姓名或邮箱关键字' })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({ description: '角色 ID' })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsString()
+  roleId?: string;
+
+  @ApiPropertyOptional({ enum: ['assigned', 'unassigned'] })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsIn(['assigned', 'unassigned'])
+  assignment?: 'assigned' | 'unassigned';
 }

--- a/src/admin/org-member/repositories/org-member.repository.spec.ts
+++ b/src/admin/org-member/repositories/org-member.repository.spec.ts
@@ -1,0 +1,83 @@
+import { PrismaService } from '@/prisma/prisma.service';
+import { OrgMemberRepository } from './org-member.repository';
+
+describe('OrgMemberRepository department scope', () => {
+  it('uses a list-specific projection instead of loading detail fields', async () => {
+    const findMany = jest.fn((query: unknown) => {
+      void query;
+      return Promise.resolve([]);
+    });
+    const prisma = {
+      orgMember: {
+        findMany,
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+    const repository = new OrgMemberRepository(
+      prisma as unknown as PrismaService,
+    );
+
+    await repository.findList({
+      where: { orgId: 'org-1', deletedAt: null },
+      skip: 0,
+      take: 20,
+    });
+
+    const query = findMany.mock.calls[0][0] as {
+      select: Record<string, unknown> & {
+        primaryDept: { select: Record<string, boolean> };
+      };
+    };
+    expect(query.select).toEqual(
+      expect.objectContaining({
+        id: true,
+        userId: true,
+        status: true,
+        joinedAt: true,
+      }),
+    );
+    expect(query.select).not.toHaveProperty('orgId');
+    expect(query.select).not.toHaveProperty('createdAt');
+    expect(query.select).not.toHaveProperty('updatedAt');
+    expect(query.select).not.toHaveProperty('deletedAt');
+    expect(query.select.primaryDept.select).toEqual({ id: true, name: true });
+  });
+
+  it('validates a department once when child departments are not requested', async () => {
+    const prisma = {
+      dept: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'dept-1' }),
+        findMany: jest.fn(),
+      },
+    };
+    const repository = new OrgMemberRepository(
+      prisma as unknown as PrismaService,
+    );
+
+    await expect(
+      repository.getDepartmentIds('org-1', 'dept-1', false),
+    ).resolves.toEqual(['dept-1']);
+    expect(prisma.dept.findMany).not.toHaveBeenCalled();
+  });
+
+  it('does not traverse a department outside the requested organization', async () => {
+    const prisma = {
+      dept: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn(),
+      },
+    };
+    const repository = new OrgMemberRepository(
+      prisma as unknown as PrismaService,
+    );
+
+    await expect(
+      repository.getDepartmentIds('org-1', 'foreign-dept', true),
+    ).resolves.toEqual([]);
+    expect(prisma.dept.findFirst).toHaveBeenCalledWith({
+      where: { id: 'foreign-dept', orgId: 'org-1', deletedAt: null },
+      select: { id: true },
+    });
+    expect(prisma.dept.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/admin/org-member/repositories/org-member.repository.ts
+++ b/src/admin/org-member/repositories/org-member.repository.ts
@@ -2,6 +2,56 @@ import { Injectable } from '@nestjs/common';
 import { OrgMember, Prisma } from '@prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
+const orgMemberListSelect = {
+  id: true,
+  userId: true,
+  type: true,
+  status: true,
+  orgDisplayName: true,
+  employeeNo: true,
+  title: true,
+  joinedAt: true,
+  user: {
+    select: {
+      username: true,
+      email: true,
+      countryCode: true,
+      phone: true,
+      profile: { select: { displayName: true, avatar: true } },
+    },
+  },
+  primaryDept: { select: { id: true, name: true } },
+} satisfies Prisma.OrgMemberSelect;
+
+const memberRoleOptionSelect = {
+  id: true,
+  userId: true,
+  orgDisplayName: true,
+  user: {
+    select: {
+      username: true,
+      email: true,
+      profile: { select: { displayName: true, avatar: true } },
+    },
+  },
+  primaryDept: { select: { name: true } },
+  memberDepartments: {
+    where: { deletedAt: null },
+    select: { dept: { select: { name: true } } },
+  },
+  memberRoles: {
+    where: { deletedAt: null },
+    select: { roleId: true },
+  },
+} satisfies Prisma.OrgMemberSelect;
+
+export type OrgMemberListRecord = Prisma.OrgMemberGetPayload<{
+  select: typeof orgMemberListSelect;
+}>;
+export type MemberRoleOptionRecord = Prisma.OrgMemberGetPayload<{
+  select: typeof memberRoleOptionSelect;
+}>;
+
 @Injectable()
 export class OrgMemberRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -45,57 +95,42 @@ export class OrgMemberRepository {
     });
   }
 
-  async findByOrgId(
-    orgId: string,
-    options?: {
-      skip?: number;
-      take?: number;
-      orderBy?: Prisma.OrgMemberOrderByWithRelationInput;
-      where?: Prisma.OrgMemberWhereInput;
-    },
-  ): Promise<{ items: OrgMember[]; total: number }> {
-    const { skip, take, orderBy, where } = options || {};
-
-    const baseWhere: Prisma.OrgMemberWhereInput = {
-      orgId,
-      deletedAt: null,
-      ...where,
-    };
-
+  async findList(options: {
+    skip?: number;
+    take?: number;
+    orderBy?: Prisma.OrgMemberOrderByWithRelationInput;
+    where: Prisma.OrgMemberWhereInput;
+  }): Promise<{ items: OrgMemberListRecord[]; total: number }> {
+    const { skip, take, orderBy, where } = options;
     const [items, total] = await Promise.all([
       this.prisma.orgMember.findMany({
-        where: baseWhere,
+        where,
         skip,
         take,
         orderBy: orderBy || { createdAt: 'desc' },
-        include: {
-          user: {
-            select: {
-              id: true,
-              username: true,
-              email: true,
-              countryCode: true,
-              phone: true,
-              profile: {
-                select: {
-                  displayName: true,
-                  avatar: true,
-                },
-              },
-            },
-          },
-          primaryDept: {
-            select: {
-              id: true,
-              name: true,
-              code: true,
-            },
-          },
-        },
+        select: orgMemberListSelect,
       }),
-      this.prisma.orgMember.count({ where: baseWhere }),
+      this.prisma.orgMember.count({ where }),
     ]);
 
+    return { items, total };
+  }
+
+  async findMemberRoleOptions(options: {
+    skip: number;
+    take: number;
+    where: Prisma.OrgMemberWhereInput;
+  }): Promise<{ items: MemberRoleOptionRecord[]; total: number }> {
+    const [items, total] = await Promise.all([
+      this.prisma.orgMember.findMany({
+        where: options.where,
+        skip: options.skip,
+        take: options.take,
+        orderBy: { createdAt: 'desc' },
+        select: memberRoleOptionSelect,
+      }),
+      this.prisma.orgMember.count({ where: options.where }),
+    ]);
     return { items, total };
   }
 
@@ -153,73 +188,28 @@ export class OrgMemberRepository {
     });
   }
 
-  async findByDepartmentId(
-    deptId: string,
-    includeChildren: boolean = false,
-    options?: {
-      skip?: number;
-      take?: number;
-    },
-  ): Promise<{ items: OrgMember[]; total: number }> {
-    const { skip, take } = options || {};
-
-    let departmentIds: string[] = [deptId];
-
-    if (includeChildren) {
-      departmentIds = await this.getAllChildDepartmentIds(deptId);
-    }
-
-    const where: Prisma.OrgMemberWhereInput = {
-      memberDepartments: {
-        some: {
-          deptId: { in: departmentIds },
-          deletedAt: null,
-        },
-      },
-      deletedAt: null,
-    };
-
-    const [items, total] = await Promise.all([
-      this.prisma.orgMember.findMany({
-        where,
-        skip,
-        take,
-        orderBy: { createdAt: 'desc' },
-        include: {
-          user: {
-            select: {
-              id: true,
-              username: true,
-              email: true,
-              countryCode: true,
-              phone: true,
-              profile: {
-                select: {
-                  displayName: true,
-                  avatar: true,
-                },
-              },
-            },
-          },
-          primaryDept: {
-            select: {
-              id: true,
-              name: true,
-              code: true,
-            },
-          },
-        },
-      }),
-      this.prisma.orgMember.count({ where }),
-    ]);
-
-    return { items, total };
+  async getDepartmentIds(
+    orgId: string,
+    parentId: string,
+    includeChildren: boolean,
+  ): Promise<string[]> {
+    const parent = await this.prisma.dept.findFirst({
+      where: { id: parentId, orgId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!parent) return [];
+    if (!includeChildren) return [parentId];
+    return [parentId, ...(await this.getChildDepartmentIds(orgId, parentId))];
   }
 
-  private async getAllChildDepartmentIds(parentId: string): Promise<string[]> {
-    const ids: string[] = [parentId];
+  private async getChildDepartmentIds(
+    orgId: string,
+    parentId: string,
+  ): Promise<string[]> {
+    const ids: string[] = [];
     const children = await this.prisma.dept.findMany({
       where: {
+        orgId,
         parentId,
         deletedAt: null,
       },
@@ -227,75 +217,13 @@ export class OrgMemberRepository {
     });
 
     for (const child of children) {
-      ids.push(...(await this.getAllChildDepartmentIds(child.id)));
+      ids.push(
+        child.id,
+        ...(await this.getChildDepartmentIds(orgId, child.id)),
+      );
     }
 
     return ids;
-  }
-
-  async searchByKeyword(
-    orgId: string,
-    keyword: string,
-    options?: {
-      skip?: number;
-      take?: number;
-    },
-  ): Promise<{ items: OrgMember[]; total: number }> {
-    const { skip, take } = options || {};
-
-    const where: Prisma.OrgMemberWhereInput = {
-      orgId,
-      deletedAt: null,
-      OR: [
-        { orgDisplayName: { contains: keyword, mode: 'insensitive' } },
-        { employeeNo: { contains: keyword, mode: 'insensitive' } },
-        { user: { username: { contains: keyword, mode: 'insensitive' } } },
-        { user: { email: { contains: keyword, mode: 'insensitive' } } },
-        {
-          user: {
-            profile: {
-              displayName: { contains: keyword, mode: 'insensitive' },
-            },
-          },
-        },
-      ],
-    };
-
-    const [items, total] = await Promise.all([
-      this.prisma.orgMember.findMany({
-        where,
-        skip,
-        take,
-        orderBy: { createdAt: 'desc' },
-        include: {
-          user: {
-            select: {
-              id: true,
-              username: true,
-              email: true,
-              countryCode: true,
-              phone: true,
-              profile: {
-                select: {
-                  displayName: true,
-                  avatar: true,
-                },
-              },
-            },
-          },
-          primaryDept: {
-            select: {
-              id: true,
-              name: true,
-              code: true,
-            },
-          },
-        },
-      }),
-      this.prisma.orgMember.count({ where }),
-    ]);
-
-    return { items, total };
   }
 
   async update(

--- a/src/admin/org-member/services/org-member.service.spec.ts
+++ b/src/admin/org-member/services/org-member.service.spec.ts
@@ -318,3 +318,111 @@ describe('OrgMemberService.batchImportMembers', () => {
     });
   });
 });
+
+describe('OrgMemberService.listMembers', () => {
+  const repository = {
+    findList: jest.fn(),
+    getDepartmentIds: jest.fn(),
+    findMemberRoleOptions: jest.fn(),
+  };
+  const service = new OrgMemberService(
+    repository as unknown as OrgMemberRepository,
+    {} as PrismaService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository.findList.mockResolvedValue({ items: [], total: 0 });
+  });
+
+  it('combines organization, department, keyword, type and status filters', async () => {
+    repository.getDepartmentIds.mockResolvedValue(['dept-1', 'dept-2']);
+
+    await service.listMembers('org-1', {
+      page: 2,
+      pageSize: 20,
+      keyword: 'Alice',
+      deptId: 'dept-1',
+      includeChildren: true,
+      type: 'INTERNAL',
+      status: 'ACTIVE',
+    });
+
+    expect(repository.getDepartmentIds).toHaveBeenCalledWith(
+      'org-1',
+      'dept-1',
+      true,
+    );
+    expect(repository.findList).toHaveBeenCalledWith({
+      skip: 20,
+      take: 20,
+      where: expect.objectContaining({
+        orgId: 'org-1',
+        deletedAt: null,
+        type: 'INTERNAL',
+        status: 'ACTIVE',
+        OR: expect.any(Array),
+        memberDepartments: {
+          some: {
+            orgId: 'org-1',
+            deptId: { in: ['dept-1', 'dept-2'] },
+            deletedAt: null,
+          },
+        },
+      }),
+    });
+  });
+
+  it('returns lightweight role options without detail lookups', async () => {
+    repository.findMemberRoleOptions.mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 'member-1',
+          userId: 'user-1',
+          orgDisplayName: null,
+          user: {
+            username: 'alice',
+            email: 'alice@example.com',
+            profile: { displayName: 'Alice', avatar: null },
+          },
+          primaryDept: { name: '研发部' },
+          memberDepartments: [{ dept: { name: '研发部' } }],
+          memberRoles: [{ roleId: 'role-1' }],
+        },
+      ],
+    });
+
+    await expect(
+      service.listMemberRoleOptions('org-1', {
+        roleId: 'role-1',
+        assignment: 'assigned',
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            id: 'member-1',
+            displayName: 'Alice',
+            departmentNames: ['研发部'],
+            roleIds: ['role-1'],
+          }),
+        ],
+      }),
+    );
+    expect(repository.findMemberRoleOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          orgId: 'org-1',
+          memberRoles: {
+            some: {
+              roleId: 'role-1',
+              deletedAt: null,
+              role: { orgId: 'org-1', deletedAt: null },
+            },
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/src/admin/org-member/services/org-member.service.ts
+++ b/src/admin/org-member/services/org-member.service.ts
@@ -15,12 +15,15 @@ import {
   UpdateMemberDepartmentsDto,
   BatchImportMemberDto,
   PaginationDto,
-  OrgMemberDto,
+  MemberRoleOptionQueryDto,
+  OrgMemberListItemDto,
   OrgMemberDetailDto,
   OrgMemberListResponse,
+  MemberRoleOptionListResponse,
   BatchImportResponse,
 } from '../dto';
 import { DesensitizationUtil } from '@/common/utils/desensitization.util';
+import type { OrgMemberListRecord } from '../repositories/org-member.repository';
 
 @Injectable()
 export class OrgMemberService {
@@ -48,41 +51,119 @@ export class OrgMemberService {
     const pageSize = pagination?.pageSize || 10;
     const skip = (page - 1) * pageSize;
 
-    let result: { items: OrgMember[]; total: number };
-
+    const where: Prisma.OrgMemberWhereInput = { orgId, deletedAt: null };
+    if (pagination?.type) where.type = pagination.type;
+    if (pagination?.status) where.status = pagination.status;
     if (pagination?.keyword) {
-      result = await this.orgMemberRepository.searchByKeyword(
-        orgId,
-        pagination.keyword,
-        { skip, take: pageSize },
-      );
-    } else if (pagination?.deptId) {
-      const includeChildren = pagination?.includeChildren || false;
-      result = await this.orgMemberRepository.findByDepartmentId(
-        pagination.deptId,
-        includeChildren,
-        { skip, take: pageSize },
-      );
-    } else {
-      const where: Prisma.OrgMemberWhereInput = {};
-
-      if (pagination?.type) {
-        where.type = pagination.type;
-      }
-
-      if (pagination?.status) {
-        where.status = pagination.status;
-      }
-
-      result = await this.orgMemberRepository.findByOrgId(orgId, {
-        skip,
-        take: pageSize,
-        where,
-      });
+      where.OR = [
+        {
+          orgDisplayName: { contains: pagination.keyword, mode: 'insensitive' },
+        },
+        { employeeNo: { contains: pagination.keyword, mode: 'insensitive' } },
+        {
+          user: {
+            username: { contains: pagination.keyword, mode: 'insensitive' },
+          },
+        },
+        {
+          user: {
+            email: { contains: pagination.keyword, mode: 'insensitive' },
+          },
+        },
+        {
+          user: {
+            profile: {
+              displayName: {
+                contains: pagination.keyword,
+                mode: 'insensitive',
+              },
+            },
+          },
+        },
+      ];
     }
+    if (pagination?.deptId) {
+      const departmentIds = await this.orgMemberRepository.getDepartmentIds(
+        orgId,
+        pagination.deptId,
+        pagination.includeChildren || false,
+      );
+      where.memberDepartments = {
+        some: { orgId, deptId: { in: departmentIds }, deletedAt: null },
+      };
+    }
+
+    const result = await this.orgMemberRepository.findList({
+      skip,
+      take: pageSize,
+      where,
+    });
 
     return {
       items: result.items.map((item) => this.toDto(item)),
+      total: result.total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(result.total / pageSize),
+    };
+  }
+
+  async listMemberRoleOptions(
+    orgId: string,
+    query: MemberRoleOptionQueryDto,
+  ): Promise<MemberRoleOptionListResponse> {
+    const page = query.page || 1;
+    const pageSize = query.pageSize || 20;
+    const where: Prisma.OrgMemberWhereInput = { orgId, deletedAt: null };
+    if (query.keyword) {
+      where.OR = [
+        { orgDisplayName: { contains: query.keyword, mode: 'insensitive' } },
+        {
+          user: { username: { contains: query.keyword, mode: 'insensitive' } },
+        },
+        { user: { email: { contains: query.keyword, mode: 'insensitive' } } },
+        {
+          user: {
+            profile: {
+              displayName: { contains: query.keyword, mode: 'insensitive' },
+            },
+          },
+        },
+      ];
+    }
+    if (query.roleId && query.assignment) {
+      where.memberRoles = {
+        [query.assignment === 'assigned' ? 'some' : 'none']: {
+          roleId: query.roleId,
+          deletedAt: null,
+          role: { orgId, deletedAt: null },
+        },
+      };
+    }
+    const result = await this.orgMemberRepository.findMemberRoleOptions({
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      where,
+    });
+    return {
+      items: result.items.map((member) => ({
+        id: member.id,
+        userId: member.userId,
+        displayName:
+          member.orgDisplayName ||
+          member.user.profile?.displayName ||
+          member.user.username ||
+          member.user.email,
+        email: member.user.email,
+        avatar: member.user.profile?.avatar || null,
+        departmentNames: [
+          ...new Set([
+            ...(member.primaryDept?.name ? [member.primaryDept.name] : []),
+            ...member.memberDepartments.map((item) => item.dept.name),
+          ]),
+        ],
+        roleIds: member.memberRoles.map((item) => item.roleId),
+      })),
       total: result.total,
       page,
       pageSize,
@@ -561,41 +642,16 @@ export class OrgMemberService {
     return 'INTERNAL_ERROR';
   }
 
-  private toDto(
-    member: OrgMember & {
-      user?: {
-        id: string;
-        username: string | null;
-        email: string | null;
-        countryCode: string | null;
-        phone: string | null;
-        profile?: {
-          displayName: string | null;
-          avatar: string | null;
-        } | null;
-      };
-      primaryDept?: {
-        id: string;
-        name: string;
-        code: string;
-      } | null;
-    },
-  ): OrgMemberDto {
+  private toDto(member: OrgMemberListRecord): OrgMemberListItemDto {
     return {
       id: member.id,
-      orgId: member.orgId,
       userId: member.userId,
       type: member.type,
       status: member.status,
       orgDisplayName: member.orgDisplayName,
       employeeNo: member.employeeNo,
-      primaryDeptId: member.primaryDeptId,
-      externalCompany: member.externalCompany,
       title: member.title,
       joinedAt: member.joinedAt,
-      createdAt: member.createdAt,
-      updatedAt: member.updatedAt,
-      deletedAt: member.deletedAt,
       user: member.user,
       primaryDept: member.primaryDept,
     };
@@ -637,7 +693,20 @@ export class OrgMemberService {
     },
   ): OrgMemberDetailDto {
     return {
-      ...this.toDto(member),
+      id: member.id,
+      orgId: member.orgId,
+      userId: member.userId,
+      type: member.type,
+      status: member.status,
+      orgDisplayName: member.orgDisplayName,
+      employeeNo: member.employeeNo,
+      primaryDeptId: member.primaryDeptId,
+      externalCompany: member.externalCompany,
+      title: member.title,
+      joinedAt: member.joinedAt,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+      deletedAt: member.deletedAt,
       user: member.user || {
         id: '',
         username: null,


### PR DESCRIPTION
## What changed

- reduce organization member list payloads with list-specific Prisma projections
- apply keyword, department, member type, and status filters consistently within the requested organization
- add a paginated member-role options endpoint with assigned and unassigned filtering
- normalize blank optional query parameters and parse `includeChildren=false` correctly
- add DTO, repository, and service regression coverage

## Why

The member list endpoint returned more relational data than the admin list needed, and role assignment screens had to assemble options inefficiently. Requests generated by clients such as Apifox also commonly include blank filter values; those values reached enum validation as empty strings and caused HTTP 400 responses.

## Impact

Admin member and role screens receive smaller, purpose-built responses and can paginate/filter on the server. Existing requests that omit filters by sending empty query parameters now behave like genuinely omitted parameters.

## Validation

- `pnpm exec jest --selectProjects unit --runInBand` (48 suites, 310 tests)
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

The repository-wide integration command still encounters pre-existing issues in the Tencent Meeting real API test and eventually exhausts the Node heap; the complete unit project passes.
