### PR TITLE
fix(auth): support cross-site refresh cookies

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -101,7 +101,7 @@ export class AuthController {
       res.cookie('refreshToken', result.refreshToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
         maxAge: (result.refreshExpiresIn || 0) * 1000,
         path: '/',
       });
@@ -138,7 +138,7 @@ export class AuthController {
       res.cookie('refreshToken', result.refreshToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
         maxAge: (result.refreshExpiresIn || 0) * 1000,
         path: '/',
       });
@@ -208,7 +208,7 @@ export class AuthController {
       res.cookie('refreshToken', result.refreshToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
         maxAge: (result.refreshExpiresIn || 0) * 1000,
         path: '/',
       });
@@ -287,7 +287,7 @@ export class AuthController {
         res.clearCookie('refreshToken', {
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production',
-          sameSite: 'strict',
+          sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
           path: '/',
         });
       }


### PR DESCRIPTION
## Summary

- allow production refresh-token cookies in cross-site requests with `SameSite=None`
- use `SameSite=Lax` for local and non-production environments
- keep logout cookie clearing options aligned with cookie creation

## Risk

- production cookies remain `Secure` and `HttpOnly`
- cross-site cookie delivery still depends on the configured CORS and credential policy

## Verification

- `pnpm exec eslint src/auth/auth.controller.ts`
- `pnpm build`