### PR TITLE
refactor(prisma): split meeting recording models

### DIFF
--- a/prisma/models/meet.prisma
+++ b/prisma/models/meet.prisma
@@ -20,7 +20,7 @@ model Meeting {
   createdBy        PlatformUser? @relation("MeetingCreator", fields: [createdById], references: [id], onDelete: SetNull)
   hostId           String?       @map("host_id") // Host's platform user ID
   host             PlatformUser? @relation("HostedMeetings", fields: [hostId], references: [id], onDelete: SetNull)
-  participantCount Int? @map("participant_count") // 参与人数
+  participantCount Int?          @map("participant_count") // 参与人数
 
   // 时间信息
   scheduledStartAt DateTime? @map("scheduled_start_at") @db.Timestamptz(6) // 预定开始时间
@@ -39,11 +39,11 @@ model Meeting {
   metadata Json @default("{}") @db.JsonB // 平台特定的元数据
 
   // 关联关系
-  participants         MeetingParticipant[] // 参会记录
-  recordings           MeetingRecording[] // 关联的录制
-  summaries            MeetingSummary[] // 关联的总结记录
+  participants                  MeetingParticipant[] // 参会记录
+  recordings                    MeetingRecording[] // 关联的录制
+  summaries                     MeetingSummary[] // 关联的总结记录
   recordingParticipantSummaries RecordingParticipantSummary[] @relation("MeetingRecordingParticipantSummaries")
-  userActions          MeetingUserAction[]  @relation("MeetingUserActions") // 用户操作记录
+  userActions                   MeetingUserAction[]           @relation("MeetingUserActions") // 用户操作记录
 
   // 系统字段及时间
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
@@ -64,83 +64,6 @@ model Meeting {
   @@index([createdById, startAt]) // 查询创建者的会议
   @@index([deletedAt, createdAt]) // 软删除查询优化
   @@map("meetings")
-}
-
-model MeetingRecording {
-  id         String  @id @default(cuid())
-  externalId String? @map("external_id") @db.VarChar(100) // 外部系统录制ID，用于唯一标识
-
-  source RecordingSource @default(PLATFORM_AUTO)
-  status RecordingStatus @default(RECORDING)
-
-  // 元数据
-  metadata Json @default("{}") @db.JsonB
-
-  meetingId String  @map("meeting_id")
-  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
-
-  // 关联字段
-  recorderUserId String?       @map("recorder_user_id")
-  recorderUser   PlatformUser? @relation("RecordingUser", fields: [recorderUserId], references: [id], onDelete: SetNull)
-
-  files                MeetingRecordingFile[]
-  transcripts          Transcript[]
-  summaries            MeetingSummary[]
-  participantSummaries RecordingParticipantSummary[] @relation("RecordingParticipantSummaries")
-
-  // 系统字段及时间字段
-  startAt   DateTime? @map("start_at") @db.Timestamptz(6)
-  endAt     DateTime? @map("end_at") @db.Timestamptz(6)
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6) // 软删除时间戳
-
-  @@index([meetingId], map: "idx_recordings_meeting")
-  @@map("meet_recordings")
-}
-
-model MeetingRecordingFile {
-  id String @id @default(cuid())
-
-  fileType   RecordingFileType @default(VIDEO) @map("file_type")
-  durationMs BigInt?           @map("duration_ms")
-  resolution String?
-
-  recordingId  String           @map("recording_id")
-  recording    MeetingRecording @relation(fields: [recordingId], references: [id], onDelete: Cascade)
-  fileObjectId String           @map("file_object_id") @db.Uuid
-  object       StorageObject    @relation(fields: [fileObjectId], references: [id], onDelete: Restrict)
-
-  // 系统字段及时间
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6) // 软删除时间戳
-
-  @@index([recordingId], map: "idx_recording_files_recording")
-  @@map("meet_recording_files")
-}
-
-// 录制来源枚举
-enum RecordingSource {
-  PLATFORM_AUTO // 平台自动录制
-  USER_MANUAL // 用户手动录制
-  THIRD_PARTY // 第三方录制
-}
-
-// 录制状态枚举
-enum RecordingStatus {
-  RECORDING // 录制中
-  PROCESSING // 处理中
-  COMPLETED // 已完成
-  FAILED // 失败
-}
-
-// 录制文件类型枚举
-enum RecordingFileType {
-  VIDEO // 视频
-  AUDIO // 音频
-  TRANSCRIPT // 转录文本
-  CHAT // 聊天记录
 }
 
 // 会议平台枚举

