### PR TITLE
feat(prisma): support Prisma 6 and 7 via prisma-client generator + driver adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,9 @@ POSTGRES_PORT="5432"
 
 # 本地开发环境 DATABASE_URL (不使用 Docker 服务名)
 # 当需要直接连接到本地 PostgreSQL 实例时使用
-DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}"
+# 注意：.env 中的 ${VAR} 不会被 Prisma 展开，请直接写明文连接串；
+# 用户名/密码/端口/库名必须与上方 POSTGRES_* 保持一致。
+DATABASE_URL="postgresql://postgres:your_postgres_password@localhost:5432/lulab?schema=public"
 
 # =============================================================================
 # 腾讯会议 API 配置

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 /generated/prisma
+/src/generated/prisma
 
 # Backup files
 /scripts/backups

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## 技术栈
 
 - **框架**：NestJS 11 + TypeScript 5.7
-- **数据库**：Prisma ORM 6 + PostgreSQL
+- **数据库**：Prisma ORM 6/7（`prisma-client` generator + `@prisma/adapter-pg` driver adapter）+ PostgreSQL
 - **缓存/队列**：Redis + BullMQ + IORedis
 - **认证**：Passport + JWT + bcryptjs
 - **API 协议**：RESTful + GraphQL (Apollo Server)
@@ -118,6 +118,33 @@ test/
 
 ## 快速开始
 
+### 0) 环境依赖（关键）
+
+运行本项目前，请确保以下服务已就绪，否则会报连接错误：
+
+| 依赖 | 用途 | 是否必需 | 默认地址 |
+|------|------|---------|---------|
+| Node.js 18+ | 运行时 | 必需 | — |
+| pnpm | 包管理 | 必需 | — |
+| PostgreSQL 14+ | 主数据库（Prisma ORM） | 必需 | `localhost:5432` |
+| Redis 6+ | 缓存 / BullMQ 队列 / Token 黑名单 | 必需 | `localhost:6379` |
+| Docker（可选） | 一键启动 PostgreSQL + Redis | 推荐 | — |
+
+> ⚠️ 若执行 `pnpm db:push` / `pnpm db:migrate` 报
+> `P1001: Can't reach database server at localhost:5432`，
+> 说明本机 **PostgreSQL 未启动**。请按下面任一方式先启动数据库：
+
+**方式 A：Docker（推荐，同时启动 PostgreSQL 与 Redis）**
+
+```bash
+docker compose up -d postgres redis
+```
+
+**方式 B：本机原生安装 PostgreSQL**
+
+- 下载并安装 [PostgreSQL](https://www.postgresql.org/download/windows/)，确认服务已启动；
+- 创建数据库 `lulab`，并将 `.env` 的 `DATABASE_URL` 改为实际连接串。
+
 1) 安装依赖
 
 ```bash
@@ -128,10 +155,17 @@ pnpm install
 
 复制 `.env.example` 为 `.env`，并按环境补充：
 
+> 注意：`.env` 中的 `DATABASE_URL` 请直接写明文连接串
+> （如 `postgresql://user:pass@localhost:5432/lulab?schema=public`），
+> 不要使用 `${VAR}` 插值——Prisma 不会展开它。
+
 3) 初始化数据库
 
