### PR TITLE
fix(permission): sync API key scopes and role grants

### DIFF
--- a/prisma/seed-utils/database-seed.ts
+++ b/prisma/seed-utils/database-seed.ts
@@ -39,6 +39,9 @@ async function seedRealDatabase(prisma: PrismaClient): Promise<void> {
   log('  2: 创建角色');
   const roles = await seedFunctions.createRoles(prisma, true, organization.id);
 
+  log('  3: 分配角色权限');
+  await seedFunctions.assignRolePermissions(prisma, permissions, roles);
+
   log(`\n🏢 organization: ${organization.name}`);
   log(
     `\n🏢 permissions: ${permissions.map((permission) => permission.name).join(', ')}`,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -34,7 +34,14 @@ async function main(): Promise<void> {
 
     switch (moduleName) {
       case 'permissions':
-        await seedFunctions.createPermissions(prisma, mode === 'real');
+        {
+          const permissions = await seedFunctions.createPermissions(
+            prisma,
+            mode === 'real',
+          );
+          const roles = await prisma.role.findMany();
+          await seedFunctions.assignRolePermissions(prisma, permissions, roles);
+        }
         break;
       case 'products':
         await seedFunctions.createProducts(prisma);

--- a/src/admin/api-key/controllers/api-key.controller.spec.ts
+++ b/src/admin/api-key/controllers/api-key.controller.spec.ts
@@ -91,12 +91,15 @@ describe('ApiKeyController', () => {
   });
 
   it('uses the dedicated permission for each API Key mutation', () => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.updateKey)).toEqual([
       'api-key:update',
     ]);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.revokeKey)).toEqual([
       'api-key:revoke',
     ]);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.rotateKey)).toEqual([
       'api-key:rotate',
     ]);

--- a/src/admin/api-key/controllers/api-key.controller.spec.ts
+++ b/src/admin/api-key/controllers/api-key.controller.spec.ts
@@ -4,6 +4,7 @@ import { ApiKeyService } from '../services/api-key.service';
 import { UserOrgService } from '../services/user-organization.service';
 import { ApiKeyStatus } from '@prisma/client';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PERMISSIONS_KEY } from '@/admin/permission/decorators/permissions.decorator';
 
 describe('ApiKeyController', () => {
   let controller: ApiKeyController;
@@ -87,6 +88,18 @@ describe('ApiKeyController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('uses the dedicated permission for each API Key mutation', () => {
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.updateKey)).toEqual([
+      'api-key:update',
+    ]);
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.revokeKey)).toEqual([
+      'api-key:revoke',
+    ]);
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.rotateKey)).toEqual([
+      'api-key:rotate',
+    ]);
   });
 
   describe('createKey', () => {

--- a/src/admin/api-key/controllers/api-key.controller.ts
+++ b/src/admin/api-key/controllers/api-key.controller.ts
@@ -171,7 +171,7 @@ export class ApiKeyController {
     status: 404,
     description: 'API Key 不存在',
   })
-  @RequirePermissions('api-key:update')
+  @RequirePermissions('api-key:revoke')
   async revokeKey(
     @User() user: CurrentUser,
     @Param('id') id: string,
@@ -208,7 +208,7 @@ export class ApiKeyController {
     status: 404,
     description: 'API Key 不存在',
   })
-  @RequirePermissions('api-key:update')
+  @RequirePermissions('api-key:rotate')
   async rotateKey(
     @User() user: CurrentUser,
     @Param('id') id: string,


### PR DESCRIPTION
## Summary

- enforce dedicated revoke and rotate permission scopes for API Key mutations
- sync role-permission relations when running the permissions seed module
- include role grants in the real-data seed flow
- add controller permission metadata regression coverage

## Validation

- `pnpm test:unit --runInBand src/admin/api-key/controllers/api-key.controller.spec.ts`
- `pnpm build`
- local permission seed and database relation verification

## Paired frontend PR

- https://github.com/lulabs-org/nove-admin/pull/104