### PR TITLE
fix(role): sort roles by level

### DIFF
--- a/src/admin/role/repositories/role.repository.ts
+++ b/src/admin/role/repositories/role.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { RoleType } from '@prisma/client';
+import { Prisma, RoleType } from '@prisma/client';
 
 @Injectable()
 export class RoleRepository {
@@ -55,11 +55,9 @@ export class RoleRepository {
       type?: RoleType;
       active?: boolean;
     };
-    orderBy?: {
-      createdAt?: 'asc' | 'desc';
-      name?: 'asc' | 'desc';
-      level?: 'asc' | 'desc';
-    };
+    orderBy?:
+      | Prisma.RoleOrderByWithRelationInput
+      | Prisma.RoleOrderByWithRelationInput[];
   }) {
     const { skip, take, where, orderBy } = options || {};
 
@@ -68,7 +66,11 @@ export class RoleRepository {
         where,
         skip,
         take,
-        orderBy: orderBy || { createdAt: 'desc' },
+        orderBy: orderBy || [
+          { level: 'asc' },
+          { createdAt: 'asc' },
+          { id: 'asc' },
+        ],
         include: {
           permissions: {
             include: {

--- a/src/admin/role/services/role.service.spec.ts
+++ b/src/admin/role/services/role.service.spec.ts
@@ -1,0 +1,20 @@
+import { RoleService } from './role.service';
+import type { RoleRepository } from '../repositories/role.repository';
+
+describe('RoleService', () => {
+  it('lists roles by permission level with a stable tie-breaker', async () => {
+    const findMany = jest.fn().mockResolvedValue({ items: [], total: 0 });
+    const roleRepository = {
+      findMany,
+    } as unknown as jest.Mocked<RoleRepository>;
+    const service = new RoleService(roleRepository);
+
+    await service.findAll({ page: 1, pageSize: 100 });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ level: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
+      }),
+    );
+  });
+});

--- a/src/admin/role/services/role.service.ts
+++ b/src/admin/role/services/role.service.ts
@@ -98,7 +98,7 @@ export class RoleService {
       skip,
       take: pageSize,
       where,
-      orderBy: { createdAt: 'desc' },
+      orderBy: [{ level: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
     });
 
     return {


### PR DESCRIPTION
## What changed

- order role lists by ascending permission level
- use creation time and role ID as stable tie-breakers for roles at the same level
- make the repository's ordering input use the Prisma role order type
- add a service regression test for the expected ordering contract

## Why

Roles already carry a `level` field where smaller numbers represent higher privilege, but the list service explicitly sorted by newest creation time. This made the role sidebar appear arbitrary and could change whenever roles were recreated.

## Impact

Role management now presents roles in a predictable privilege hierarchy, with super administrators and other higher-level roles shown before lower-level roles. Equal-level roles retain a deterministic order.

## Validation

- `pnpm exec jest --selectProjects unit --runInBand src/admin/role/services/role.service.spec.ts`
- focused ESLint for the three changed role files
- `pnpm run build`
- `git diff --check`