+> `pnpm install` 会通过 `postinstall` 自动执行 `prisma generate`，
+> 将 Prisma Client 生成到 `src/generated/prisma`（该目录已 gitignore）。
+> 手动重新生成可运行 `pnpm db:generate`。
+
 ```bash
-pnpm db:generate
 pnpm db:push      # 或 pnpm db:migrate
 pnpm db:seed      # 可选
 ```

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs'],
+    ignores: ['eslint.config.mjs', 'src/generated/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,

--- a/package.json
+++ b/package.json
@@ -5,11 +5,9 @@
   "author": "",
   "private": true,
   "license": "MIT",
-  "prisma": {
-    "schema": "./prisma"
-  },
   "scripts": {
     "build": "nest build",
+    "postinstall": "prisma generate",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"prisma/**/*.ts\" ",
     "start": "nest start",
     "start:dev": "nest start --watch",
@@ -69,7 +67,8 @@
     "@nestjs/platform-express": "^11.1.3",
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.0",
-    "@prisma/client": "^6.10.1",
+    "@prisma/adapter-pg": "6.17.1",
+    "@prisma/client": "6.17.1",
     "@rekog/mcp-nest": "^1.9.7",
     "@types/nodemailer": "^6.4.17",
     "@types/passport-jwt": "^4.0.1",
@@ -87,6 +86,7 @@
     "nodemailer": "^7.0.3",
     "openai": "^5.23.2",
     "passport": "^0.7.0",
+    "pg": "^8.13.1",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@alicloud/credentials': 2.4.4
+
 importers:
 
   .:
     dependencies:
       '@alicloud/credentials':
-        specifier: ^2.4.4
+        specifier: 2.4.4
         version: 2.4.4
       '@alicloud/dysmsapi20170525':
         specifier: 4.1.2
@@ -71,8 +74,11 @@ importers:
       '@nestjs/swagger':
         specifier: ^11.2.0
         version: 11.2.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
+      '@prisma/adapter-pg':
+        specifier: 6.17.1
+        version: 6.17.1
       '@prisma/client':
-        specifier: ^6.10.1
+        specifier: 6.17.1
         version: 6.17.1(prisma@6.17.1(typescript@5.9.3))(typescript@5.9.3)
       '@rekog/mcp-nest':
         specifier: ^1.9.7
@@ -131,6 +137,9 @@ importers:
       passport-local:
         specifier: ^1.0.0
         version: 1.0.0
+      pg:
+        specifier: ^8.13.1
+        version: 8.23.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -369,7 +378,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -1814,42 +1823,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -2103,6 +2119,9 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@prisma/adapter-pg@6.17.1':
+    resolution: {integrity: sha512-iy5aL2HHzW2sAGspgeUGXgM+JDiXm31R4iONSnAWdpFSc/SWgsR+z8muS0HAZnzclAUwqXrWFJh4RbneCM2ktA==}
+
   '@prisma/client@6.17.1':
     resolution: {integrity: sha512-zL58jbLzYamjnNnmNA51IOZdbk5ci03KviXCuB0Tydc9btH2kDWsi1pQm2VecviRTM7jGia0OPPkgpGnT3nKvw==}
     engines: {node: '>=18.18'}
@@ -2120,6 +2139,9 @@ packages:
 
   '@prisma/debug@6.17.1':
     resolution: {integrity: sha512-Vf7Tt5Wh9XcndpbmeotuqOMLWPTjEKCsgojxXP2oxE1/xYe7PtnP76hsouG9vis6fctX+TxgmwxTuYi/+xc7dQ==}
+
+  '@prisma/driver-adapter-utils@6.17.1':
+    resolution: {integrity: sha512-GT4QbVUyJa5sXj5vjrBPnZ68v1P/FoKBCSIkrFrCPrOi6OSzk+567XDZyBtWIECKxruuMTa7fU4wwNmtMQylrg==}
 
   '@prisma/engines-version@6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac':
     resolution: {integrity: sha512-17140E3huOuD9lMdJ9+SF/juOf3WR3sTJMVyyenzqUPbuH+89nPhSWcrY+Mf7tmSs6HvaO+7S+HkELinn6bhdg==}
@@ -2414,24 +2436,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.5':
     resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.5':
     resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.5':
     resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.5':
     resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
@@ -3414,6 +3440,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cron@4.3.0:
     resolution: {integrity: sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==}
@@ -4093,11 +4120,12 @@ packages:
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4836,10 +4864,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
-    engines: {node: '>= 0.6'}
-
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
@@ -5226,6 +5250,40 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.16.0:
+    resolution: {integrity: sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.23.0:
+    resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5269,6 +5327,26 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5520,10 +5598,6 @@ packages:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
 
-  send@1.2.0:
-    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
-    engines: {node: '>= 18'}
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -5628,6 +5702,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
@@ -6057,10 +6135,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6147,6 +6227,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -8794,6 +8875,14 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@prisma/adapter-pg@6.17.1':
+    dependencies:
+      '@prisma/driver-adapter-utils': 6.17.1
+      pg: 8.23.0
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
+
   '@prisma/client@6.17.1(prisma@6.17.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.17.1(typescript@5.9.3)
@@ -8809,6 +8898,10 @@ snapshots:
       - magicast
 
   '@prisma/debug@6.17.1': {}
+
+  '@prisma/driver-adapter-utils@6.17.1':
+    dependencies:
+      '@prisma/debug': 6.17.1
 
   '@prisma/engines-version@6.17.1-1.272a37d34178c2894197e17273bf937f25acdeac': {}
 
@@ -9773,7 +9866,7 @@ snapshots:
 
   accepts@2.0.0:
     dependencies:
-      mime-types: 3.0.1
+      mime-types: 3.0.2
       negotiator: 1.0.0
 
   acorn-import-phases@1.0.4(acorn@8.15.0):
@@ -10878,9 +10971,9 @@ snapshots:
       etag: 1.8.1
       finalhandler: 2.1.0
       fresh: 2.0.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 2.0.0
-      mime-types: 3.0.1
+      mime-types: 3.0.2
       on-finished: 2.4.1
       once: 1.4.0
       parseurl: 1.3.3
@@ -10888,7 +10981,7 @@ snapshots:
       qs: 6.14.0
       range-parser: 1.2.1
       router: 2.2.0
-      send: 1.2.0
+      send: 1.2.1
       serve-static: 2.2.0
       statuses: 2.0.2
       type-is: 2.0.1
@@ -12032,10 +12125,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.1:
-    dependencies:
-      mime-db: 1.54.0
-
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
@@ -12408,6 +12497,41 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
+  pg-protocol@1.16.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.23.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-protocol: 1.16.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -12442,6 +12566,18 @@ snapshots:
       trouter: 2.0.1
 
   possible-typed-array-names@1.1.0: {}
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -12703,22 +12839,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.0
-      mime-types: 3.0.1
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -12861,6 +12981,8 @@ snapshots:
   source-map@0.7.4: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   split@1.0.1:
     dependencies:
@@ -13200,7 +13322,7 @@ snapshots:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
-      mime-types: 3.0.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+allowBuilds:
+  '@alicloud/openapi-core': true
+  '@apollo/protobufjs': true
+  '@compodoc/compodoc': true
+  '@nestjs/core': true
+  '@prisma/client': true
+  '@prisma/engines': true
+  '@scarf/scarf': true
+  '@swc/core': true
+  esbuild: true
+  msgpackr-extract: true
+  prisma: true
+  protobufjs: true
+overrides:
+  '@alicloud/credentials': 2.4.4

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import { defineConfig } from 'prisma/config';
+
+// Prisma 7 起必须使用 prisma.config.ts（package.json#prisma 已废弃并将被移除）。
+// Prisma CLI 不再自动加载 .env，因此这里显式引入 dotenv 来加载环境变量。
+export default defineConfig({
+  // 指向 prisma 目录：schema.prisma 与 prisma/models/*.prisma 会被递归合并。
+  schema: 'prisma',
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,9 +5,8 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
-  // output   = "../generated/prisma"
+  provider = "prisma-client"
+  output   = "../src/generated/prisma"
 }
 
 datasource db {

--- a/prisma/seed-utils/command-handler.ts
+++ b/prisma/seed-utils/command-handler.ts
@@ -12,7 +12,7 @@ import type { ParsedCommandLineArgs, DatabaseCommand, SeedMode } from './types';
 import { cleanDatabase, dropAllTables } from './database-clean';
 import { seedDatabase } from './database-seed';
 import { analyzeDatabaseStructure } from './table-dependencies';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 
 async function resetDatabase(
   prisma: PrismaClient,

--- a/prisma/seed-utils/database-clean.ts
+++ b/prisma/seed-utils/database-clean.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import * as readline from 'readline';
 import type { DatabaseOperationOptions } from './types';
 import {

--- a/prisma/seed-utils/database-seed.ts
+++ b/prisma/seed-utils/database-seed.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import type { SeedMode } from './types';
 import * as seedFunctions from '../seeds/index';
 

--- a/prisma/seed-utils/table-dependencies.ts
+++ b/prisma/seed-utils/table-dependencies.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import type { TableDependencies } from './types';
 
 export async function getAllTables(prisma: PrismaClient): Promise<string[]> {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -18,10 +18,14 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient } from '@prisma/client';
+import 'dotenv/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@/generated/prisma/client';
 import { parseCommandLineArgs, executeDatabaseOperation } from './seed-utils';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
 
 async function main(): Promise<void> {
   const { command, force, mode } = parseCommandLineArgs();

--- a/prisma/seeds/channels/channels.ts
+++ b/prisma/seeds/channels/channels.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import { CHANNEL_CONFIGS } from './config';
 import type { CreatedChannels } from './type';
 

--- a/prisma/seeds/channels/config.ts
+++ b/prisma/seeds/channels/config.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export const CHANNEL_CONFIGS = [
   {

--- a/prisma/seeds/channels/type.ts
+++ b/prisma/seeds/channels/type.ts
@@ -1,4 +1,4 @@
-import { Channel } from '@prisma/client';
+import { Channel } from '@/generated/prisma/client';
 
 export interface CreatedChannels {
   channels: Channel[];

--- a/prisma/seeds/core/organization/organization.ts
+++ b/prisma/seeds/core/organization/organization.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, Org } from '@prisma/client';
+import { PrismaClient, Org } from '@/generated/prisma/client';
 import { ORGANIZATION_CONFIG, REAL_ORGANIZATION_CONFIG } from './config';
 
 export async function createOrganization(

--- a/prisma/seeds/core/roles/config.ts
+++ b/prisma/seeds/core/roles/config.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 import type { RoleConfig } from './type';
 
 export const REAL_ROLE_CONFIGS: RoleConfig[] = [

--- a/prisma/seeds/core/roles/roles.ts
+++ b/prisma/seeds/core/roles/roles.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, Role } from '@prisma/client';
+import { PrismaClient, Role } from '@/generated/prisma/client';
 import { ROLE_CONFIGS, REAL_ROLE_CONFIGS } from './config';
 import { RoleConfig } from './type';
 

--- a/prisma/seeds/core/roles/type.ts
+++ b/prisma/seeds/core/roles/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 
 export interface RoleConfig {
   orgId?: string;

--- a/prisma/seeds/curriculums/curriculums.ts
+++ b/prisma/seeds/curriculums/curriculums.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Curriculum, Project, Prisma } from '@prisma/client';
+import { PrismaClient, Curriculum, Project, Prisma } from '@/generated/prisma/client';
 import { CURRICULUM_CONFIGS } from './config';
 import type { CreateCurriculumsParams, CreatedCurriculums } from './type';
 

--- a/prisma/seeds/curriculums/type.ts
+++ b/prisma/seeds/curriculums/type.ts
@@ -1,4 +1,4 @@
-import { Curriculum, Project } from '@prisma/client';
+import { Curriculum, Project } from '@/generated/prisma/client';
 
 export interface CurriculumConfig {
   id: string;

--- a/prisma/seeds/departments/departments.ts
+++ b/prisma/seeds/departments/departments.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import { DEPARTMENT_CONFIGS } from './config';
 import type { CreatedDepartments } from './type';
 

--- a/prisma/seeds/departments/type.ts
+++ b/prisma/seeds/departments/type.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { Dept } from '@prisma/client';
+import { Dept } from '@/generated/prisma/client';
 
 export interface DepartmentConfig {
   code: string;

--- a/prisma/seeds/meetings/meetings/config.ts
+++ b/prisma/seeds/meetings/meetings/config.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType, ProcessingStatus } from '@/generated/prisma/client';
 import type { MeetingConfig } from './type';
 
 const createTime = (hoursAgo: number): Date => {

--- a/prisma/seeds/meetings/meetings/meetings.ts
+++ b/prisma/seeds/meetings/meetings/meetings.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import { MEETING_CONFIGS } from './config';
 
 export async function createMeetings(prisma: PrismaClient) {

--- a/prisma/seeds/meetings/meetings/type.ts
+++ b/prisma/seeds/meetings/meetings/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export type MeetingConfig = Omit<
   Prisma.MeetingCreateInput,

--- a/prisma/seeds/meetings/participant-summaries/participant-summaries.ts
+++ b/prisma/seeds/meetings/participant-summaries/participant-summaries.ts
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, PeriodType, GenerationMethod } from '@prisma/client';
+import { PrismaClient, PeriodType, GenerationMethod } from '@/generated/prisma/client';
 import { PARTICIPANT_SUMMARY_CONFIGS } from './config';
 import type { ParticipantSummary } from './type';
 

--- a/prisma/seeds/meetings/participant-summaries/type.ts
+++ b/prisma/seeds/meetings/participant-summaries/type.ts
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export type ParticipantSummaryConfig = {
   userName: string;

--- a/prisma/seeds/meetings/recordings/config.ts
+++ b/prisma/seeds/meetings/recordings/config.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { StorageProvider, RecordingFileType } from '@prisma/client';
+import { StorageProvider, RecordingFileType } from '@/generated/prisma/client';
 
 export const RECORDING_FILE_CONFIGS = {
   recording: {

--- a/prisma/seeds/meetings/recordings/recordings.ts
+++ b/prisma/seeds/meetings/recordings/recordings.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, RecordingStatus, Prisma } from '@prisma/client';
+import { PrismaClient, RecordingStatus, Prisma } from '@/generated/prisma/client';
 import { RECORDING_FILE_CONFIGS } from './config';
 import type { CreatedMeetingRecordings } from './type';
 

--- a/prisma/seeds/meetings/recordings/type.ts
+++ b/prisma/seeds/meetings/recordings/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export interface CreatedMeetingRecordings {
   meetingRecording: Prisma.MeetingRecordingGetPayload<Record<string, never>>;

--- a/prisma/seeds/meetings/summaries/config.ts
+++ b/prisma/seeds/meetings/summaries/config.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { ProcessingStatus, GenerationMethod } from '@prisma/client';
+import { ProcessingStatus, GenerationMethod } from '@/generated/prisma/client';
 import type { MeetingSummaryConfig } from './type';
 
 export const MEETING_SUMMARY_CONFIGS: {

--- a/prisma/seeds/meetings/summaries/summaries.ts
+++ b/prisma/seeds/meetings/summaries/summaries.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, ProcessingStatus, Prisma } from '@prisma/client';
+import { PrismaClient, ProcessingStatus, Prisma } from '@/generated/prisma/client';
 import { MEETING_SUMMARY_CONFIGS } from './config';
 import type { CreatedMeetingSummaries } from './type';
 

--- a/prisma/seeds/meetings/summaries/type.ts
+++ b/prisma/seeds/meetings/summaries/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export type MeetingSummaryConfig = Omit<
   Prisma.MeetingSummaryUncheckedCreateInput,

--- a/prisma/seeds/orders/orders.ts
+++ b/prisma/seeds/orders/orders.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Currency, OrderStatus } from '@prisma/client';
+import { PrismaClient, Currency, OrderStatus } from '@/generated/prisma/client';
 
 export async function createOrders(prisma: PrismaClient) {
   const orders = [

--- a/prisma/seeds/orders/type.ts
+++ b/prisma/seeds/orders/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { Product, User, Channel } from '@prisma/client';
+import { Product, User, Channel } from '@/generated/prisma/client';
 
 export interface CreateOrdersParams {
   users: {

--- a/prisma/seeds/permissions/config.ts
+++ b/prisma/seeds/permissions/config.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 import type { PermissionConfig } from './type';
 
 export const REAL_PERMISSION_CONFIGS: readonly PermissionConfig[] = [

--- a/prisma/seeds/permissions/permissions.ts
+++ b/prisma/seeds/permissions/permissions.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, Permission } from '@prisma/client';
+import { PrismaClient, Permission } from '@/generated/prisma/client';
 import { PERMISSION_CONFIGS, REAL_PERMISSION_CONFIGS } from './config';
 
 export async function createPermissions(

--- a/prisma/seeds/permissions/type.ts
+++ b/prisma/seeds/permissions/type.ts
@@ -1,4 +1,4 @@
-import { Permission } from '@prisma/client';
+import { Permission } from '@/generated/prisma/client';
 
 export interface PermissionConfig {
   name: string;

--- a/prisma/seeds/platform-users/config.ts
+++ b/prisma/seeds/platform-users/config.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@prisma/client';
+import { Platform } from '@/generated/prisma/client';
 import type { PlatformUserConfig } from './type';
 
 export const PLATFORM_USER_CONFIGS: Record<string, PlatformUserConfig> = {

--- a/prisma/seeds/platform-users/platform-users.ts
+++ b/prisma/seeds/platform-users/platform-users.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import { PLATFORM_USER_CONFIGS } from './config';
 
 export async function createPlatformUsers(prisma: PrismaClient) {

--- a/prisma/seeds/platform-users/type.ts
+++ b/prisma/seeds/platform-users/type.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { Platform, Prisma } from '@prisma/client';
+import { Platform, Prisma } from '@/generated/prisma/client';
 
 export type PlatformUserConfig = Omit<
   Prisma.PlatformUserUncheckedCreateInput,

--- a/prisma/seeds/products/config.ts
+++ b/prisma/seeds/products/config.ts
@@ -1,4 +1,4 @@
-import { ProductCategory } from '@prisma/client';
+import { ProductCategory } from '@/generated/prisma/client';
 import { ProductConfig } from './type';
 
 export const PRODUCT_CONFIGS: ProductConfig[] = [

--- a/prisma/seeds/products/products.ts
+++ b/prisma/seeds/products/products.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, Product, ProductStatus, Currency } from '@prisma/client';
+import { PrismaClient, Product, ProductStatus, Currency } from '@/generated/prisma/client';
 import { ProductConfig } from './type';
 import { PRODUCT_CONFIGS } from './config';
 

--- a/prisma/seeds/products/type.ts
+++ b/prisma/seeds/products/type.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { ProductCategory } from '@prisma/client';
+import { ProductCategory } from '@/generated/prisma/client';
 
 export interface ProductConfig {
   productCode: string;

--- a/prisma/seeds/projects/projects.ts
+++ b/prisma/seeds/projects/projects.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma } from '@/generated/prisma/client';
 import { PROJECT_CONFIGS } from './config';
 import type { CreatedProjects } from './type';
 

--- a/prisma/seeds/projects/type.ts
+++ b/prisma/seeds/projects/type.ts
@@ -1,4 +1,4 @@
-import { Project } from '@prisma/client';
+import { Project } from '@/generated/prisma/client';
 
 export interface ProjectConfig {
   id: string;

--- a/prisma/seeds/refunds/config.ts
+++ b/prisma/seeds/refunds/config.ts
@@ -1,4 +1,4 @@
-import { RefundChannel, RefundStatus } from '@prisma/client';
+import { RefundChannel, RefundStatus } from '@/generated/prisma/client';
 import { RefundConfig } from './type';
 
 export const REFUND_CONFIGS: RefundConfig[] = [

--- a/prisma/seeds/refunds/refunds.ts
+++ b/prisma/seeds/refunds/refunds.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, OrderRefund } from '@prisma/client';
+import { PrismaClient, OrderRefund } from '@/generated/prisma/client';
 import { RefundConfig, RefundCreateInput } from './type';
 import { REFUND_CONFIGS } from './config';
 

--- a/prisma/seeds/refunds/type.ts
+++ b/prisma/seeds/refunds/type.ts
@@ -1,5 +1,5 @@
-import { Order, RefundChannel, RefundStatus, User } from '@prisma/client';
-import { Prisma } from '@prisma/client';
+import { Order, RefundChannel, RefundStatus, User } from '@/generated/prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 export interface CreateRefundsParams {
   users: {

--- a/prisma/seeds/relations/permission-relations/role-permissions.ts
+++ b/prisma/seeds/relations/permission-relations/role-permissions.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Permission, Role } from '@prisma/client';
+import { PrismaClient, Permission, Role } from '@/generated/prisma/client';
 
 // 管理员角色排除的权限列表
 const ADMIN_EXCLUDED_PERMISSIONS = ['system:config'];

--- a/prisma/seeds/relations/permission-relations/user-permission.ts
+++ b/prisma/seeds/relations/permission-relations/user-permission.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, User } from '@prisma/client';
+import { PrismaClient, User } from '@/generated/prisma/client';
 
 async function getOrgMemberId(
   prisma: PrismaClient,

--- a/prisma/seeds/relations/user-relations/user-department.ts
+++ b/prisma/seeds/relations/user-relations/user-department.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, User, Dept } from '@prisma/client';
+import { PrismaClient, User, Dept } from '@/generated/prisma/client';
 
 async function getOrgMemberId(
   prisma: PrismaClient,

--- a/prisma/seeds/relations/user-relations/user-organization.ts
+++ b/prisma/seeds/relations/user-relations/user-organization.ts
@@ -9,8 +9,8 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient } from '@prisma/client';
-import { User } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
+import { User } from '@/generated/prisma/client';
 
 export async function createUserOrganizationRelations(
   prisma: PrismaClient,

--- a/prisma/seeds/relations/user-relations/user-roles.ts
+++ b/prisma/seeds/relations/user-relations/user-roles.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, User, Role } from '@prisma/client';
+import { PrismaClient, User, Role } from '@/generated/prisma/client';
 
 export async function assignRolesToUsers(
   prisma: PrismaClient,

--- a/prisma/seeds/transcripts/transcripts.ts
+++ b/prisma/seeds/transcripts/transcripts.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import { TRANSCRIPT_DIALOGUE } from './config';
 
 export async function createSimulatedTranscript(

--- a/prisma/seeds/users/config.ts
+++ b/prisma/seeds/users/config.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { $Enums } from '@prisma/client';
+import { $Enums } from '@/generated/prisma/client';
 
 export const PASSWORDS = {
   ADMIN: 'admin123',

--- a/prisma/seeds/users/type.ts
+++ b/prisma/seeds/users/type.ts
@@ -1,4 +1,4 @@
-import { Gender } from '@prisma/client';
+import { Gender } from '@/generated/prisma/client';
 
 export interface UserProfileCreateInput {
   displayName?: string;

--- a/prisma/seeds/users/users.ts
+++ b/prisma/seeds/users/users.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { PrismaClient, User } from '@prisma/client';
+import { PrismaClient, User } from '@/generated/prisma/client';
 import bcrypt from 'bcryptjs';
 import { COUNTRY_CODE, USERS_MOCK, USERS_REAL } from './config';
 import { UserConfig, UserProfileCreateInput } from './type';

--- a/scripts/assign-permissions.ts
+++ b/scripts/assign-permissions.ts
@@ -8,10 +8,14 @@
  * 
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved. 
  */
-import { PrismaClient } from '@prisma/client';
+import 'dotenv/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@/generated/prisma/client';
 import { assignPermissionsToRole } from '../prisma/seeds/relations/permission-relations/role-permissions';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
 
 interface CommandLineArgs {
   roleId: string;

--- a/scripts/mjs/import-csv-prisma.ts
+++ b/scripts/mjs/import-csv-prisma.ts
@@ -1,15 +1,20 @@
+// @ts-nocheck
 import fs from "fs";
 import { parse } from "csv-parse";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaClient, Prisma } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
 import cuid from 'cuid';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
 
 /**
  * 用法:
- *   node scripts/import-csv-prisma.mjs --model=User --file=./data.csv --batch=1000 --skipDuplicates=true
- *   node scripts/import-csv-prisma.mjs --model=User --file=scripts/csv_data/user.csv --batch=1000 --skipDuplicates=true
- *   node scripts/import-csv-prisma.mjs --model=PlatformUser --file=scripts/csv_data/data.csv --batch=1000 --skipDuplicates=true
+ *   tsx scripts/mjs/import-csv-prisma.ts --model=User --file=./data.csv --batch=1000 --skipDuplicates=true
+ *   tsx scripts/mjs/import-csv-prisma.ts --model=User --file=scripts/csv_data/user.csv --batch=1000 --skipDuplicates=true
+ *   tsx scripts/mjs/import-csv-prisma.ts --model=PlatformUser --file=scripts/csv_data/data.csv --batch=1000 --skipDuplicates=true
  *
  * 说明:
  *   - --model 必填: Prisma 的 Model 名（区分大小写，如 User / Post）

--- a/scripts/mjs/relate-tables.ts
+++ b/scripts/mjs/relate-tables.ts
@@ -1,10 +1,15 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+// @ts-nocheck
+import { PrismaClient, Prisma } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
 
 /**
  * 用法:
- *   node scripts/relate-tables.mjs --sourceModel=PlatformUser --targetModel=User --sourceField=email --targetField=email --foreignKey=localUserId --batch=1000 --dryRun=true
+ *   tsx scripts/mjs/relate-tables.ts --sourceModel=PlatformUser --targetModel=User --sourceField=email --targetField=email --foreignKey=localUserId --batch=1000 --dryRun=true
  *
  * 说明:
  *   - --sourceModel 必填: 源模型名称（需要更新外键的模型）

--- a/scripts/ts/assign-roles.ts
+++ b/scripts/ts/assign-roles.ts
@@ -15,10 +15,14 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved. 
  */
 
-import { PrismaClient } from '@prisma/client';
+import 'dotenv/config';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@/generated/prisma/client';
 import { assignRolesToUsers } from '../../prisma/seeds/relations/user-relations/user-roles';
 
-const prisma = new PrismaClient();
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
 
 interface CommandLineArgs {
   userIds: string[];

--- a/src/api-key/controllers/api-key.controller.spec.ts
+++ b/src/api-key/controllers/api-key.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ApiKeyController } from './api-key.controller';
 import { ApiKeyService } from '../services/api-key.service';
 import { UserOrgService } from '../services/user-organization.service';
-import { ApiKeyStatus } from '@prisma/client';
+import { ApiKeyStatus } from '@/generated/prisma/client';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('ApiKeyController', () => {

--- a/src/api-key/dto/api-key.dto.ts
+++ b/src/api-key/dto/api-key.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { ApiKeyStatus } from '@prisma/client';
+import { ApiKeyStatus } from '@/generated/prisma/client';
 
 /**
  * API Key 响应 DTO

--- a/src/api-key/dto/pagination.dto.ts
+++ b/src/api-key/dto/pagination.dto.ts
@@ -11,7 +11,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Min, IsEnum } from 'class-validator';
-import { ApiKeyStatus } from '@prisma/client';
+import { ApiKeyStatus } from '@/generated/prisma/client';
 
 /**
  * 分页查询 DTO

--- a/src/api-key/repositories/api-key.repository.ts
+++ b/src/api-key/repositories/api-key.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ApiKey, ApiKeyStatus, Prisma } from '@prisma/client';
+import { ApiKey, ApiKeyStatus, Prisma } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 /**

--- a/src/api-key/repositories/usage-log.repository.ts
+++ b/src/api-key/repositories/usage-log.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ApiKeyUsageLog, Prisma } from '@prisma/client';
+import { ApiKeyUsageLog, Prisma } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 /**

--- a/src/api-key/services/api-key.service.spec.ts
+++ b/src/api-key/services/api-key.service.spec.ts
@@ -7,7 +7,7 @@ import {
 import { ApiKeyService } from './api-key.service';
 import { ApiKeyRepository } from '../repositories/api-key.repository';
 import { apiKeyConfig } from '@/configs/api-key.config';
-import { ApiKeyStatus } from '@prisma/client';
+import { ApiKeyStatus } from '@/generated/prisma/client';
 import { CreateApiKeyDto, UpdateApiKeyDto } from '../dto';
 import { computeKeyHash } from '../utils/crypto.util';
 import { PermService } from '@/permission/services/permission.service';

--- a/src/api-key/services/api-key.service.ts
+++ b/src/api-key/services/api-key.service.ts
@@ -7,7 +7,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
-import { ApiKeyStatus } from '@prisma/client';
+import { ApiKeyStatus } from '@/generated/prisma/client';
 import { ApiKeyRepository } from '../repositories/api-key.repository';
 import { apiKeyConfig } from '@/configs/api-key.config';
 import {

--- a/src/auth/utils/auth-user-mapper.ts
+++ b/src/auth/utils/auth-user-mapper.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { User, UserProfile } from '@prisma/client';
+import { User, UserProfile } from '@/generated/prisma/client';
 import { AuthUserMinimalDto } from '@/auth/dto/auth-user-minimal.dto';
 
 export function formatAuthUserResponse(

--- a/src/common/utils/user-mapper.ts
+++ b/src/common/utils/user-mapper.ts
@@ -9,7 +9,7 @@
  * Copyright (c) 2025 by ${git_name_email}, All Rights Reserved.
  */
 
-import { User, UserProfile } from '@prisma/client';
+import { User, UserProfile } from '@/generated/prisma/client';
 import { UserProfileResponseDto } from '@/user/dto/user-profile-response.dto';
 
 export function formatUserResponse(

--- a/src/dept/repositories/department.repository.ts
+++ b/src/dept/repositories/department.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Dept, Prisma } from '@prisma/client';
+import { Dept, Prisma } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 @Injectable()

--- a/src/dept/services/department.service.ts
+++ b/src/dept/services/department.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 import { DepartmentRepository } from '../repositories/department.repository';
 import {
   CreateDepartmentDto,

--- a/src/mcp-server/repositories/meeting-stats.repository.ts
+++ b/src/mcp-server/repositories/meeting-stats.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import type { Meeting } from '@prisma/client';
+import type { Meeting } from '@/generated/prisma/client';
 import type { MeetingDetailsResult } from '../types/meeting-stats.types';
 
 @Injectable()

--- a/src/mcp-server/repositories/participant-summary.repository.ts
+++ b/src/mcp-server/repositories/participant-summary.repository.ts
@@ -11,8 +11,8 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { PeriodType } from '@prisma/client';
-import type { Meeting, ParticipantSummary } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
+import type { Meeting, ParticipantSummary } from '@/generated/prisma/client';
 
 @Injectable()
 export class ParticipantSummaryRepository {

--- a/src/mcp-server/repositories/platform-user.repository.ts
+++ b/src/mcp-server/repositories/platform-user.repository.ts
@@ -11,7 +11,7 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import type { PlatformUser } from '@prisma/client';
+import type { PlatformUser } from '@/generated/prisma/client';
 
 @Injectable()
 export class PlatformUserRepository {

--- a/src/mcp-server/tools/meeting-stats.tool.ts
+++ b/src/mcp-server/tools/meeting-stats.tool.ts
@@ -6,7 +6,7 @@ import {
   ParticipantSummaryRepository,
   PlatformUserRepository,
 } from '../repositories';
-import { PeriodType } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
 
 @Injectable()
 export class MeetingStatsTool {

--- a/src/mcp-server/types/meeting-stats.types.ts
+++ b/src/mcp-server/types/meeting-stats.types.ts
@@ -2,7 +2,7 @@ import type {
   Meeting,
   MeetingParticipant,
   MeetingRecording,
-} from '@prisma/client';
+} from '@/generated/prisma/client';
 
 export type MeetingDetailsResult = Meeting & {
   createdBy: {

--- a/src/meeting/decorators/meeting-record.decorators.ts
+++ b/src/meeting/decorators/meeting-record.decorators.ts
@@ -6,7 +6,11 @@ import {
   ApiParam,
   ApiBody,
 } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 import {
   MeetingRecordListResponseDto,
   MeetingStatsResponseDto,

--- a/src/meeting/dto/meeting-record-create.dto.ts
+++ b/src/meeting/dto/meeting-record-create.dto.ts
@@ -8,7 +8,11 @@ import {
   Min,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class CreateMeetingRecordDto {

--- a/src/meeting/dto/meeting-record-query.dto.ts
+++ b/src/meeting/dto/meeting-record-query.dto.ts
@@ -18,7 +18,11 @@ import {
   Max,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class QueryMeetingRecordsDto {

--- a/src/meeting/dto/meeting-record-response.dto.ts
+++ b/src/meeting/dto/meeting-record-response.dto.ts
@@ -1,5 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 
 export class MeetingRecordResponseDto {
   @ApiProperty({ description: '会议记录ID' })

--- a/src/meeting/dto/meeting-record-stats.dto.ts
+++ b/src/meeting/dto/meeting-record-stats.dto.ts
@@ -1,5 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 import { MeetingRecordResponseDto } from './meeting-record-response.dto';
 
 export class PlatformStatsDto {

--- a/src/meeting/dto/meeting-record-update.dto.ts
+++ b/src/meeting/dto/meeting-record-update.dto.ts
@@ -7,7 +7,7 @@ import {
   Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingType, ProcessingStatus } from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class UpdateMeetingRecordDto {

--- a/src/meeting/meeting.service.ts
+++ b/src/meeting/meeting.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ProcessingStatus, Prisma } from '@prisma/client';
+import { ProcessingStatus, Prisma } from '@/generated/prisma/client';
 import { MeetingRepository } from './repositories/meeting.repository';
 import { GetMeetingRecordsParams } from './types';
 import {

--- a/src/meeting/repositories/meeting.repository.spec.ts
+++ b/src/meeting/repositories/meeting.repository.spec.ts
@@ -5,7 +5,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MeetingRepository } from './meeting.repository';
 import { PrismaService } from '../../prisma/prisma.service';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 
 describe('MeetingRepository', () => {
   let repository: MeetingRepository;

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import type { GetMeetingRecordsParams } from '@/meeting/types';
 
-import { MeetingPlatform, Prisma } from '@prisma/client';
+import { MeetingPlatform, Prisma } from '@/generated/prisma/client';
 
 type UpdateMeetingRecordData = Prisma.MeetingUncheckedUpdateInput;
 type CreateMeetingRecordData = Omit<

--- a/src/meeting/types/meeting-file.types.ts
+++ b/src/meeting/types/meeting-file.types.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2025 by LuLab-Team, All Rights Reserved.
  */
-import { RecordingFileType } from '@prisma/client';
+import { RecordingFileType } from '@/generated/prisma/client';
 
 /**
  * 会议文件创建参数

--- a/src/meeting/types/meeting-record.types.ts
+++ b/src/meeting/types/meeting-record.types.ts
@@ -9,7 +9,11 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import {
+  MeetingPlatform,
+  MeetingType,
+  ProcessingStatus,
+} from '@/generated/prisma/client';
 
 /**
  * 会议记录创建参数

--- a/src/org-member/dto/create-org-member.dto.ts
+++ b/src/org-member/dto/create-org-member.dto.ts
@@ -6,7 +6,7 @@ import {
   IsEnum,
   IsArray,
 } from 'class-validator';
-import { MemberType } from '@prisma/client';
+import { MemberType } from '@/generated/prisma/client';
 
 export class CreateOrgMemberDto {
   @ApiProperty({

--- a/src/org-member/dto/org-member.dto.ts
+++ b/src/org-member/dto/org-member.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { MemberType, MemberStatus } from '@prisma/client';
+import { MemberType, MemberStatus } from '@/generated/prisma/client';
 
 export class OrgMemberDto {
   @ApiProperty({

--- a/src/org-member/dto/pagination.dto.ts
+++ b/src/org-member/dto/pagination.dto.ts
@@ -18,7 +18,7 @@ import {
   IsEnum,
   IsBoolean,
 } from 'class-validator';
-import { MemberType, MemberStatus } from '@prisma/client';
+import { MemberType, MemberStatus } from '@/generated/prisma/client';
 import { Type } from 'class-transformer';
 
 export class PaginationDto {

--- a/src/org-member/dto/update-member-status.dto.ts
+++ b/src/org-member/dto/update-member-status.dto.ts
@@ -10,7 +10,7 @@
  */
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNotEmpty } from 'class-validator';
-import { MemberStatus } from '@prisma/client';
+import { MemberStatus } from '@/generated/prisma/client';
 
 export class UpdateMemberStatusDto {
   @ApiProperty({

--- a/src/org-member/dto/update-org-member.dto.ts
+++ b/src/org-member/dto/update-org-member.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsEnum, IsDateString } from 'class-validator';
-import { MemberType } from '@prisma/client';
+import { MemberType } from '@/generated/prisma/client';
 
 export class UpdateOrgMemberDto {
   @ApiPropertyOptional({

--- a/src/org-member/repositories/org-member.repository.ts
+++ b/src/org-member/repositories/org-member.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { OrgMember, Prisma } from '@prisma/client';
+import { OrgMember, Prisma } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 @Injectable()

--- a/src/org-member/services/org-member.service.ts
+++ b/src/org-member/services/org-member.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Prisma, OrgMember } from '@prisma/client';
+import { Prisma, OrgMember } from '@/generated/prisma/client';
 import { OrgMemberRepository } from '../repositories/org-member.repository';
 import {
   CreateOrgMemberDto,

--- a/src/org/repositories/organization.repository.ts
+++ b/src/org/repositories/organization.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Org, Prisma } from '@prisma/client';
+import { Org, Prisma } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 
 @Injectable()

--- a/src/org/services/organization.service.ts
+++ b/src/org/services/organization.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 import { OrganizationRepository } from '../repositories/organization.repository';
 import {
   CreateOrganizationDto,

--- a/src/permission/dto/create-permission.dto.ts
+++ b/src/permission/dto/create-permission.dto.ts
@@ -17,7 +17,7 @@ import {
   IsInt,
   IsBoolean,
 } from 'class-validator';
-import { PermissionType } from '@prisma/client';
+import { PermissionType } from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class CreatePermissionDto {

--- a/src/permission/dto/permission-tree.dto.ts
+++ b/src/permission/dto/permission-tree.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { PermissionType } from '@prisma/client';
+import { PermissionType } from '@/generated/prisma/client';
 
 export class PermissionTreeDto {
   @ApiProperty({ description: '权限ID' })

--- a/src/permission/dto/query-permission.dto.ts
+++ b/src/permission/dto/query-permission.dto.ts
@@ -10,7 +10,7 @@
  */
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, IsEnum, IsBoolean } from 'class-validator';
-import { PermissionType } from '@prisma/client';
+import { PermissionType } from '@/generated/prisma/client';
 import { Type, Transform } from 'class-transformer';
 
 export class QueryPermissionDto {

--- a/src/permission/dto/update-permission.dto.ts
+++ b/src/permission/dto/update-permission.dto.ts
@@ -6,7 +6,7 @@ import {
   IsInt,
   IsBoolean,
 } from 'class-validator';
-import { PermissionType } from '@prisma/client';
+import { PermissionType } from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class UpdatePermissionDto {

--- a/src/permission/repositories/permission.repository.ts
+++ b/src/permission/repositories/permission.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { PermissionType, Permission } from '@prisma/client';
+import { PermissionType, Permission } from '@/generated/prisma/client';
 
 interface PermissionWithChildren extends Permission {
   parent: Permission | null;

--- a/src/permission/services/data-permission.service.ts
+++ b/src/permission/services/data-permission.service.ts
@@ -12,7 +12,7 @@ import {
   DataPermissionRuleDto,
   DataPermissionRuleListResponse,
 } from '../dto';
-import { DataPermissionRule } from '@prisma/client';
+import { DataPermissionRule } from '@/generated/prisma/client';
 
 interface DataPermissionRuleWithFields extends DataPermissionRule {
   createdAt: Date;

--- a/src/permission/services/permission.service.ts
+++ b/src/permission/services/permission.service.ts
@@ -12,7 +12,7 @@ import {
   PermissionTreeDto,
   PermissionListResponse,
 } from '../dto';
-import { Permission } from '@prisma/client';
+import { Permission } from '@/generated/prisma/client';
 
 interface PermissionWithChildren extends Permission {
   parent?: Permission | null;

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -9,12 +9,19 @@
  * Copyright (c) 2025 by ${git_name_email}, All Rights Reserved.
  */
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@/generated/prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
   constructor() {
+    // Prisma 7 起使用 driver adapter（Rust-free）；Prisma 6.x 亦兼容。
+    // 连接串由 @nestjs/config 在模块初始化时从 .env 载入 process.env。
+    const adapter = new PrismaPg({
+      connectionString: process.env.DATABASE_URL,
+    });
     super({
+      adapter,
       log: ['query', 'info', 'warn', 'error'],
     });
   }

--- a/src/role/dto/create-role.dto.ts
+++ b/src/role/dto/create-role.dto.ts
@@ -17,7 +17,7 @@ import {
   IsInt,
   IsBoolean,
 } from 'class-validator';
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 import { Transform } from 'class-transformer';
 
 export class CreateRoleDto {

--- a/src/role/dto/query-role.dto.ts
+++ b/src/role/dto/query-role.dto.ts
@@ -17,7 +17,7 @@ import {
   IsBoolean,
   IsInt,
 } from 'class-validator';
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 import { Type, Transform } from 'class-transformer';
 
 export class QueryRoleDto {

--- a/src/role/dto/role.dto.ts
+++ b/src/role/dto/role.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 
 export class RoleDto {
   @ApiProperty({

--- a/src/role/repositories/role.repository.ts
+++ b/src/role/repositories/role.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { RoleType } from '@prisma/client';
+import { RoleType } from '@/generated/prisma/client';
 
 @Injectable()
 export class RoleRepository {

--- a/src/role/services/role.service.ts
+++ b/src/role/services/role.service.ts
@@ -14,7 +14,7 @@ import {
   CreateRoleBindingDto,
   RoleBindingDto,
 } from '../dto';
-import { Role, RoleType, Permission } from '@prisma/client';
+import { Role, RoleType, Permission } from '@/generated/prisma/client';
 import { PermissionDto } from '@/permission/dto';
 
 interface RoleWithPermissions extends Role {

--- a/src/task/decorators/tasks.decorators.ts
+++ b/src/task/decorators/tasks.decorators.ts
@@ -15,7 +15,7 @@ import {
   ApiParam,
   ApiQuery,
 } from '@nestjs/swagger';
-import { TaskStatus, TaskType } from '@prisma/client';
+import { TaskStatus, TaskType } from '@/generated/prisma/client';
 import { CreateOnceDto } from '../dtos/create-once.dto';
 import { CreateCronDto } from '../dtos/create-cron.dto';
 import { UpdateTaskDto } from '../dtos/update-task.dto';

--- a/src/task/dtos/update-task.dto.ts
+++ b/src/task/dtos/update-task.dto.ts
@@ -11,7 +11,7 @@
 
 // src/tasks/dtos/update-task.dto.ts
 import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
-import { TaskStatus } from '@prisma/client';
+import { TaskStatus } from '@/generated/prisma/client';
 
 export class UpdateTaskDto {
   @IsOptional()

--- a/src/task/processors/task.processor.ts
+++ b/src/task/processors/task.processor.ts
@@ -19,7 +19,7 @@ import {
 import type { Job } from 'bullmq';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Injectable, Logger } from '@nestjs/common';
-import { TaskStatus, PeriodType } from '@prisma/client';
+import { TaskStatus, PeriodType } from '@/generated/prisma/client';
 
 import { PeriodSummary } from '../service/period-summary.service';
 

--- a/src/task/repositories/period-summary.repository.ts
+++ b/src/task/repositories/period-summary.repository.ts
@@ -10,7 +10,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { PeriodType } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
 
 @Injectable()
 export class PeriodSummaryRepository {

--- a/src/task/service/period-summary-tool.ts
+++ b/src/task/service/period-summary-tool.ts
@@ -11,7 +11,7 @@
 import { OpenaiService } from '../../integrations/openai/openai.service';
 import { PeriodSummaryRepository } from '../repositories/period-summary.repository';
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { PeriodType } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
 import { PeriodTimeRange } from '../utils/period-time-range';
 
 import { openaiConfig } from '../../configs/openai.config';

--- a/src/task/service/period-summary.service.ts
+++ b/src/task/service/period-summary.service.ts
@@ -11,7 +11,7 @@
 // import type { Job } from 'bullmq';
 import { PeriodSummaryTool } from './period-summary-tool';
 import { Injectable, Logger } from '@nestjs/common';
-import { PeriodType } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
 
 @Injectable()
 export class PeriodSummary {

--- a/src/task/service/tasks.service.ts
+++ b/src/task/service/tasks.service.ts
@@ -7,7 +7,7 @@ import { CreateOnceDto } from '../dtos/create-once.dto';
 import { CreateCronDto } from '../dtos/create-cron.dto';
 import { UpdateTaskDto } from '../dtos/update-task.dto';
 import { QueryDto } from '../dtos/query.dto';
-import { ScheduledTask, TaskStatus, TaskType } from '@prisma/client';
+import { ScheduledTask, TaskStatus, TaskType } from '@/generated/prisma/client';
 
 @Injectable()
 export class TasksService {

--- a/src/task/tasks.controller.ts
+++ b/src/task/tasks.controller.ts
@@ -26,7 +26,7 @@ import { CreateOnceDto } from './dtos/create-once.dto';
 import { CreateCronDto } from './dtos/create-cron.dto';
 import { UpdateTaskDto } from './dtos/update-task.dto';
 import { QueryDto } from './dtos/query.dto';
-import { TaskStatus, TaskType } from '@prisma/client';
+import { TaskStatus, TaskType } from '@/generated/prisma/client';
 import {
   ApiHealthCheckDocs,
   ApiCreateOnceDocs,

--- a/src/task/utils/period-time-range.ts
+++ b/src/task/utils/period-time-range.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PeriodType } from '@prisma/client';
+import { PeriodType } from '@/generated/prisma/client';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/src/tencent-mtg-hook/handlers/events/recording-completed.handler.ts
+++ b/src/tencent-mtg-hook/handlers/events/recording-completed.handler.ts
@@ -18,7 +18,7 @@ import {
   GenerationMethod,
   ProcessingStatus,
   MeetingPlatform,
-} from '@prisma/client';
+} from '@/generated/prisma/client';
 
 import { BaseEventHandler } from '../base/base-event.handler';
 import {

--- a/src/tencent-mtg-hook/pipes/tencent-webhook-body-decryption.pipe.ts
+++ b/src/tencent-mtg-hook/pipes/tencent-webhook-body-decryption.pipe.ts
@@ -37,9 +37,7 @@ export class TencentWebhookDecryptionPipe implements PipeTransform {
     private readonly tencentConfig: ConfigType<typeof tencentMeetingConfig>,
   ) {}
 
-  async transform(
-    value: TencentWebhookEventBodyDto,
-  ): Promise<MeetingEvent> {
+  async transform(value: TencentWebhookEventBodyDto): Promise<MeetingEvent> {
     // 1. 基础参数校验
     if (!value || !value.data) {
       throw new BadRequestException(

--- a/src/tencent-mtg-hook/repositories/meeting-recording.repository.ts
+++ b/src/tencent-mtg-hook/repositories/meeting-recording.repository.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { RecordingSource, RecordingStatus, PrismaClient } from '@prisma/client';
+import {
+  RecordingSource,
+  RecordingStatus,
+  PrismaClient,
+} from '@/generated/prisma/client';
 
 type PrismaTransaction = Omit<
   PrismaClient,

--- a/src/tencent-mtg-hook/repositories/meeting-summary.repository.ts
+++ b/src/tencent-mtg-hook/repositories/meeting-summary.repository.ts
@@ -11,7 +11,11 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { GenerationMethod, ProcessingStatus, Prisma } from '@prisma/client';
+import {
+  GenerationMethod,
+  ProcessingStatus,
+  Prisma,
+} from '@/generated/prisma/client';
 
 type CreateInput = Prisma.MeetingSummaryUncheckedCreateInput;
 

--- a/src/tencent-mtg-hook/repositories/participant-summary.repository.ts
+++ b/src/tencent-mtg-hook/repositories/participant-summary.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { GenerationMethod, PeriodType } from '@prisma/client';
+import { GenerationMethod, PeriodType } from '@/generated/prisma/client';
 
 @Injectable()
 export class ParticipantSummaryRepository {

--- a/src/tencent-mtg-hook/repositories/transcript.repository.ts
+++ b/src/tencent-mtg-hook/repositories/transcript.repository.ts
@@ -11,7 +11,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
 import { PrismaTransaction } from '@/tencent-mtg-hook/types';
-import { Prisma } from '@prisma/client';
+import { Prisma } from '@/generated/prisma/client';
 
 @Injectable()
 export class TranscriptRepository {

--- a/src/tencent-mtg-hook/services/meeting-database.service.ts
+++ b/src/tencent-mtg-hook/services/meeting-database.service.ts
@@ -14,7 +14,7 @@ import { Meetuser, EventPayload } from '../types';
 import { TencentEventUtils } from '../utils/tencent-event.utils';
 import { PlatformUserRepository } from '@/user-platform/repositories/platform-user.repository';
 import { MeetingRepository } from '@/meeting/repositories/meeting.repository';
-import { Platform, PlatformUser, Prisma } from '@prisma/client';
+import { Platform, PlatformUser, Prisma } from '@/generated/prisma/client';
 
 /**
  * 会议数据库服务

--- a/src/tencent-mtg-hook/services/speaker.service.ts
+++ b/src/tencent-mtg-hook/services/speaker.service.ts
@@ -11,7 +11,7 @@
 
 import { Injectable, Logger } from '@nestjs/common';
 import { NewSpeakerInfo } from '@/tencent-mtg-hook/types';
-import { Platform, PlatformUser, User } from '@prisma/client';
+import { Platform, PlatformUser, User } from '@/generated/prisma/client';
 import { UserRepository } from '@/user/repositories/user.repository';
 import { PlatformUserRepository } from '@/user-platform/repositories/platform-user.repository';
 import {

--- a/src/tencent-mtg-hook/services/transcript-batch-processor.service.ts
+++ b/src/tencent-mtg-hook/services/transcript-batch-processor.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Platform, PlatformUser } from '@prisma/client';
+import { Platform, PlatformUser } from '@/generated/prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 import { PlatformUserRepository } from '@/user-platform/repositories/platform-user.repository';
 import {

--- a/src/tencent-mtg-hook/types/transcript.types.ts
+++ b/src/tencent-mtg-hook/types/transcript.types.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@/generated/prisma/client';
 import {
   RecordingTranscriptResponse,
   RecordingTranscriptParagraph,

--- a/src/tencent-mtg-hook/utils/tencent-event.utils.spec.ts
+++ b/src/tencent-mtg-hook/utils/tencent-event.utils.spec.ts
@@ -10,7 +10,7 @@
  */
 
 import { TencentEventUtils } from './tencent-event.utils';
-import { MeetingType } from '@prisma/client';
+import { MeetingType } from '@/generated/prisma/client';
 import { MeetingType as TencentMeetingType } from '../enums/tencent-mtg.enum';
 
 describe('TencentEventUtils', () => {

--- a/src/tencent-mtg-hook/utils/tencent-event.utils.ts
+++ b/src/tencent-mtg-hook/utils/tencent-event.utils.ts
@@ -9,7 +9,7 @@ import {
   MeetingSessionInfo as MeetInfo,
   Meetuser,
 } from '../types';
-import { MeetingType } from '@prisma/client';
+import { MeetingType } from '@/generated/prisma/client';
 
 // 类型工具函数
 export class TencentEventUtils {

--- a/src/user-platform/repositories/platform-user.repository.ts
+++ b/src/user-platform/repositories/platform-user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import type { PlatformUser, Platform, Prisma } from '@prisma/client';
+import type { PlatformUser, Platform, Prisma } from '@/generated/prisma/client';
 
 type PlatformUserCreateInput = Prisma.PlatformUserUncheckedCreateInput;
 type PlatformUserUpdateInput = Prisma.PlatformUserUncheckedUpdateInput;

--- a/src/user/repositories/user.repository.ts
+++ b/src/user/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import type { User, UserProfile } from '@prisma/client';
+import type { User, UserProfile } from '@/generated/prisma/client';
 
 @Injectable()
 export class UserRepository {

--- a/src/verification/repositories/verification.repository.ts
+++ b/src/verification/repositories/verification.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { VerificationCodeType } from '@prisma/client';
+import { VerificationCodeType } from '@/generated/prisma/client';
 
 @Injectable()
 export class VerificationRepository {

--- a/src/verification/verification.service.ts
+++ b/src/verification/verification.service.ts
@@ -8,7 +8,7 @@ import { VerificationRepository } from './repositories/verification.repository';
 import { MailService } from '@/mail/mail.service';
 import { AliyunSmsService } from '../integrations/aliyun/aliyun-sms.service';
 import { CodeType } from '@/verification/enums';
-import { VerificationCodeType } from '@prisma/client';
+import { VerificationCodeType } from '@/generated/prisma/client';
 import {
   generateNumericCode,
   isValidEmail,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "prisma.config.ts"]
 }


### PR DESCRIPTION
## Summary

Makes the project compatible with **both Prisma 6.x and Prisma 7.x**.

## Changes

- **Prisma config**: migrate `package.json#prisma` to `prisma.config.ts` (required by Prisma 7; deprecated in 6.x).
- **Generator**: switch from `prisma-client-js` to the new `prisma-client` generator with `output = src/generated/prisma`; drop `binaryTargets` (removed in Prisma 7).
- **Driver adapter**: add `@prisma/adapter-pg` + `pg`, and wire `PrismaService` through `new PrismaClient({ adapter: new PrismaPg({ connectionString }) })`.
- **Imports**: replace all `@prisma/client` imports across `src/`, `prisma/` (seeds), and `scripts/` with the generated client.
- **Seeds/scripts**: migrate seed + utility scripts to the driver adapter; convert the two Prisma `.mjs` scripts to `tsx`-run `.ts`.
- **Build**: add `postinstall: prisma generate` and gitignore the generated client.
- **Tooling**: fix CRLF/prettier friction (`endOfLine: auto`), exclude generated client from eslint, pin `@alicloud/credentials` to fix a transitive type mismatch.
- **Docs**: document key dependencies and DATABASE_URL requirements.

## Verification

```
prisma generate   -> OK
prisma validate   -> OK
nest build        -> OK
eslint            -> OK
```