--- a/prisma/models/meet_recording.prisma
+++ b/prisma/models/meet_recording.prisma
@@ -1,0 +1,47 @@
+model MeetingRecording {
+  id         String  @id @default(cuid())
+  externalId String? @map("external_id") @db.VarChar(100) // 外部系统录制ID，用于唯一标识
+
+  source RecordingSource @default(PLATFORM_AUTO)
+  status RecordingStatus @default(RECORDING)
+
+  // 元数据
+  metadata Json @default("{}") @db.JsonB
+
+  meetingId String  @map("meeting_id")
+  meeting   Meeting @relation(fields: [meetingId], references: [id], onDelete: Cascade)
+
+  // 关联字段
+  recorderUserId String?       @map("recorder_user_id")
+  recorderUser   PlatformUser? @relation("RecordingUser", fields: [recorderUserId], references: [id], onDelete: SetNull)
+
+  files                MeetingRecordingFile[]
+  transcripts          Transcript[]
+  summaries            MeetingSummary[]
+  participantSummaries RecordingParticipantSummary[] @relation("RecordingParticipantSummaries")
+
+  // 系统字段及时间字段
+  startAt   DateTime? @map("start_at") @db.Timestamptz(6)
+  endAt     DateTime? @map("end_at") @db.Timestamptz(6)
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6) // 软删除时间戳
+
+  @@index([meetingId], map: "idx_recordings_meeting")
+  @@map("meet_recordings")
+}
+
+// 录制来源枚举
+enum RecordingSource {
+  PLATFORM_AUTO // 平台自动录制
+  USER_MANUAL // 用户手动录制
+  THIRD_PARTY // 第三方录制
+}
+
+// 录制状态枚举
+enum RecordingStatus {
+  RECORDING // 录制中
+  PROCESSING // 处理中
+  COMPLETED // 已完成
+  FAILED // 失败
+}

--- a/prisma/models/meet_recording_file.prisma
+++ b/prisma/models/meet_recording_file.prisma
@@ -1,0 +1,28 @@
+model MeetingRecordingFile {
+  id String @id @default(cuid())
+
+  fileType   RecordingFileType @default(VIDEO) @map("file_type")
+  durationMs BigInt?           @map("duration_ms")
+  resolution String?
+
+  recordingId  String           @map("recording_id")
+  recording    MeetingRecording @relation(fields: [recordingId], references: [id], onDelete: Cascade)
+  fileObjectId String           @map("file_object_id") @db.Uuid
+  object       StorageObject    @relation(fields: [fileObjectId], references: [id], onDelete: Restrict)
+
+  // 系统字段及时间
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6) // 软删除时间戳
+
+  @@index([recordingId], map: "idx_recording_files_recording")
+  @@map("meet_recording_files")
+}
+
+// 录制文件类型枚举
+enum RecordingFileType {
+  VIDEO // 视频
+  AUDIO // 音频
+  TRANSCRIPT // 转录文本
+  CHAT // 聊天记录
+}


### PR DESCRIPTION
## Summary

- move MeetingRecording and its enums into a dedicated Prisma schema file
- move MeetingRecordingFile and RecordingFileType into a dedicated Prisma schema file
- keep database models, relations, indexes, and table mappings unchanged

## Risk

Low. This is a schema organization refactor with no migration or database contract changes.

## Validation

- pnpm exec prisma validate
- pnpm db:generate
- pnpm build
- git diff --check