### PR TITLE
feat(meeting): add external recording summaries

### DIFF
--- a/src/meeting/controllers/meeting-recording.controller.ts
+++ b/src/meeting/controllers/meeting-recording.controller.ts
@@ -31,7 +31,9 @@ import {
   MeetingRecordingListResponseDto,
   MeetingRecordingDto,
   MeetingRecordingDeleteResponseDto,
+  CreateRecordingSummaryDto,
 } from '../dto/meeting-recording.dto';
+import { MeetingSummaryDto } from '../dto/meeting-summary.dto';
 
 @ApiTags('Meet Recording')
 @Controller('recordings')
@@ -45,10 +47,10 @@ export class MeetingRecordingController {
   ) {}
 
   /**
-   * 创建录音
+   * 创建录制
    */
   @Post()
-  @RequirePermissions('meeting:create')
+  @RequirePermissions('meeting-recording:create')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: '创建录制记录' })
   @ApiResponse({
@@ -64,11 +66,11 @@ export class MeetingRecordingController {
   }
 
   /**
-   * 获取录音列表
+   * 获取录制列表
    */
   @Get()
-  @RequirePermissions('meeting:read')
-  @ApiOperation({ summary: '获取录音列表' })
+  @RequirePermissions('meeting-recording:read')
+  @ApiOperation({ summary: '获取录制列表' })
   @ApiResponse({ status: 200, type: MeetingRecordingListResponseDto })
   async getRecordings(
     @Query(new ValidationPipe({ transform: true }))
@@ -78,11 +80,11 @@ export class MeetingRecordingController {
   }
 
   /**
-   * 获取录音详情
+   * 获取录制详情
    */
   @Get(':id')
-  @RequirePermissions('meeting:read')
-  @ApiOperation({ summary: '获取录音详情' })
+  @RequirePermissions('meeting-recording:read')
+  @ApiOperation({ summary: '获取录制详情' })
   @ApiParam({ name: 'id', description: '录制记录ID', type: 'string' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -94,10 +96,10 @@ export class MeetingRecordingController {
   }
 
   /**
-   * 获取录制转写文本
+   * 获取录制转写
    */
   @Get(':id/transcript')
-  @RequirePermissions('meeting:read')
+  @RequirePermissions('meeting-recording:read')
   @HttpCode(HttpStatus.OK)
   @ApiGetTranscriptByRecordingIdDocs()
   async getTranscript(
@@ -128,10 +130,47 @@ export class MeetingRecordingController {
   }
 
   /**
+   * 获取录制总结
+   */
+  @Get(':id/summary')
+  @RequirePermissions('meeting-recording:read')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '获取录制总结' })
+  @ApiParam({ name: 'id', description: '录制记录ID', type: 'string' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: '获取成功',
+    type: MeetingSummaryDto,
+  })
+  async getRecordingSummary(@Param('id', CuidPipe) id: string) {
+    return this.recordingService.getSummary(id);
+  }
+
+  /**
+   * 写入外部 AI 生成的录制总结
+   */
+  @Post(':id/summary')
+  @RequirePermissions('meeting-recording:create')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: '写入外部 AI 生成的录制总结' })
+  @ApiParam({ name: 'id', description: '录制记录ID', type: 'string' })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: '创建成功',
+    type: MeetingSummaryDto,
+  })
+  async createRecordingSummary(
+    @Param('id', CuidPipe) id: string,
+    @Body(new ValidationPipe()) createParams: CreateRecordingSummaryDto,
+  ) {
+    return this.recordingService.createSummary(id, createParams);
+  }
+
+  /**
    * 更新录制记录
    */
   @Patch(':id')
