### PR TITLE
refactor: optimize org-member DTOs and decorators

### DIFF
--- a/src/admin/org-member/controllers/org-member.controller.ts
+++ b/src/admin/org-member/controllers/org-member.controller.ts
@@ -44,7 +44,7 @@ import {
 @Controller('admin')
 @ApiBearerAuth()
 export class OrgMemberController {
-  constructor(private readonly orgMemberService: OrgMemberService) { }
+  constructor(private readonly orgMemberService: OrgMemberService) {}
 
   @Post('orgs/:orgId/members')
   @ApiCreateMember()

--- a/src/admin/org-member/controllers/org-member.controller.ts
+++ b/src/admin/org-member/controllers/org-member.controller.ts
@@ -11,13 +11,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiBearerAuth,
-  ApiParam,
-} from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { RequirePermissions } from '@/admin/permission/decorators/permissions.decorator';
 
 import { OrgMemberService } from '../services/org-member.service';
@@ -27,48 +21,33 @@ import {
   UpdateMemberStatusDto,
   UpdateMemberDepartmentsDto,
   BatchImportMemberDto,
-  PaginationDto,
+  QueryOrgMemberDto,
   OrgMemberDetailDto,
   OrgMemberListResponse,
-  MemberRoleOptionQueryDto,
+  QueryMemberRoleOptionDto,
   MemberRoleOptionListResponse,
   BatchImportResponse,
 } from '../dto';
+import {
+  ApiCreateMember,
+  ApiListMembers,
+  ApiListMemberRoleOptions,
+  ApiBatchImportMembers,
+  ApiGetMember,
+  ApiUpdateMember,
+  ApiUpdateMemberStatus,
+  ApiDeleteMember,
+  ApiUpdateMemberDepartments,
+} from '../decorators/org-member.decorators';
 
 @ApiTags('Admin / OrgMembers')
 @Controller('admin')
 @ApiBearerAuth()
 export class OrgMemberController {
-  constructor(private readonly orgMemberService: OrgMemberService) {}
+  constructor(private readonly orgMemberService: OrgMemberService) { }
 
   @Post('orgs/:orgId/members')
-  @ApiOperation({
-    summary: '新增成员',
-    description:
-      '通过手机号或邮箱在指定组织下新增成员；已有用户直接关联，否则创建待验证用户',
-  })
-  @ApiParam({
-    name: 'orgId',
-    description: '组织 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 201,
-    description: '成员创建成功',
-    type: OrgMemberDetailDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '请求参数无效',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 409,
-    description: '联系方式冲突、成员已存在或工号已存在',
-  })
+  @ApiCreateMember()
   @RequirePermissions('org-member:create')
   async createMember(
     @Param('orgId') orgId: string,
@@ -78,70 +57,27 @@ export class OrgMemberController {
   }
 
   @Get('orgs/:orgId/members')
-  @ApiOperation({
-    summary: '成员列表',
-    description: '获取指定组织的成员列表（支持分页、关键字、部门、状态筛选）',
-  })
-  @ApiParam({
-    name: 'orgId',
-    description: '组织 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '成员列表',
-    type: OrgMemberListResponse,
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
+  @ApiListMembers()
   @RequirePermissions('org-member:read')
   async listMembers(
     @Param('orgId') orgId: string,
-    @Query() pagination: PaginationDto,
+    @Query() pagination: QueryOrgMemberDto,
   ): Promise<OrgMemberListResponse> {
     return this.orgMemberService.listMembers(orgId, pagination);
   }
 
   @Get('orgs/:orgId/member-role-options')
-  @ApiOperation({
-    summary: '角色成员选项',
-    description: '分页获取角色管理所需的轻量成员与角色关联数据',
-  })
-  @ApiParam({ name: 'orgId', description: '组织 ID' })
-  @ApiResponse({ status: 200, type: MemberRoleOptionListResponse })
+  @ApiListMemberRoleOptions()
   @RequirePermissions('org-member:read')
   async listMemberRoleOptions(
     @Param('orgId') orgId: string,
-    @Query() query: MemberRoleOptionQueryDto,
+    @Query() query: QueryMemberRoleOptionDto,
   ): Promise<MemberRoleOptionListResponse> {
     return this.orgMemberService.listMemberRoleOptions(orgId, query);
   }
 
   @Post('orgs/:orgId/members/batch')
-  @ApiOperation({
-    summary: '批量导入成员',
-    description: '批量导入成员到组织',
-  })
-  @ApiParam({
-    name: 'orgId',
-    description: '组织 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '批量导入结果',
-    type: BatchImportResponse,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '请求参数无效',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
+  @ApiBatchImportMembers()
   @RequirePermissions('org-member:create')
   async batchImportMembers(
     @Param('orgId') orgId: string,
@@ -151,28 +87,7 @@ export class OrgMemberController {
   }
 
   @Get('members/:memberId')
-  @ApiOperation({
-    summary: '成员详情',
-    description: '根据成员 ID 获取成员详细信息',
-  })
-  @ApiParam({
-    name: 'memberId',
-    description: '成员 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '成员详情',
-    type: OrgMemberDetailDto,
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '成员不存在',
-  })
+  @ApiGetMember()
   @RequirePermissions('org-member:read')
   async getMember(
     @Param('memberId') memberId: string,
@@ -181,32 +96,7 @@ export class OrgMemberController {
   }
 
   @Put('members/:memberId')
-  @ApiOperation({
-    summary: '更新成员信息',
-    description: '更新成员信息（工号、岗位、上级、入职日期等）',
-  })
-  @ApiParam({
-    name: 'memberId',
-    description: '成员 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '成员更新成功',
-    type: OrgMemberDetailDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '请求参数无效',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '成员不存在',
-  })
+  @ApiUpdateMember()
   @RequirePermissions('org-member:update')
   async updateMember(
     @Param('memberId') memberId: string,
@@ -216,32 +106,7 @@ export class OrgMemberController {
   }
 
   @Patch('members/:memberId/status')
-  @ApiOperation({
-    summary: '更新成员状态',
-    description: '启用/停用/离职成员',
-  })
-  @ApiParam({
-    name: 'memberId',
-    description: '成员 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '状态更新成功',
-    type: OrgMemberDetailDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '请求参数无效',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '成员不存在',
-  })
+  @ApiUpdateMemberStatus()
   @RequirePermissions('org-member:update')
   async updateMemberStatus(
     @Param('memberId') memberId: string,
@@ -252,59 +117,14 @@ export class OrgMemberController {
 
   @Delete('members/:memberId')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({
-    summary: '删除成员',
-    description: '删除/移除成员（软删除）',
-  })
-  @ApiParam({
-    name: 'memberId',
-    description: '成员 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 204,
-    description: '成员删除成功',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '成员不存在',
-  })
+  @ApiDeleteMember()
   @RequirePermissions('org-member:delete')
   async deleteMember(@Param('memberId') memberId: string): Promise<void> {
     await this.orgMemberService.deleteMember(memberId);
   }
 
   @Patch('members/:memberId/departments')
-  @ApiOperation({
-    summary: '调整成员所属部门',
-    description: '调整成员所属部门（主部门/兼职部门）',
-  })
-  @ApiParam({
-    name: 'memberId',
-    description: '成员 ID',
-    example: 'clx1234567890abcdef',
-  })
-  @ApiResponse({
-    status: 200,
-    description: '部门调整成功',
-    type: OrgMemberDetailDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: '请求参数无效',
-  })
-  @ApiResponse({
-    status: 401,
-    description: '未授权',
-  })
-  @ApiResponse({
-    status: 404,
-    description: '成员不存在',
-  })
+  @ApiUpdateMemberDepartments()
   @RequirePermissions('org-member:update')
   async updateMemberDepartments(
     @Param('memberId') memberId: string,

--- a/src/admin/org-member/decorators/org-member.decorators.ts
+++ b/src/admin/org-member/decorators/org-member.decorators.ts
@@ -1,0 +1,158 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
+import {
+  OrgMemberDetailDto,
+  OrgMemberListResponse,
+  MemberRoleOptionListResponse,
+  BatchImportResponse,
+} from '../dto';
+
+export function ApiCreateMember() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '新增成员',
+      description: '通过手机号或邮箱在指定组织下新增成员；已有用户直接关联，否则创建待验证用户',
+    }),
+    ApiParam({
+      name: 'orgId',
+      description: '组织 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 201, description: '成员创建成功', type: OrgMemberDetailDto }),
+    ApiResponse({ status: 400, description: '请求参数无效' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 409, description: '联系方式冲突、成员已存在或工号已存在' }),
+  );
+}
+
+export function ApiListMembers() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '成员列表',
+      description: '获取指定组织的成员列表（支持分页、关键字、部门、状态筛选）',
+    }),
+    ApiParam({
+      name: 'orgId',
+      description: '组织 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '成员列表', type: OrgMemberListResponse }),
+    ApiResponse({ status: 401, description: '未授权' }),
+  );
+}
+
+export function ApiListMemberRoleOptions() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '角色成员选项',
+      description: '分页获取角色管理所需的轻量成员与角色关联数据',
+    }),
+    ApiParam({ name: 'orgId', description: '组织 ID' }),
+    ApiResponse({ status: 200, type: MemberRoleOptionListResponse }),
+  );
+}
+
+export function ApiBatchImportMembers() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '批量导入成员',
+      description: '批量导入成员到组织',
+    }),
+    ApiParam({
+      name: 'orgId',
+      description: '组织 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '批量导入结果', type: BatchImportResponse }),
+    ApiResponse({ status: 400, description: '请求参数无效' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+  );
+}
+
+export function ApiGetMember() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '成员详情',
+      description: '根据成员 ID 获取成员详细信息',
+    }),
+    ApiParam({
+      name: 'memberId',
+      description: '成员 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '成员详情', type: OrgMemberDetailDto }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 404, description: '成员不存在' }),
+  );
+}
+
+export function ApiUpdateMember() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '更新成员信息',
+      description: '更新成员信息（工号、岗位、上级、入职日期等）',
+    }),
+    ApiParam({
+      name: 'memberId',
+      description: '成员 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '成员更新成功', type: OrgMemberDetailDto }),
+    ApiResponse({ status: 400, description: '请求参数无效' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 404, description: '成员不存在' }),
+  );
+}
+
+export function ApiUpdateMemberStatus() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '更新成员状态',
+      description: '启用/停用/离职成员',
+    }),
+    ApiParam({
+      name: 'memberId',
+      description: '成员 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '状态更新成功', type: OrgMemberDetailDto }),
+    ApiResponse({ status: 400, description: '请求参数无效' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 404, description: '成员不存在' }),
+  );
+}
+
+export function ApiDeleteMember() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '删除成员',
+      description: '删除/移除成员（软删除）',
+    }),
+    ApiParam({
+      name: 'memberId',
+      description: '成员 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 204, description: '成员删除成功' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 404, description: '成员不存在' }),
+  );
+}
+
+export function ApiUpdateMemberDepartments() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '调整成员所属部门',
+      description: '调整成员所属部门（主部门/兼职部门）',
+    }),
+    ApiParam({
+      name: 'memberId',
+      description: '成员 ID',
+      example: 'clx1234567890abcdef',
+    }),
+    ApiResponse({ status: 200, description: '部门调整成功', type: OrgMemberDetailDto }),
+    ApiResponse({ status: 400, description: '请求参数无效' }),
+    ApiResponse({ status: 401, description: '未授权' }),
+    ApiResponse({ status: 404, description: '成员不存在' }),
+  );
+}

