### PR TITLE
feat(permission): add unified keyword search

### DIFF
--- a/src/admin/permission/dto/query-permission.dto.ts
+++ b/src/admin/permission/dto/query-permission.dto.ts
@@ -14,6 +14,14 @@ import { PermissionType } from '@prisma/client';
 import { Type, Transform } from 'class-transformer';
 
 export class QueryPermissionDto {
+  @ApiPropertyOptional({
+    description: '统一搜索关键词（匹配权限名称、编码、资源或动作）',
+    example: 'user',
+  })
+  @IsString()
+  @IsOptional()
+  keyword?: string;
+
   @ApiPropertyOptional({ description: '权限名称（模糊搜索）', example: 'user' })
   @IsString()
   @IsOptional()

--- a/src/admin/permission/services/permission.service.ts
+++ b/src/admin/permission/services/permission.service.ts
@@ -210,6 +210,15 @@ export class PermService {
 
     const where: Record<string, any> = {};
 
+    if (query.keyword) {
+      where.OR = [
+        { name: { contains: query.keyword } },
+        { code: { contains: query.keyword } },
+        { resource: { contains: query.keyword } },
+        { action: { contains: query.keyword } },
+      ];
+    }
+
     if (query.name) {
       where.name = { contains: query.name };
     }


### PR DESCRIPTION
## What changed

- Added a unified `keyword` query parameter to the permission list endpoint.
- Searches permission name, code, resource, and action using OR semantics.
- Keeps existing exact resource, type, status, parent, and pagination filters compatible.

## Why

The admin permission page now presents a single search field. The previous API accepted separate name, code, and resource filters and combined them with AND semantics, so merging the UI alone would have reduced search capability.

## Impact

Clients can search across the primary permission identity fields with one parameter while existing query parameters continue to work.

Frontend counterpart: [nove-admin #102](https://github.com/lulabs-org/nove-admin/pull/102)

## Verification

- `pnpm exec eslint src/admin/permission/dto/query-permission.dto.ts src/admin/permission/services/permission.service.ts`
- `pnpm run build`