-  @RequirePermissions('meeting:update')
+  @RequirePermissions('meeting-recording:update')
   @ApiOperation({ summary: '更新录制记录' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -149,7 +188,7 @@ export class MeetingRecordingController {
    * 删除录制记录
    */
   @Delete(':id')
-  @RequirePermissions('meeting:delete')
+  @RequirePermissions('meeting-recording:delete')
   @ApiOperation({ summary: '删除录制记录' })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/meeting/dto/meeting-recording.dto.ts
+++ b/src/meeting/dto/meeting-recording.dto.ts
@@ -8,9 +8,13 @@ import {
   Min,
   Max,
   IsObject,
+  IsNotEmpty,
+  IsInt,
+  IsArray,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { RecordingSource, RecordingStatus } from '@prisma/client';
+import { CreateMeetingSummaryDto } from './meeting-summary.dto';
 
 export class QueryMeetingRecordingDto {
   @ApiPropertyOptional({ description: '会议ID' })
@@ -93,6 +97,58 @@ export class CreateMeetingRecordingDto {
 export class UpdateMeetingRecordingDto extends PartialType(
   CreateMeetingRecordingDto,
 ) {}
+
+export class CreateRecordingSummaryDto extends CreateMeetingSummaryDto {
+  @ApiProperty({ description: '外部 AI 生成的录制总结内容' })
+  @IsString()
+  @IsNotEmpty()
+  declare content: string;
+
+  @ApiPropertyOptional({
+    description: '外部 AI 模型名称或版本',
+    example: 'gpt-5',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  aiModel?: string;
+
+  @ApiPropertyOptional({ description: '总结语言', default: 'zh-CN' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  language?: string;
+
+  @ApiPropertyOptional({
+    description: '外部 AI 处理耗时（毫秒）',
+    minimum: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  processingTime?: number;
+
+  @ApiPropertyOptional({ description: '参与者总结' })
+  @IsOptional()
+  @IsArray()
+  speakerInsights?: Record<string, unknown>[];
+
+  @ApiPropertyOptional({ description: '会议金句' })
+  @IsOptional()
+  @IsArray()
+  goldenQuotes?: Record<string, unknown>[];
+
+  @ApiPropertyOptional({
+    description: '外部 AI 返回的置信度',
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  confidence?: number;
+}
 
 export class MeetingRecordingDto {
   @ApiProperty({ description: '录音ID' })

--- a/src/meeting/dto/meeting-summary.dto.ts
+++ b/src/meeting/dto/meeting-summary.dto.ts
@@ -9,7 +9,7 @@ import {
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { ProcessingStatus } from '@prisma/client';
+import { GenerationMethod, ProcessingStatus } from '@prisma/client';
 
 export class CreateMeetingSummaryDto {
   @ApiPropertyOptional({ description: '总结标题' })
@@ -132,6 +132,33 @@ export class MeetingSummaryDto {
 
   @ApiPropertyOptional({ description: '状态', enum: ProcessingStatus })
   status?: ProcessingStatus;
+
+  @ApiProperty({ description: '会议ID' })
+  meetingId: string;
+
+  @ApiPropertyOptional({ description: '录制ID' })
+  recordingId?: string;
+
+  @ApiPropertyOptional({ description: 'AI模型名称或版本' })
+  aiModel?: string;
+
+  @ApiPropertyOptional({ description: '生成方式', enum: GenerationMethod })
+  generatedBy?: GenerationMethod;
+
+  @ApiPropertyOptional({ description: '置信度' })
+  confidence?: number;
+
+  @ApiPropertyOptional({ description: '总结语言' })
+  language?: string;
+
+  @ApiProperty({ description: '版本号' })
+  version: number;
+
+  @ApiProperty({ description: '是否为最新版本' })
+  isLatest: boolean;
+
+  @ApiPropertyOptional({ description: '处理耗时（毫秒）' })
+  processingTime?: number;
 
   @ApiProperty({ description: '创建时间' })
   createdAt: Date;

--- a/src/meeting/repositories/meeting-summary.repository.spec.ts
+++ b/src/meeting/repositories/meeting-summary.repository.spec.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { GenerationMethod, Prisma, ProcessingStatus } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+import { MeetingSummaryRepository } from './meeting-summary.repository';
+
+describe('MeetingSummaryRepository', () => {
+  it('only returns the latest non-deleted recording summary', async () => {
+    const findFirst = jest.fn().mockResolvedValue({ id: 'summary-1' });
+    const repository = new MeetingSummaryRepository({
+      meetingSummary: { findFirst },
+    } as unknown as PrismaService);
+
+    await repository.findByRecordingId('recording-1');
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        recordingId: 'recording-1',
+        isLatest: true,
+        deletedAt: null,
+      },
+      orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
+    });
+  });
+
+  it('creates a new latest version from externally generated content', async () => {
+    const previous = { id: 'summary-1', version: 2 };
+    const findFirst = jest.fn().mockResolvedValue(previous);
+    const update = jest
+      .fn()
+      .mockResolvedValue({ ...previous, isLatest: false });
+    const create = jest.fn(({ data }: { data: Record<string, unknown> }) => ({
+      id: 'summary-2',
+      ...data,
+    }));
+    const transaction = jest
+      .fn()
+      .mockImplementation((callback: (tx: unknown) => unknown) =>
+        Promise.resolve(
+          callback({ meetingSummary: { findFirst, update, create } }),
+        ),
+      );
+    const repository = new MeetingSummaryRepository({
+      $transaction: transaction,
+    } as unknown as PrismaService);
+
+    const result = await repository.createExternalForRecording(
+      'meeting-1',
+      'recording-1',
+      {
+        content: 'External summary',
+        aiModel: 'external-model',
+        keywords: ['external'],
+      },
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'summary-1' },
+      data: { isLatest: false },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        meetingId: 'meeting-1',
+        recordingId: 'recording-1',
+        content: 'External summary',
+        keywords: ['external'],
+        generatedBy: GenerationMethod.AI,
+        aiModel: 'external-model',
+        language: 'zh-CN',
+        status: ProcessingStatus.COMPLETED,
+        version: 3,
+        isLatest: true,
+        parentSummaryId: 'summary-1',
+      }),
+    });
+    expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
+    expect(result).toEqual(expect.objectContaining({ id: 'summary-2' }));
+  });
+});

--- a/src/meeting/repositories/meeting-summary.repository.ts
+++ b/src/meeting/repositories/meeting-summary.repository.ts
@@ -12,6 +12,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { GenerationMethod, ProcessingStatus, Prisma } from '@prisma/client';
+import { retryVersionTransaction } from '@/common/utils/prisma-transaction-retry';
+import { CreateRecordingSummaryDto } from '../dto/meeting-recording.dto';
 
 type CreateInput = Prisma.MeetingSummaryUncheckedCreateInput;
 
@@ -86,8 +88,67 @@ export class MeetingSummaryRepository {
       where: {
         recordingId,
         isLatest: true,
+        deletedAt: null,
       },
+      orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
     });
+  }
+
+  async createExternalForRecording(
+    meetingId: string,
+    recordingId: string,
+    data: CreateRecordingSummaryDto,
+  ) {
+    return retryVersionTransaction(() =>
+      this.prisma.$transaction(
+        async (tx) => {
+          const previous = await tx.meetingSummary.findFirst({
+            where: { recordingId, isLatest: true, deletedAt: null },
+            orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
+          });
+
+          if (previous) {
+            await tx.meetingSummary.update({
+              where: { id: previous.id },
+              data: { isLatest: false },
+            });
+          }
+
+          return tx.meetingSummary.create({
+            data: {
+              meetingId,
+              recordingId,
+              title: data.title,
+              content: data.content,
+              keywords: data.keywords ?? [],
+              aiMinutes: data.aiMinutes as Prisma.InputJsonValue | undefined,
+              keyPoints: data.keyPoints as Prisma.InputJsonValue | undefined,
+              actionItems: data.actionItems as
+                | Prisma.InputJsonValue
+                | undefined,
+              decisions: data.decisions as Prisma.InputJsonValue | undefined,
+              speakerInsights: data.speakerInsights as
+                | Prisma.InputJsonValue
+                | undefined,
+              goldenQuotes: data.goldenQuotes as
+                | Prisma.InputJsonValue
+                | undefined,
+              metadata: data.metadata as Prisma.InputJsonValue | undefined,
+              generatedBy: GenerationMethod.AI,
+              aiModel: data.aiModel ?? 'external-ai',
+              confidence: data.confidence,
+              language: data.language ?? 'zh-CN',
+              processingTime: data.processingTime,
+              status: ProcessingStatus.COMPLETED,
+              version: (previous?.version ?? 0) + 1,
+              isLatest: true,
+              parentSummaryId: previous?.id,
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      ),
+    );
   }
 
   async findById(id: string) {

--- a/src/meeting/services/meeting-recording.service.spec.ts
+++ b/src/meeting/services/meeting-recording.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test } from '@nestjs/testing';
+import { MeetingSummaryNotFoundException } from '../exceptions/meeting.exceptions';
+import { MeetingRecordingRepository } from '../repositories/meeting-recording.repository';
+import { MeetingSummaryRepository } from '../repositories/meeting-summary.repository';
+import { MeetingRecordingService } from './meeting-recording.service';
+
+describe('MeetingRecordingService', () => {
+  let service: MeetingRecordingService;
+  let recordings: {
+    findById: jest.Mock;
+  };
+  let summaries: {
+    findByRecordingId: jest.Mock;
+    createExternalForRecording: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    recordings = { findById: jest.fn() };
+    summaries = {
+      findByRecordingId: jest.fn(),
+      createExternalForRecording: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MeetingRecordingService,
+        { provide: MeetingRecordingRepository, useValue: recordings },
+        { provide: MeetingSummaryRepository, useValue: summaries },
+      ],
+    }).compile();
+
+    service = moduleRef.get(MeetingRecordingService);
+  });
+
+  it('returns the latest summary for an existing recording', async () => {
+    recordings.findById.mockResolvedValue({
+      id: 'recording-1',
+      meetingId: 'meeting-1',
+    });
+    summaries.findByRecordingId.mockResolvedValue({ id: 'summary-1' });
+
+    await expect(service.getSummary('recording-1')).resolves.toEqual({
+      id: 'summary-1',
+    });
+    expect(summaries.findByRecordingId).toHaveBeenCalledWith('recording-1');
+  });
+
+  it('throws when an existing recording has no summary', async () => {
+    recordings.findById.mockResolvedValue({
+      id: 'recording-1',
+      meetingId: 'meeting-1',
+    });
+    summaries.findByRecordingId.mockResolvedValue(null);
+
+    await expect(service.getSummary('recording-1')).rejects.toBeInstanceOf(
+      MeetingSummaryNotFoundException,
+    );
+  });
+
+  it('associates an external summary with the recording meeting', async () => {
+    recordings.findById.mockResolvedValue({
+      id: 'recording-1',
+      meetingId: 'meeting-1',
+    });
+    summaries.createExternalForRecording.mockResolvedValue({
+      id: 'summary-1',
+      content: 'External summary',
+    });
+
+    await expect(
+      service.createSummary('recording-1', {
+        content: 'External summary',
+        aiModel: 'external-model',
+      }),
+    ).resolves.toEqual({ id: 'summary-1', content: 'External summary' });
+    expect(summaries.createExternalForRecording).toHaveBeenCalledWith(
+      'meeting-1',
+      'recording-1',
+      { content: 'External summary', aiModel: 'external-model' },
+    );
+  });
+});

--- a/src/meeting/services/meeting-recording.service.ts
+++ b/src/meeting/services/meeting-recording.service.ts
@@ -1,16 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { MeetingRecordingRepository } from '../repositories/meeting-recording.repository';
+import { MeetingSummaryRepository } from '../repositories/meeting-summary.repository';
 import { RecordingNotFoundException } from '../exceptions/meeting.exceptions';
+import { MeetingSummaryNotFoundException } from '../exceptions/meeting.exceptions';
 import {
   QueryMeetingRecordingDto,
   UpdateMeetingRecordingDto,
   CreateMeetingRecordingDto,
+  CreateRecordingSummaryDto,
 } from '../dto/meeting-recording.dto';
 
 @Injectable()
 export class MeetingRecordingService {
   constructor(
     private readonly meetingRecordingRepository: MeetingRecordingRepository,
+    private readonly meetingSummaryRepository: MeetingSummaryRepository,
   ) {}
 
   /**
@@ -48,6 +52,24 @@ export class MeetingRecordingService {
 
   async create(data: CreateMeetingRecordingDto) {
     return this.meetingRecordingRepository.create(data);
+  }
+
+  async getSummary(id: string) {
+    await this.getById(id);
+    const summary = await this.meetingSummaryRepository.findByRecordingId(id);
+    if (!summary) {
+      throw new MeetingSummaryNotFoundException(id);
+    }
+    return summary;
+  }
+
+  async createSummary(id: string, data: CreateRecordingSummaryDto) {
+    const recording = await this.getById(id);
+    return this.meetingSummaryRepository.createExternalForRecording(
+      recording.meetingId,
+      id,
+      data,
+    );
   }
 
   async update(id: string, updateData: UpdateMeetingRecordingDto) {


### PR DESCRIPTION
## What changed

- add `GET /recordings/:id/summary` for reading the latest recording summary
- add `POST /recordings/:id/summary` for persisting externally generated AI summaries without invoking Nove's internal LLM
- derive the meeting association from the recording instead of accepting a client-provided meeting ID
- create recording summary versions transactionally and retain the previous version chain
- expose external model, language, confidence, processing time, structured minutes, action items, decisions, speaker insights, and golden quotes
- update recording routes to use the staged `meeting-recording:*` permission scopes
- add service and repository unit coverage

## Why

External AI systems need a supported API for writing completed recording summaries directly into Nove while preserving recording ownership, soft-delete filtering, and version history.

## Impact

Clients can retrieve the latest summary for a recording and submit a new externally generated version. No Prisma schema migration is required.

## Validation

- `pnpm build`
- ESLint on all changed TypeScript files
- `pnpm exec jest --selectProjects unit --runInBand` — 51 suites, 316 tests passed
- `git diff --cached --check`

## Deployment note

The controller now requires `meeting-recording:read`, `meeting-recording:create`, `meeting-recording:update`, and `meeting-recording:delete`. The repository seed configuration currently contains the older `meeting:*` permissions, so the target environment's permission configuration must be confirmed before this PR is marked ready for review.