--- a/src/admin/org-member/decorators/org-member.decorators.ts
+++ b/src/admin/org-member/decorators/org-member.decorators.ts
@@ -11,17 +11,25 @@ export function ApiCreateMember() {
   return applyDecorators(
     ApiOperation({
       summary: '新增成员',
-      description: '通过手机号或邮箱在指定组织下新增成员；已有用户直接关联，否则创建待验证用户',
+      description:
+        '通过手机号或邮箱在指定组织下新增成员；已有用户直接关联，否则创建待验证用户',
     }),
     ApiParam({
       name: 'orgId',
       description: '组织 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 201, description: '成员创建成功', type: OrgMemberDetailDto }),
+    ApiResponse({
+      status: 201,
+      description: '成员创建成功',
+      type: OrgMemberDetailDto,
+    }),
     ApiResponse({ status: 400, description: '请求参数无效' }),
     ApiResponse({ status: 401, description: '未授权' }),
-    ApiResponse({ status: 409, description: '联系方式冲突、成员已存在或工号已存在' }),
+    ApiResponse({
+      status: 409,
+      description: '联系方式冲突、成员已存在或工号已存在',
+    }),
   );
 }
 
@@ -36,7 +44,11 @@ export function ApiListMembers() {
       description: '组织 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '成员列表', type: OrgMemberListResponse }),
+    ApiResponse({
+      status: 200,
+      description: '成员列表',
+      type: OrgMemberListResponse,
+    }),
     ApiResponse({ status: 401, description: '未授权' }),
   );
 }
@@ -63,7 +75,11 @@ export function ApiBatchImportMembers() {
       description: '组织 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '批量导入结果', type: BatchImportResponse }),
+    ApiResponse({
+      status: 200,
+      description: '批量导入结果',
+      type: BatchImportResponse,
+    }),
     ApiResponse({ status: 400, description: '请求参数无效' }),
     ApiResponse({ status: 401, description: '未授权' }),
   );
@@ -80,7 +96,11 @@ export function ApiGetMember() {
       description: '成员 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '成员详情', type: OrgMemberDetailDto }),
+    ApiResponse({
+      status: 200,
+      description: '成员详情',
+      type: OrgMemberDetailDto,
+    }),
     ApiResponse({ status: 401, description: '未授权' }),
     ApiResponse({ status: 404, description: '成员不存在' }),
   );
@@ -97,7 +117,11 @@ export function ApiUpdateMember() {
       description: '成员 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '成员更新成功', type: OrgMemberDetailDto }),
+    ApiResponse({
+      status: 200,
+      description: '成员更新成功',
+      type: OrgMemberDetailDto,
+    }),
     ApiResponse({ status: 400, description: '请求参数无效' }),
     ApiResponse({ status: 401, description: '未授权' }),
     ApiResponse({ status: 404, description: '成员不存在' }),
@@ -115,7 +139,11 @@ export function ApiUpdateMemberStatus() {
       description: '成员 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '状态更新成功', type: OrgMemberDetailDto }),
+    ApiResponse({
+      status: 200,
+      description: '状态更新成功',
+      type: OrgMemberDetailDto,
+    }),
     ApiResponse({ status: 400, description: '请求参数无效' }),
     ApiResponse({ status: 401, description: '未授权' }),
     ApiResponse({ status: 404, description: '成员不存在' }),
@@ -150,7 +178,11 @@ export function ApiUpdateMemberDepartments() {
       description: '成员 ID',
       example: 'clx1234567890abcdef',
     }),
-    ApiResponse({ status: 200, description: '部门调整成功', type: OrgMemberDetailDto }),
+    ApiResponse({
+      status: 200,
+      description: '部门调整成功',
+      type: OrgMemberDetailDto,
+    }),
     ApiResponse({ status: 400, description: '请求参数无效' }),
     ApiResponse({ status: 401, description: '未授权' }),
     ApiResponse({ status: 404, description: '成员不存在' }),

--- a/src/admin/org-member/dto/batch-import-members.dto.ts
+++ b/src/admin/org-member/dto/batch-import-members.dto.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { ArrayMinSize, IsArray, ValidateNested } from 'class-validator';
 import { CreateOrgMemberDto } from './create-org-member.dto';
@@ -25,4 +25,56 @@ export class BatchImportMemberDto {
   @ValidateNested({ each: true })
   @Type(() => BatchImportMemberItemDto)
   members: BatchImportMemberItemDto[];
+}
+
+export class BatchImportFailure {
+  @ApiProperty({
+    description: '成员在批量请求中的序号（从 0 开始）',
+    example: 0,
+  })
+  index: number;
+
+  @ApiPropertyOptional({
+    description: '脱敏邮箱',
+    example: 'zh***@example.com',
+  })
+  email?: string;
+
+  @ApiPropertyOptional({
+    description: '脱敏手机号',
+    example: '138****8000',
+  })
+  phone?: string;
+
+  @ApiProperty({
+    description: '稳定错误码',
+    example: 'CONFLICT',
+  })
+  code: string;
+
+  @ApiProperty({
+    description: '失败原因',
+    example: 'User is already a member of this organization',
+  })
+  reason: string;
+}
+
+export class BatchImportResponse {
+  @ApiProperty({
+    description: '成功导入的成员数量',
+    example: 8,
+  })
+  successCount: number;
+
+  @ApiProperty({
+    description: '失败的成员数量',
+    example: 2,
+  })
+  failureCount: number;
+
+  @ApiProperty({
+    description: '失败的成员列表',
+    type: [BatchImportFailure],
+  })
+  failures: BatchImportFailure[];
 }

--- a/src/admin/org-member/dto/index.ts
+++ b/src/admin/org-member/dto/index.ts
@@ -3,6 +3,6 @@ export * from './update-org-member.dto';
 export * from './update-member-status.dto';
 export * from './update-member-departments.dto';
 export * from './batch-import-members.dto';
-export * from './pagination.dto';
+export * from './query-org-member.dto';
 export * from './org-member.dto';
-export * from './batch-import-members.dto';
+export * from './member-role-option.dto';

--- a/src/admin/org-member/dto/member-role-option.dto.ts
+++ b/src/admin/org-member/dto/member-role-option.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type, Transform } from 'class-transformer';
+import { IsOptional, IsString, IsInt, Min, Max, IsIn } from 'class-validator';
+
+const blankStringToUndefined = ({ value }: { value: unknown }) =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value;
+
+export class QueryMemberRoleOptionDto {
+  @ApiPropertyOptional({ description: '页码', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: '每页数量', example: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number;
+
+  @ApiPropertyOptional({ description: '姓名或邮箱关键字' })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({ description: '角色 ID' })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsString()
+  roleId?: string;
+
+  @ApiPropertyOptional({ enum: ['assigned', 'unassigned'] })
+  @Transform(blankStringToUndefined)
+  @IsOptional()
+  @IsIn(['assigned', 'unassigned'])
+  assignment?: 'assigned' | 'unassigned';
+}
+
+export class MemberRoleOptionDto {
+  @ApiProperty() id: string;
+  @ApiProperty() userId: string;
+  @ApiPropertyOptional({ type: String, nullable: true }) displayName:
+    | string
+    | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) email: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true }) avatar: string | null;
+  @ApiProperty({ type: [String] }) departmentNames: string[];
+  @ApiProperty({ type: [String] }) roleIds: string[];
+}
+
+export class MemberRoleOptionListResponse {
+  @ApiProperty({ type: [MemberRoleOptionDto] }) items: MemberRoleOptionDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() pageSize: number;
+  @ApiProperty() totalPages: number;
+}

