### PR TITLE
refactor/minute schema cleanup

### DIFF
--- a/prisma/migrations/20260821200702_remove_unused_fields_from_summaries/migration.sql
+++ b/prisma/migrations/20260821200702_remove_unused_fields_from_summaries/migration.sql
@@ -1,0 +1,72 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `confidence` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted_at` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `error_message` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `language` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `processing_time` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `status` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `title` on the `minute_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `confidence` on the `speaker_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted_at` on the `speaker_summaries` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted_at` on the `transcript_segments` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted_at` on the `transcripts` table. All the data in the column will be lost.
+  - You are about to drop the column `confidence` on the `user_tracking_reports` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[minute_id,version]` on the table `minute_summaries` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "public"."idx_minute_summary_is_latest";
+
+-- DropIndex
+DROP INDEX "public"."idx_minute_summary_language";
+
+-- DropIndex
+DROP INDEX "public"."idx_minute_summary_status";
+
+-- DropIndex
+DROP INDEX "public"."idx_minute_summary_status_created";
+
+-- DropIndex
+DROP INDEX "public"."idx_minute_summary_version";
+
+-- DropIndex
+DROP INDEX "public"."minute_participant_summaries_minute_id_platform_user_id_del_idx";
+
+-- AlterTable
+ALTER TABLE "minute_summaries" DROP COLUMN "confidence",
+DROP COLUMN "deleted_at",
+DROP COLUMN "error_message",
+DROP COLUMN "language",
+DROP COLUMN "processing_time",
+DROP COLUMN "status",
+DROP COLUMN "title";
+
+-- AlterTable
+ALTER TABLE "speaker_summaries" RENAME CONSTRAINT "minute_participant_summaries_pkey" TO "speaker_summaries_pkey";
+
+ALTER TABLE "speaker_summaries"
+DROP COLUMN "confidence",
+DROP COLUMN "deleted_at";
+
+-- AlterTable
+ALTER TABLE "transcript_segments" DROP COLUMN "deleted_at";
+
+-- AlterTable
+ALTER TABLE "transcripts" DROP COLUMN "deleted_at";
+
+-- AlterTable
+ALTER TABLE "user_tracking_reports" DROP COLUMN "confidence";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_minute_summary_version" ON "minute_summaries"("minute_id", "version");
+
+-- CreateIndex
+CREATE INDEX "speaker_summaries_minute_id_platform_user_id_idx" ON "speaker_summaries"("minute_id", "platform_user_id");
+
+-- RenameForeignKey
+ALTER TABLE "speaker_summaries" RENAME CONSTRAINT "minute_participant_summaries_minute_id_fkey" TO "speaker_summaries_minute_id_fkey";
+
+-- RenameForeignKey
+ALTER TABLE "speaker_summaries" RENAME CONSTRAINT "minute_participant_summaries_platform_user_id_fkey" TO "speaker_summaries_platform_user_id_fkey";

--- a/prisma/models/minute_summary.prisma
+++ b/prisma/models/minute_summary.prisma
@@ -3,7 +3,6 @@ model MinuteSummary {
   id String @id @default(cuid())
 
   // 总结内容
-  title        String?  @db.VarChar(500) // 总结标题
   content      String   @db.Text // 总结内容
   // AI生成的结构化会议纪要，格式: { "sections": [{ "title": "string", "content": "string", "timestamp": "string" }] }
   aiMinutes    Json?    @map("ai_minutes")
@@ -23,32 +22,20 @@ model MinuteSummary {
   // 生成信息
   generatedBy GenerationMethod? @map("generated_by") // 生成方式
   aiModel     String?           @map("ai_model") // AI模型版本
-  confidence  Float? // 置信度
-  language    String? // 总结语言
 
   // 版本控制
   version  Int     @default(1) @map("version")
   isLatest Boolean @default(true) @map("is_latest")
-
-  // 状态管理
-  status         ProcessingStatus @default(PENDING) @map("status")
-  processingTime Int?             @map("processing_time") // 处理耗时（毫秒）
-  errorMessage   String?          @map("error_message") // 错误信息
 
   // 关联录制 (Minute)
   minuteId String @map("minute_id")
   minute   Minute @relation(fields: [minuteId], references: [id], onDelete: Cascade)
 
   // 系统字段及时间
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
+  @@unique([minuteId, version], map: "uq_minute_summary_version")
   @@index([minuteId], map: "idx_minute_summary_minute")
-  @@index([isLatest], map: "idx_minute_summary_is_latest")
-  @@index([status], map: "idx_minute_summary_status")
-  @@index([version], map: "idx_minute_summary_version")
-  @@index([language], map: "idx_minute_summary_language") // 语言查询优化
-  @@index([status, createdAt], map: "idx_minute_summary_status_created") // 按状态查询总结列表
   @@map("minute_summaries")
 }

--- a/prisma/models/speaker_summary.prisma
+++ b/prisma/models/speaker_summary.prisma
@@ -11,18 +11,16 @@ model SpeakerSummary {
   keywords    String[]
   generatedBy GenerationMethod? @map("generated_by")
   aiModel     String?           @map("ai_model")
-  confidence  Float?
 
   version  Int     @default(1)
   isLatest Boolean @default(true) @map("is_latest")
 
   reportSources TrackingReportMinuteSummarySource[]
 
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@unique([minuteId, platformUserId, version], map: "uq_speaker_summary_version")
-  @@index([minuteId, platformUserId, deletedAt])
+  @@index([minuteId, platformUserId])
   @@map("speaker_summaries")
 }

--- a/prisma/models/transcript.prisma
+++ b/prisma/models/transcript.prisma
@@ -13,9 +13,8 @@ model Transcript {
   startedAt  DateTime? @map("started_at") @db.Timestamptz(6)
   finishedAt DateTime? @map("finished_at") @db.Timestamptz(6)
 
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@index([createdAt])
   @@index([minuteId])
@@ -47,9 +46,8 @@ model TranscriptSegment {
   wordsDetail Json? @map("words_detail")
 
   // 系统字段及时间
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   @@index([transcriptId, startTimeMs])
   @@index([speakerId])

--- a/prisma/models/user_tracking_report.prisma
+++ b/prisma/models/user_tracking_report.prisma
@@ -34,7 +34,6 @@ model UserTrackingReport {
   schemaVersion       Int                @default(1) @map("schema_version")
   generatedBy         GenerationMethod?  @map("generated_by")
   aiModel             String?            @map("ai_model")
-  confidence          Float?
 
   versionGroupKey      String                              @map("version_group_key") @db.VarChar(700)
   version              Int                                 @default(1)

--- a/prisma/seeds/minutes/minute-summaries/config.ts
+++ b/prisma/seeds/minutes/minute-summaries/config.ts
@@ -15,12 +15,9 @@ export const MINUTE_SUMMARY_CONFIGS: {
   teamSummary: MinuteSummaryConfig;
 } = {
   teamSummary: {
-    title: '周例会总结 - 2024年12月第3周',
     content: '本次会议主要讨论了各项目的进展情况...',
     generatedBy: GenerationMethod.AI,
     aiModel: 'gpt-4',
-    confidence: 0.95,
-    language: 'zh-CN',
     keyPoints: [
       '项目A进度正常，预计下周完成',
       '项目B遇到技术难点，需要额外支持',
@@ -35,7 +32,5 @@ export const MINUTE_SUMMARY_CONFIGS: {
       },
     ],
     decisions: ['决定采用新的代码审查工具', '调整项目B的开发计划'],
-
-    status: ProcessingStatus.COMPLETED,
   },
 } as const;

--- a/prisma/seeds/minutes/minute-summaries/config.ts
+++ b/prisma/seeds/minutes/minute-summaries/config.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { ProcessingStatus, GenerationMethod } from '@prisma/client';
+import { GenerationMethod } from '@prisma/client';
 import type { MinuteSummaryConfig } from './type';
 
 export const MINUTE_SUMMARY_CONFIGS: {

--- a/prisma/seeds/minutes/minute-summaries/minute-summaries.ts
+++ b/prisma/seeds/minutes/minute-summaries/minute-summaries.ts
@@ -31,8 +31,6 @@ export async function createMinuteSummary(
     data: {
       minuteId: minute.id,
       ...MINUTE_SUMMARY_CONFIGS.teamSummary,
-      processingTime: 30000,
-      status: ProcessingStatus.COMPLETED,
     },
   });
 }

--- a/prisma/seeds/minutes/minute-summaries/minute-summaries.ts
+++ b/prisma/seeds/minutes/minute-summaries/minute-summaries.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, ProcessingStatus, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { MINUTE_SUMMARY_CONFIGS } from './config';
 import type { CreatedMinuteSummaries } from './type';
 

--- a/src/minute/controllers/minute-summary.controller.ts
+++ b/src/minute/controllers/minute-summary.controller.ts
@@ -48,7 +48,7 @@ export class MinuteSummaryController {
     query: QueryMinuteSummaryDto,
   ) {
     this.logger.log(`获取会议纪要总结列表: ${minuteId}`, { query });
-    return this.minuteSummaryService.findMany(
+    return this.minuteSummaryService.findVersionsByMinuteId(
       minuteId,
       query.page,
       query.limit,

--- a/src/minute/dto/minute-summary.dto.ts
+++ b/src/minute/dto/minute-summary.dto.ts
@@ -15,10 +15,6 @@ export class CreateMinuteSummaryDto {
   @ApiProperty({ description: '关联的录制ID' })
   @IsString()
   minuteId: string;
-  @ApiPropertyOptional({ description: '总结标题' })
-  @IsOptional()
-  @IsString()
-  title?: string;
 
   @ApiProperty({ description: '总结内容' })
   @IsString()
@@ -56,12 +52,7 @@ export class CreateMinuteSummaryDto {
   metadata?: any;
 }
 
-export class UpdateMinuteSummaryDto extends CreateMinuteSummaryDto {
-  @ApiPropertyOptional({ description: '处理状态', enum: ProcessingStatus })
-  @IsOptional()
-  @IsEnum(ProcessingStatus)
-  status?: ProcessingStatus;
-}
+export class UpdateMinuteSummaryDto extends CreateMinuteSummaryDto {}
 
 export class QueryMinuteSummaryDto {
   @ApiPropertyOptional({
@@ -91,20 +82,11 @@ export class QueryMinuteSummaryDto {
     return value as unknown;
   })
   isLatest?: boolean;
-
-  @ApiPropertyOptional({ description: '状态', enum: ProcessingStatus })
-  @IsOptional()
-  @Transform(({ value }) => (value === '' ? undefined : (value as string)))
-  @IsEnum(ProcessingStatus)
-  status?: ProcessingStatus;
 }
 
 export class MinuteSummaryDto {
   @ApiProperty({ description: '总结ID' })
   id: string;
-
-  @ApiPropertyOptional({ description: '总结标题' })
-  title?: string;
 
   @ApiProperty({ description: '总结内容' })
   content: string;
@@ -130,9 +112,6 @@ export class MinuteSummaryDto {
   @ApiPropertyOptional({ description: '元数据' })
   metadata?: any;
 
-  @ApiPropertyOptional({ description: '状态', enum: ProcessingStatus })
-  status?: ProcessingStatus;
-
   @ApiPropertyOptional({ description: '录制ID' })
   minuteId?: string;
 
@@ -142,20 +121,11 @@ export class MinuteSummaryDto {
   @ApiPropertyOptional({ description: '生成方式', enum: GenerationMethod })
   generatedBy?: GenerationMethod;
 
-  @ApiPropertyOptional({ description: '置信度' })
-  confidence?: number;
-
-  @ApiPropertyOptional({ description: '总结语言' })
-  language?: string;
-
   @ApiProperty({ description: '版本号' })
   version: number;
 
   @ApiProperty({ description: '是否为最新版本' })
   isLatest: boolean;
-
-  @ApiPropertyOptional({ description: '处理耗时（毫秒）' })
-  processingTime?: number;
 
   @ApiProperty({ description: '创建时间' })
   createdAt: Date;

--- a/src/minute/dto/minute-summary.dto.ts
+++ b/src/minute/dto/minute-summary.dto.ts
@@ -2,14 +2,13 @@ import {
   IsString,
   IsOptional,
   IsArray,
-  IsEnum,
   IsObject,
   IsInt,
   Min,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { GenerationMethod, ProcessingStatus } from '@prisma/client';
+import { GenerationMethod } from '@prisma/client';
 
 export class CreateMinuteSummaryDto {
   @ApiProperty({ description: '关联的录制ID' })

--- a/src/minute/dto/minute.dto.ts
+++ b/src/minute/dto/minute.dto.ts
@@ -9,7 +9,6 @@ import {
   Max,
   IsObject,
   IsNotEmpty,
-  IsInt,
   IsArray,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';

--- a/src/minute/dto/minute.dto.ts
+++ b/src/minute/dto/minute.dto.ts
@@ -111,21 +111,6 @@ export class CreateRecordingSummaryDto extends CreateMinuteSummaryDto {
   @IsNotEmpty()
   aiModel?: string;
 
-  @ApiPropertyOptional({ description: '总结语言', default: 'zh-CN' })
-  @IsOptional()
-  @IsString()
-  @IsNotEmpty()
-  language?: string;
-
-  @ApiPropertyOptional({
-    description: '外部 AI 处理耗时（毫秒）',
-    minimum: 0,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(0)
-  processingTime?: number;
-
   @ApiPropertyOptional({ description: '参与者总结' })
   @IsOptional()
   @IsArray()
@@ -135,17 +120,6 @@ export class CreateRecordingSummaryDto extends CreateMinuteSummaryDto {
   @IsOptional()
   @IsArray()
   goldenQuotes?: Record<string, unknown>[];
-
-  @ApiPropertyOptional({
-    description: '外部 AI 返回的置信度',
-    minimum: 0,
-    maximum: 1,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(1)
-  confidence?: number;
 }
 
 export class MinuteDto {

--- a/src/minute/repositories/minute-summary.repository.spec.ts
+++ b/src/minute/repositories/minute-summary.repository.spec.ts
@@ -25,7 +25,7 @@ describe('MinuteSummaryRepository', () => {
       $transaction: transaction,
     } as unknown as PrismaService);
 
-    const result = await repository.createExternalForRecording('recording-1', {
+    const result = await repository.saveNewVersion('recording-1', {
       content: 'New content',
       aiModel: 'GPT-4',
       keywords: ['tech'],
@@ -43,8 +43,6 @@ describe('MinuteSummaryRepository', () => {
         keywords: ['tech'],
         generatedBy: GenerationMethod.AI,
         aiModel: 'GPT-4',
-        language: 'zh-CN',
-        status: ProcessingStatus.COMPLETED,
         version: 3,
         isLatest: true,
       }),

--- a/src/minute/repositories/minute-summary.repository.spec.ts
+++ b/src/minute/repositories/minute-summary.repository.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { GenerationMethod, Prisma, ProcessingStatus } from '@prisma/client';
+import { GenerationMethod, Prisma } from '@prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 import { MinuteSummaryRepository } from './minute-summary.repository';
 

--- a/src/minute/repositories/minute-summary.repository.ts
+++ b/src/minute/repositories/minute-summary.repository.ts
@@ -11,7 +11,7 @@
 
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import { GenerationMethod, ProcessingStatus, Prisma } from '@prisma/client';
+import { GenerationMethod, Prisma } from '@prisma/client';
 import { retryVersionTransaction } from '@/common/utils/prisma-transaction-retry';
 import { CreateRecordingSummaryDto } from '../dto/minute.dto';
 
@@ -26,16 +26,13 @@ export class MinuteSummaryRepository {
       data: {
         ...data,
         generatedBy: data.generatedBy || GenerationMethod.AI,
-        aiModel: data.aiModel || 'tencent-meeting-ai',
-        status: data.status || ProcessingStatus.COMPLETED,
-        language: data.language || 'zh-CN',
         version: data.version || 1,
         isLatest: data.isLatest !== undefined ? data.isLatest : true,
       },
     });
   }
 
-  async upsert(data: CreateInput) {
+  async updateCurrentVersion(data: CreateInput) {
     const existingSummary = await this.prisma.minuteSummary.findFirst({
       where: {
         minuteId: data.minuteId,
@@ -52,9 +49,6 @@ export class MinuteSummaryRepository {
           actionItems: data.actionItems,
           generatedBy: data.generatedBy,
           aiModel: data.aiModel,
-          status: data.status,
-          processingTime: data.processingTime,
-          language: data.language,
           updatedAt: new Date(),
         },
       });
@@ -64,8 +58,6 @@ export class MinuteSummaryRepository {
           ...data,
           generatedBy: data.generatedBy || GenerationMethod.AI,
           aiModel: data.aiModel || 'tencent-meeting-ai',
-          status: data.status || ProcessingStatus.COMPLETED,
-          language: data.language || 'zh-CN',
           version: data.version || 1,
           isLatest: data.isLatest !== undefined ? data.isLatest : true,
         },
@@ -73,15 +65,12 @@ export class MinuteSummaryRepository {
     }
   }
 
-  async createExternalForRecording(
-    minuteId: string,
-    data: CreateRecordingSummaryDto,
-  ) {
+  async saveNewVersion(minuteId: string, data: CreateRecordingSummaryDto) {
     return retryVersionTransaction(() =>
       this.prisma.$transaction(
         async (tx) => {
           const previous = await tx.minuteSummary.findFirst({
-            where: { minuteId, isLatest: true, deletedAt: null },
+            where: { minuteId, isLatest: true },
             orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
           });
 
@@ -95,7 +84,6 @@ export class MinuteSummaryRepository {
           return tx.minuteSummary.create({
             data: {
               minuteId,
-              title: data.title,
               content: data.content,
               keywords: data.keywords ?? [],
               aiMinutes: data.aiMinutes as Prisma.InputJsonValue | undefined,
@@ -110,10 +98,6 @@ export class MinuteSummaryRepository {
               metadata: data.metadata as Prisma.InputJsonValue | undefined,
               generatedBy: GenerationMethod.AI,
               aiModel: data.aiModel ?? 'external-ai',
-              confidence: data.confidence,
-              language: data.language ?? 'zh-CN',
-              processingTime: data.processingTime,
-              status: ProcessingStatus.COMPLETED,
               version: (previous?.version ?? 0) + 1,
               isLatest: true,
             },
@@ -126,17 +110,23 @@ export class MinuteSummaryRepository {
 
   async findById(id: string) {
     return this.prisma.minuteSummary.findUnique({
-      where: { id, deletedAt: null },
+      where: { id },
     });
   }
 
-  async findMany(minuteId: string, skip: number, take: number) {
+  async findLatestByMinuteId(minuteId: string) {
+    return this.prisma.minuteSummary.findFirst({
+      where: { minuteId, isLatest: true },
+    });
+  }
+
+  async findVersionsByMinuteId(minuteId: string, skip: number, take: number) {
     const [total, records] = await this.prisma.$transaction([
       this.prisma.minuteSummary.count({
-        where: { minuteId, deletedAt: null },
+        where: { minuteId },
       }),
       this.prisma.minuteSummary.findMany({
-        where: { minuteId, deletedAt: null },
+        where: { minuteId },
         skip,
         take,
         orderBy: { createdAt: 'desc' },
@@ -156,11 +146,8 @@ export class MinuteSummaryRepository {
   }
 
   async delete(id: string) {
-    return this.prisma.minuteSummary.update({
+    return this.prisma.minuteSummary.delete({
       where: { id },
-      data: {
-        deletedAt: new Date(),
-      },
     });
   }
 }

--- a/src/minute/repositories/speaker-summary.repository.spec.ts
+++ b/src/minute/repositories/speaker-summary.repository.spec.ts
@@ -20,17 +20,15 @@ describe('SpeakerSummaryRepository', () => {
         },
         select: expect.objectContaining({
           summaries: expect.objectContaining({
-            where: { isLatest: true, deletedAt: null },
+            where: { isLatest: true },
             orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
             take: 1,
           }),
           transcripts: expect.objectContaining({
-            where: { deletedAt: null },
             orderBy: { createdAt: 'desc' },
             take: 1,
             select: {
               segments: expect.objectContaining({
-                where: { deletedAt: null },
                 orderBy: { startTimeMs: 'asc' },
                 select: expect.objectContaining({
                   speaker: expect.objectContaining({

--- a/src/minute/repositories/speaker-summary.repository.ts
+++ b/src/minute/repositories/speaker-summary.repository.ts
@@ -12,7 +12,6 @@ export class SpeakerSummaryRepository {
       where: {
         id,
         minuteId,
-        deletedAt: null,
       },
     });
   }
@@ -29,7 +28,6 @@ export class SpeakerSummaryRepository {
     const where: Prisma.SpeakerSummaryWhereInput = {
       minuteId,
       isLatest: true,
-      deletedAt: null,
     };
     const [total, records] = await this.prisma.$transaction([
       this.prisma.speakerSummary.count({ where }),
@@ -57,7 +55,6 @@ export class SpeakerSummaryRepository {
               minuteId: params.minuteId,
               platformUserId: params.platformUserId,
               isLatest: true,
-              deletedAt: null,
             },
             orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
           });
@@ -83,7 +80,7 @@ export class SpeakerSummaryRepository {
     );
   }
 
-  async softDelete(minuteId: string, id: string) {
+  async delete(minuteId: string, id: string) {
     return retryVersionTransaction(() =>
       this.prisma.$transaction(
         async (tx) => {
@@ -91,19 +88,16 @@ export class SpeakerSummaryRepository {
             where: {
               id,
               minuteId,
-              deletedAt: null,
             },
           });
-          await tx.speakerSummary.update({
+          await tx.speakerSummary.delete({
             where: { id },
-            data: { deletedAt: new Date(), isLatest: false },
           });
           if (current.isLatest) {
             const predecessor = await tx.speakerSummary.findFirst({
               where: {
                 minuteId: current.minuteId,
                 platformUserId: current.platformUserId,
-                deletedAt: null,
               },
               orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
             });
@@ -131,7 +125,6 @@ export class SpeakerSummaryRepository {
           ? { in: platformUserIds }
           : undefined,
         isLatest: true,
-        deletedAt: null,
         createdAt: { gte: range.periodStart, lte: range.periodEnd },
       },
       include: {
@@ -161,7 +154,7 @@ export class SpeakerSummaryRepository {
           },
         },
         summaries: {
-          where: { isLatest: true, deletedAt: null },
+          where: { isLatest: true },
           orderBy: [{ version: 'desc' }, { createdAt: 'desc' }],
           take: 1,
           select: {
@@ -174,12 +167,10 @@ export class SpeakerSummaryRepository {
           },
         },
         transcripts: {
-          where: { deletedAt: null },
           orderBy: { createdAt: 'desc' },
           take: 1,
           select: {
             segments: {
-              where: { deletedAt: null },
               orderBy: { startTimeMs: 'asc' },
               select: {
                 startTimeMs: true,
@@ -203,7 +194,6 @@ export class SpeakerSummaryRepository {
       where: {
         platformUserId: { in: params.platformUserIds },
         isLatest: true,
-        deletedAt: null,
         createdAt: { gte: params.startDate, lte: params.endDate },
       },
       include: {

--- a/src/minute/repositories/transcript.repository.ts
+++ b/src/minute/repositories/transcript.repository.ts
@@ -97,13 +97,12 @@ export class TranscriptRepository {
   async findByRecordingId(minuteId: string) {
     return this.prisma.transcript.findFirst({
       where: { minuteId },
-      omit: { deletedAt: true },
     });
   }
 
   async findDetails(minuteId: string) {
     return this.prisma.transcript.findFirst({
-      where: { minuteId, deletedAt: null },
+      where: { minuteId },
       include: {
         segments: {
           orderBy: {
@@ -114,14 +113,12 @@ export class TranscriptRepository {
           },
         },
       },
-      omit: { deletedAt: true },
     });
   }
 
   async findBySource(source: string) {
     return this.prisma.transcript.findFirst({
       where: { source },
-      omit: { deletedAt: true },
     });
   }
 

--- a/src/minute/services/minute-summary.service.ts
+++ b/src/minute/services/minute-summary.service.ts
@@ -14,8 +14,8 @@ export class MinuteSummaryService {
     private readonly meetingSummaryRepository: MinuteSummaryRepository,
   ) {}
 
-  async upsert(data: Prisma.MinuteSummaryUncheckedCreateInput) {
-    return this.meetingSummaryRepository.upsert(data);
+  async updateCurrentVersion(data: Prisma.MinuteSummaryUncheckedCreateInput) {
+    return this.meetingSummaryRepository.updateCurrentVersion(data);
   }
 
   async findById(minuteId: string, id: string) {
@@ -26,13 +26,18 @@ export class MinuteSummaryService {
     return summary;
   }
 
-  async findMany(minuteId: string, page: number = 1, limit: number = 10) {
+  async findVersionsByMinuteId(
+    minuteId: string,
+    page: number = 1,
+    limit: number = 10,
+  ) {
     const skip = (page - 1) * limit;
-    const { total, records } = await this.meetingSummaryRepository.findMany(
-      minuteId,
-      skip,
-      limit,
-    );
+    const { total, records } =
+      await this.meetingSummaryRepository.findVersionsByMinuteId(
+        minuteId,
+        skip,
+        limit,
+      );
     return {
       data: records,
       total,
@@ -45,7 +50,7 @@ export class MinuteSummaryService {
   async create(minuteId: string, data: CreateMinuteSummaryDto) {
     // 迁移原 POST /minutes/:id/summary 的多版本管理逻辑
     // 确保旧的 isLatest 为 false，新总结版本号递增
-    return this.meetingSummaryRepository.createExternalForRecording(
+    return this.meetingSummaryRepository.saveNewVersion(
       minuteId,
       data as unknown as CreateRecordingSummaryDto,
     );

--- a/src/minute/services/speaker-summary-crud.service.ts
+++ b/src/minute/services/speaker-summary-crud.service.ts
@@ -55,7 +55,7 @@ export class SpeakerSummaryCrudService {
 
   async delete(minuteId: string, id: string) {
     await this.findById(minuteId, id);
-    const data = await this.summaries.softDelete(minuteId, id);
+    const data = await this.summaries.delete(minuteId, id);
     return { success: true, data };
   }
 }

--- a/src/tencent-mtg/services/summary-core.service.ts
+++ b/src/tencent-mtg/services/summary-core.service.ts
@@ -22,7 +22,7 @@ export class TencentMtgSummaryCoreService {
     aiMinutes?: string,
     actionItems?: string,
   ) {
-    return await this.meetingSummaryService.upsert({
+    return await this.meetingSummaryService.updateCurrentVersion({
       minuteId,
       content: fullSummary || '',
       aiMinutes: aiMinutes ? { content: aiMinutes } : undefined,
@@ -57,7 +57,7 @@ export class TencentMtgSummaryCoreService {
       return;
     }
 
-    await this.meetingSummaryService.upsert({
+    await this.meetingSummaryService.updateCurrentVersion({
       minuteId: minuteId,
       content: content.fullSummary || '',
       aiMinutes: content.aiMinutes ? { content: content.aiMinutes } : undefined,

--- a/src/tencent-mtg/services/summary-core.service.ts
+++ b/src/tencent-mtg/services/summary-core.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { MinuteSummaryService } from '@/minute/services';
-import { GenerationMethod, ProcessingStatus } from '@prisma/client';
+import { GenerationMethod } from '@prisma/client';
 import { SummaryService as ApiSummaryService } from '@/integrations/tencent-meeting/services/meeting-summary.service';
 
 @Injectable()
@@ -29,8 +29,6 @@ export class TencentMtgSummaryCoreService {
       actionItems: actionItems ? { items: actionItems } : undefined,
       generatedBy: GenerationMethod.AI,
       aiModel: 'tencent-meeting-ai',
-      status: ProcessingStatus.COMPLETED,
-      language: 'zh-CN',
       version: 1,
       isLatest: true,
     });
@@ -64,8 +62,6 @@ export class TencentMtgSummaryCoreService {
       actionItems: content.todo ? { items: content.todo } : undefined,
       generatedBy: GenerationMethod.AI,
       aiModel: 'tencent-meeting-ai',
-      status: ProcessingStatus.COMPLETED,
-      language: 'zh-CN',
       version: 1,
       isLatest: true,
     });


### PR DESCRIPTION
- **refactor: remove soft delete and unused metadata fields from minute and speaker summaries**
- **refactor: remove redundant status, language, and processing time fields from minute summary entities and DTOs**
- **refactor: remove unused ProcessingStatus import from minute summaries seed script**
- **refactor: drop unused columns from summary tables and update index and constraint schemas**