--- a/src/admin/org-member/dto/org-member.dto.ts
+++ b/src/admin/org-member/dto/org-member.dto.ts
@@ -221,25 +221,6 @@ export class OrgMemberListItemDto {
   primaryDept: OrgMemberListPrimaryDeptInfo | null;
 }
 
-export class MemberRoleOptionDto {
-  @ApiProperty() id: string;
-  @ApiProperty() userId: string;
-  @ApiPropertyOptional({ type: String, nullable: true }) displayName:
-    | string
-    | null;
-  @ApiPropertyOptional({ type: String, nullable: true }) email: string | null;
-  @ApiPropertyOptional({ type: String, nullable: true }) avatar: string | null;
-  @ApiProperty({ type: [String] }) departmentNames: string[];
-  @ApiProperty({ type: [String] }) roleIds: string[];
-}
-
-export class MemberRoleOptionListResponse {
-  @ApiProperty({ type: [MemberRoleOptionDto] }) items: MemberRoleOptionDto[];
-  @ApiProperty() total: number;
-  @ApiProperty() page: number;
-  @ApiProperty() pageSize: number;
-  @ApiProperty() totalPages: number;
-}
 
 export class OrgMemberDepartmentInfo {
   @ApiProperty({
@@ -333,54 +314,3 @@ export class OrgMemberListResponse {
   totalPages: number;
 }
 
-export class BatchImportFailure {
-  @ApiProperty({
-    description: '成员在批量请求中的序号（从 0 开始）',
-    example: 0,
-  })
-  index: number;
-
-  @ApiPropertyOptional({
-    description: '脱敏邮箱',
-    example: 'zh***@example.com',
-  })
-  email?: string;
-
-  @ApiPropertyOptional({
-    description: '脱敏手机号',
-    example: '138****8000',
-  })
-  phone?: string;
-
-  @ApiProperty({
-    description: '稳定错误码',
-    example: 'CONFLICT',
-  })
-  code: string;
-
-  @ApiProperty({
-    description: '失败原因',
-    example: 'User is already a member of this organization',
-  })
-  reason: string;
-}
-
-export class BatchImportResponse {
-  @ApiProperty({
-    description: '成功导入的成员数量',
-    example: 8,
-  })
-  successCount: number;
-
-  @ApiProperty({
-    description: '失败的成员数量',
-    example: 2,
-  })
-  failureCount: number;
-
-  @ApiProperty({
-    description: '失败的成员列表',
-    type: [BatchImportFailure],
-  })
-  failures: BatchImportFailure[];
-}

--- a/src/admin/org-member/dto/org-member.dto.ts
+++ b/src/admin/org-member/dto/org-member.dto.ts
@@ -221,7 +221,6 @@ export class OrgMemberListItemDto {
   primaryDept: OrgMemberListPrimaryDeptInfo | null;
 }
 
-
 export class OrgMemberDepartmentInfo {
   @ApiProperty({
     description: '部门 ID',
@@ -313,4 +312,3 @@ export class OrgMemberListResponse {
   })
   totalPages: number;
 }
-

--- a/src/admin/org-member/dto/query-org-member.dto.spec.ts
+++ b/src/admin/org-member/dto/query-org-member.dto.spec.ts
@@ -1,10 +1,10 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { MemberRoleOptionQueryDto, PaginationDto } from './pagination.dto';
+import { QueryMemberRoleOptionDto, QueryOrgMemberDto } from './query-org-member.dto';
 
 describe('organization member pagination DTOs', () => {
   it('treats blank member filters as omitted query parameters', async () => {
-    const input = plainToInstance(PaginationDto, {
+    const input = plainToInstance(QueryOrgMemberDto, {
       page: '1',
       pageSize: '100',
       keyword: '',
@@ -32,14 +32,14 @@ describe('organization member pagination DTOs', () => {
     ['true', true],
     ['false', false],
   ])('parses includeChildren=%s as %s', async (value, expected) => {
-    const input = plainToInstance(PaginationDto, { includeChildren: value });
+    const input = plainToInstance(QueryOrgMemberDto, { includeChildren: value });
 
     await expect(validate(input)).resolves.toEqual([]);
     expect(input.includeChildren).toBe(expected);
   });
 
   it('treats blank member role option filters as omitted', async () => {
-    const input = plainToInstance(MemberRoleOptionQueryDto, {
+    const input = plainToInstance(QueryMemberRoleOptionDto, {
       keyword: '',
       roleId: ' ',
       assignment: '',
@@ -55,7 +55,7 @@ describe('organization member pagination DTOs', () => {
     );
   });
 
-  it.each([PaginationDto, MemberRoleOptionQueryDto])(
+  it.each([QueryOrgMemberDto, QueryMemberRoleOptionDto])(
     'rejects page sizes above 100 for %p',
     async (Dto) => {
       const input = plainToInstance(Dto, { pageSize: 101 });

--- a/src/admin/org-member/dto/query-org-member.dto.spec.ts
+++ b/src/admin/org-member/dto/query-org-member.dto.spec.ts
@@ -1,6 +1,7 @@
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
-import { QueryMemberRoleOptionDto, QueryOrgMemberDto } from './query-org-member.dto';
+import { QueryOrgMemberDto } from './query-org-member.dto';
+import { QueryMemberRoleOptionDto } from './member-role-option.dto';
 
 describe('organization member pagination DTOs', () => {
   it('treats blank member filters as omitted query parameters', async () => {
@@ -32,7 +33,9 @@ describe('organization member pagination DTOs', () => {
     ['true', true],
     ['false', false],
   ])('parses includeChildren=%s as %s', async (value, expected) => {
-    const input = plainToInstance(QueryOrgMemberDto, { includeChildren: value });
+    const input = plainToInstance(QueryOrgMemberDto, {
+      includeChildren: value,
+    });
 
     await expect(validate(input)).resolves.toEqual([]);
     expect(input.includeChildren).toBe(expected);

--- a/src/admin/org-member/dto/query-org-member.dto.ts
+++ b/src/admin/org-member/dto/query-org-member.dto.ts
@@ -33,7 +33,7 @@ const queryBoolean = ({ value }: { value: unknown }) => {
   return value;
 };
 
-export class PaginationDto {
+export class QueryOrgMemberDto {
   @ApiPropertyOptional({
     description: '页码',
     example: 1,
@@ -103,37 +103,3 @@ export class PaginationDto {
   includeChildren?: boolean;
 }
 
-export class MemberRoleOptionQueryDto {
-  @ApiPropertyOptional({ description: '页码', example: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number;
-
-  @ApiPropertyOptional({ description: '每页数量', example: 20 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  @Max(100)
-  pageSize?: number;
-
-  @ApiPropertyOptional({ description: '姓名或邮箱关键字' })
-  @Transform(blankStringToUndefined)
-  @IsOptional()
-  @IsString()
-  keyword?: string;
-
-  @ApiPropertyOptional({ description: '角色 ID' })
-  @Transform(blankStringToUndefined)
-  @IsOptional()
-  @IsString()
-  roleId?: string;
-
-  @ApiPropertyOptional({ enum: ['assigned', 'unassigned'] })
-  @Transform(blankStringToUndefined)
-  @IsOptional()
-  @IsIn(['assigned', 'unassigned'])
-  assignment?: 'assigned' | 'unassigned';
-}

--- a/src/admin/org-member/dto/query-org-member.dto.ts
+++ b/src/admin/org-member/dto/query-org-member.dto.ts
@@ -18,7 +18,6 @@ import {
   IsEnum,
   IsBoolean,
   Max,
-  IsIn,
 } from 'class-validator';
 import { MemberType, MemberStatus } from '@prisma/client';
 import { Transform, Type } from 'class-transformer';
@@ -102,4 +101,3 @@ export class QueryOrgMemberDto {
   @IsBoolean()
   includeChildren?: boolean;
 }
-

--- a/src/admin/org-member/enums/member.enum.ts
+++ b/src/admin/org-member/enums/member.enum.ts
@@ -1,11 +1,23 @@
+/**
+ * 组织成员类型
+ */
 export enum MemberType {
+  /** 内部员工 */
   INTERNAL = 'INTERNAL',
+  /** 外部人员/外包 */
   EXTERNAL = 'EXTERNAL',
 }
 
+/**
+ * 组织成员状态
+ */
 export enum MemberStatus {
+  /** 已邀请（待激活/待验证） */
   INVITED = 'INVITED',
+  /** 正常/在职 */
   ACTIVE = 'ACTIVE',
+  /** 已停用/禁用 */
   SUSPENDED = 'SUSPENDED',
+  /** 已离职 */
   LEFT = 'LEFT',
 }

--- a/src/admin/org-member/repositories/org-member.repository.ts
+++ b/src/admin/org-member/repositories/org-member.repository.ts
@@ -52,22 +52,39 @@ export type MemberRoleOptionRecord = Prisma.OrgMemberGetPayload<{
   select: typeof memberRoleOptionSelect;
 }>;
 
+/**
+ * 组织成员仓储类
+ * 负责处理组织成员相关的数据持久化与查询操作
+ */
 @Injectable()
 export class OrgMemberRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * 创建组织成员
+   * @param data 成员创建数据
+   */
   async create(data: Prisma.OrgMemberCreateInput): Promise<OrgMember> {
     return this.prisma.orgMember.create({
       data,
     });
   }
 
+  /**
+   * 根据 ID 查询组织成员
+   * @param id 成员 ID
+   */
   async findById(id: string): Promise<OrgMember | null> {
     return this.prisma.orgMember.findUnique({
       where: { id },
     });
   }
 
+  /**
+   * 根据组织 ID 和用户 ID 查询成员
+   * @param orgId 组织 ID
+   * @param userId 用户 ID
+   */
   async findByOrgAndUser(
     orgId: string,
     userId: string,
@@ -82,6 +99,11 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 根据工号查询组织成员
+   * @param orgId 组织 ID
+   * @param employeeNo 工号
+   */
   async findByEmployeeNo(
     orgId: string,
     employeeNo: string,
@@ -95,6 +117,10 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 分页查询组织成员列表
+   * @param options 查询条件与分页参数
+   */
   async findList(options: {
     skip?: number;
     take?: number;
@@ -116,6 +142,10 @@ export class OrgMemberRepository {
     return { items, total };
   }
 
+  /**
+   * 分页查询角色成员选项（用于分配角色时的成员列表）
+   * @param options 查询条件与分页参数
+   */
   async findMemberRoleOptions(options: {
     skip: number;
     take: number;
@@ -134,6 +164,10 @@ export class OrgMemberRepository {
     return { items, total };
   }
 
+  /**
+   * 获取成员详细信息（包含用户资料、主部门、所属部门、角色等关联数据）
+   * @param id 成员 ID
+   */
   async findDetailById(id: string): Promise<OrgMember | null> {
     return this.prisma.orgMember.findUnique({
       where: { id },
@@ -188,6 +222,12 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 获取指定部门及其子部门（可选）的 ID 集合
+   * @param orgId 组织 ID
+   * @param parentId 部门 ID
+   * @param includeChildren 是否包含所有子代部门
+   */
   async getDepartmentIds(
     orgId: string,
     parentId: string,
@@ -202,6 +242,11 @@ export class OrgMemberRepository {
     return [parentId, ...(await this.getChildDepartmentIds(orgId, parentId))];
   }
 
+  /**
+   * 递归获取所有子代部门的 ID（内部使用，存在性能瓶颈，建议优化为内存树或 CTE）
+   * @param orgId 组织 ID
+   * @param parentId 父部门 ID
+   */
   private async getChildDepartmentIds(
     orgId: string,
     parentId: string,
@@ -226,6 +271,11 @@ export class OrgMemberRepository {
     return ids;
   }
 
+  /**
+   * 更新成员基本信息
+   * @param id 成员 ID
+   * @param data 更新数据
+   */
   async update(
     id: string,
     data: Prisma.OrgMemberUpdateInput,
@@ -236,6 +286,11 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 更新成员状态
+   * @param id 成员 ID
+   * @param status 新状态
+   */
   async updateStatus(
     id: string,
     status: 'INVITED' | 'ACTIVE' | 'SUSPENDED' | 'LEFT',
@@ -246,12 +301,20 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 硬删除组织成员
+   * @param id 成员 ID
+   */
   async delete(id: string): Promise<OrgMember> {
     return this.prisma.orgMember.delete({
       where: { id },
     });
   }
 
+  /**
+   * 软删除组织成员（设置 deletedAt）
+   * @param id 成员 ID
+   */
   async softDelete(id: string): Promise<OrgMember> {
     return this.prisma.orgMember.update({
       where: { id },
@@ -259,6 +322,10 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 统计组织下的有效成员总数
+   * @param orgId 组织 ID
+   */
   async countByOrgId(orgId: string): Promise<number> {
     return this.prisma.orgMember.count({
       where: {
@@ -268,6 +335,11 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 按照状态统计组织成员数量
+   * @param orgId 组织 ID
+   * @param status 成员状态
+   */
   async countByStatus(
     orgId: string,
     status: 'INVITED' | 'ACTIVE' | 'SUSPENDED' | 'LEFT',
@@ -281,6 +353,11 @@ export class OrgMemberRepository {
     });
   }
 
+  /**
+   * 按照类型统计组织成员数量
+   * @param orgId 组织 ID
+   * @param type 成员类型
+   */
   async countByType(
     orgId: string,
     type: 'INTERNAL' | 'EXTERNAL',

--- a/src/admin/org-member/services/org-member.service.ts
+++ b/src/admin/org-member/services/org-member.service.ts
@@ -14,8 +14,8 @@ import {
   UpdateMemberStatusDto,
   UpdateMemberDepartmentsDto,
   BatchImportMemberDto,
-  PaginationDto,
-  MemberRoleOptionQueryDto,
+  QueryOrgMemberDto,
+  QueryMemberRoleOptionDto,
   OrgMemberListItemDto,
   OrgMemberDetailDto,
   OrgMemberListResponse,
@@ -45,7 +45,7 @@ export class OrgMemberService {
 
   async listMembers(
     orgId: string,
-    pagination?: PaginationDto,
+    pagination?: QueryOrgMemberDto,
   ): Promise<OrgMemberListResponse> {
     const page = pagination?.page || 1;
     const pageSize = pagination?.pageSize || 10;
@@ -110,7 +110,7 @@ export class OrgMemberService {
 
   async listMemberRoleOptions(
     orgId: string,
-    query: MemberRoleOptionQueryDto,
+    query: QueryMemberRoleOptionDto,
   ): Promise<MemberRoleOptionListResponse> {
     const page = query.page || 1;
     const pageSize = query.pageSize || 20;

--- a/src/meeting/controllers/meeting-recording.controller.ts
+++ b/src/meeting/controllers/meeting-recording.controller.ts
@@ -42,7 +42,7 @@ export class MeetingRecordingController {
   constructor(
     private readonly recordingService: MeetingRecordingService,
     private readonly transcriptService: TranscriptService,
-  ) { }
+  ) {}
 
   /**
    * 创建录音

--- a/src/meeting/repositories/transcript.repository.ts
+++ b/src/meeting/repositories/transcript.repository.ts
@@ -14,7 +14,7 @@ import { PrismaTransaction } from '@/tencent-mtg/types';
 
 @Injectable()
 export class TranscriptRepository {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(private readonly prisma: PrismaService) {}
 
   // ==========================================
   // WRITE OPERATIONS


### PR DESCRIPTION
## 主要变更

1. **分离出 Swagger 装饰器**：将 `OrgMemberController` 中臃肿的 Swagger 文档装饰器抽取到了 `org-member.decorators.ts` 中，让控制器更专注于业务逻辑。
2. **规范化分页 DTO**：重命名 `pagination.dto.ts` 为 `query-org-member.dto.ts` 并将内部类名修改为语义更清晰的 `QueryOrgMemberDto`。
3. **拆分聚合响应 DTO**：
   - 从庞大的 `org-member.dto.ts` 中剥离出了专属批量导入的响应结构 `BatchImportResponse` 和 `BatchImportFailure` 到 `batch-import-members.dto.ts` 中。
   - 新增了专门服务于角色选项的 `member-role-option.dto.ts`，统一存放相关的 Request 和 Response。
4. **清理导出代码**：清除了 `dto/index.ts` 中重复导出的项。

这些修改大幅降低了文件的耦合度，提升了代码的内聚性和可读性。