### PR TITLE
feat(minute): 完善参会者总结创建元数据

### DIFF
--- a/src/minute/controllers/speaker-summary.controller.ts
+++ b/src/minute/controllers/speaker-summary.controller.ts
@@ -41,6 +41,7 @@ export class SpeakerSummaryController {
 
   @Get()
   @RequirePermissions('speaker-summary:read')
+  @ApiOperation({ summary: '获取参会者总结列表' })
   @ApiResponse({
     status: HttpStatus.OK,
     type: SpeakerSummaryListResponseDto,
@@ -55,6 +56,7 @@ export class SpeakerSummaryController {
 
   @Get(':summaryId')
   @RequirePermissions('speaker-summary:read')
+  @ApiOperation({ summary: '获取参会者总结详情' })
   @ApiResponse({ status: HttpStatus.OK, type: SpeakerSummaryDto })
   get(
     @Param('minuteId', CuidPipe) minuteId: string,
@@ -66,7 +68,7 @@ export class SpeakerSummaryController {
   @Post()
   @RequirePermissions('speaker-summary:create')
   @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ summary: '为录制中的参会者创建新总结版本' })
+  @ApiOperation({ summary: '创建参会者总结' })
   create(
     @Param('minuteId', CuidPipe) minuteId: string,
     @Body(new ValidationPipe()) dto: CreateSpeakerSummaryDto,
@@ -76,6 +78,7 @@ export class SpeakerSummaryController {
 
   @Put(':summaryId')
   @RequirePermissions('speaker-summary:update')
+  @ApiOperation({ summary: '更新参会者总结' })
   update(
     @Param('minuteId', CuidPipe) minuteId: string,
     @Param('summaryId', CuidPipe) summaryId: string,
@@ -86,6 +89,7 @@ export class SpeakerSummaryController {
 
   @Delete(':summaryId')
   @RequirePermissions('speaker-summary:delete')
+  @ApiOperation({ summary: '删除参会者总结' })
   delete(
     @Param('minuteId', CuidPipe) minuteId: string,
     @Param('summaryId', CuidPipe) summaryId: string,

--- a/src/minute/dto/speaker-summary.dto.spec.ts
+++ b/src/minute/dto/speaker-summary.dto.spec.ts
@@ -1,0 +1,32 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { GenerationMethod } from '@prisma/client';
+import { CreateSpeakerSummaryDto } from './speaker-summary.dto';
+
+const validSummary = {
+  platformUserId: 'cmt4uz61o0000cc0dnqdq1lza',
+  partSummary: '参会者总结',
+};
+
+describe('CreateSpeakerSummaryDto', () => {
+  it('accepts a supported generation method and AI model', async () => {
+    const dto = plainToInstance(CreateSpeakerSummaryDto, {
+      ...validSummary,
+      generatedBy: GenerationMethod.AI,
+      aiModel: 'gpt-4o',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects an unsupported generation method', async () => {
+    const dto = plainToInstance(CreateSpeakerSummaryDto, {
+      ...validSummary,
+      generatedBy: 'UNKNOWN',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.map((error) => error.property)).toContain('generatedBy');
+  });
+});

--- a/src/minute/dto/speaker-summary.dto.ts
+++ b/src/minute/dto/speaker-summary.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
+  IsEnum,
   IsInt,
   IsOptional,
   IsString,
@@ -9,25 +10,62 @@ import {
   Min,
 } from 'class-validator';
 
+import { GenerationMethod } from '@prisma/client';
+
 export class CreateSpeakerSummaryDto {
-  @ApiProperty({ description: '平台用户 ID' })
+  @ApiProperty({
+    description: '平台用户 ID',
+    example: 'cmt4uz61o0000cc0dnqdq1lza',
+  })
   @IsString()
   platformUserId: string;
 
-  @ApiProperty({ description: '总结正文' })
+  @ApiProperty({
+    description: '总结正文',
+    example: '张三在会议中汇报了上周的工作进展，并提出了下周的计划。',
+  })
   @IsString()
   partSummary: string;
 
-  @ApiPropertyOptional({ type: [String] })
+  @ApiPropertyOptional({
+    description: '提取的关键词列表',
+    type: [String],
+    example: ['工作进展', '下周计划'],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   keywords?: string[];
+
+  @ApiPropertyOptional({
+    description: '生成方式 (留空则默认为 MANUAL)',
+    enum: GenerationMethod,
+    example: GenerationMethod.AI,
+  })
+  @IsOptional()
+  @IsEnum(GenerationMethod)
+  generatedBy?: GenerationMethod;
+
+  @ApiPropertyOptional({ description: '使用的 AI 模型', example: 'gpt-4o' })
+  @IsOptional()
+  @IsString()
+  aiModel?: string;
 }
 
 export class UpdateSpeakerSummaryDto {
-  @ApiPropertyOptional() @IsOptional() @IsString() partSummary?: string;
-  @ApiPropertyOptional({ type: [String] })
+  @ApiPropertyOptional({
+    description: '总结正文',
+    example: '更新后的总结正文...',
+  })
+  @IsOptional()
+  @IsString()
+  partSummary?: string;
+
+  @ApiPropertyOptional({
+    description: '提取的关键词列表',
+    type: [String],
+    example: ['更新', '关键词'],
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
@@ -50,25 +88,72 @@ export class QuerySpeakerSummaryDto {
 }
 
 export class SpeakerSummaryDto {
-  @ApiProperty() id: string;
-  @ApiProperty() minuteId: string;
-  @ApiProperty() platformUserId: string;
+  @ApiProperty({
+    description: '总结记录唯一ID',
+    example: 'cmt4uz6280004cc0d6valv3tj',
+  })
+  id: string;
 
-  @ApiProperty() partSummary: string;
-  @ApiProperty({ type: [String] }) keywords: string[];
-  @ApiProperty() version: number;
-  @ApiProperty() isLatest: boolean;
-  @ApiProperty() createdAt: Date;
-  @ApiProperty() updatedAt: Date;
+  @ApiProperty({
+    description: '所属录制记录ID',
+    example: 'cmt4uz6230002cc0dkoq8r8d5',
+  })
+  minuteId: string;
+
+  @ApiProperty({
+    description: '平台用户ID',
+    example: 'cmt4uz61o0000cc0dnqdq1lza',
+  })
+  platformUserId: string;
+
+  @ApiProperty({
+    description: '参会者总结正文',
+    example: '张三在会议中汇报了上周的工作进展，并提出了下周的计划。',
+  })
+  partSummary: string;
+
+  @ApiProperty({
+    description: '总结提取的关键词',
+    type: [String],
+    example: ['工作进展', '下周计划'],
+  })
+  keywords: string[];
+
+  @ApiPropertyOptional({
+    description: '总结生成方式',
+    enum: GenerationMethod,
+    example: GenerationMethod.AI,
+  })
+  generatedBy?: GenerationMethod;
+
+  @ApiPropertyOptional({
+    description: '处理该总结的AI模型名称',
+    example: 'tencent-meeting-ai',
+  })
+  aiModel?: string;
+
+  @ApiProperty({ description: '记录创建时间' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '记录最后更新时间' })
+  updatedAt: Date;
 }
 
 export class SpeakerSummaryListResponseDto {
-  @ApiProperty({ type: [SpeakerSummaryDto] })
+  @ApiProperty({ description: '总结数据列表', type: [SpeakerSummaryDto] })
   data: SpeakerSummaryDto[];
-  @ApiProperty() total: number;
-  @ApiProperty() page: number;
-  @ApiProperty() limit: number;
-  @ApiProperty() totalPages: number;
+
+  @ApiProperty({ description: '符合条件的总记录数', example: 1 })
+  total: number;
+
+  @ApiProperty({ description: '当前页码', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: '每页条数', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: '总页数', example: 1 })
+  totalPages: number;
 }
 
 export class GenerateParticipantSummaryDto {

--- a/src/minute/services/speaker-summary-crud.service.ts
+++ b/src/minute/services/speaker-summary-crud.service.ts
@@ -38,7 +38,8 @@ export class SpeakerSummaryCrudService {
     return this.summaries.upsert({
       ...data,
       minuteId: minuteId,
-      generatedBy: GenerationMethod.MANUAL,
+      generatedBy: data.generatedBy ?? GenerationMethod.MANUAL,
+      aiModel: data.aiModel ?? null,
     });
   }
 


### PR DESCRIPTION
## Summary

- accept optional `generatedBy` and `aiModel` metadata when creating a speaker summary, with `MANUAL` as the default generation method
- validate generation methods against the Prisma enum and document speaker-summary CRUD operations and payloads in Swagger
- align the response DTO with the simplified speaker-summary schema and add focused DTO validation coverage

## Validation

- `pnpm exec eslint src/minute/controllers/speaker-summary.controller.ts src/minute/dto/speaker-summary.dto.ts src/minute/dto/speaker-summary.dto.spec.ts src/minute/services/speaker-summary-crud.service.ts`
- `pnpm test:unit -- --runInBand src/minute/dto/speaker-summary.dto.spec.ts src/minute/repositories/speaker-summary.repository.spec.ts src/minute/services/speaker-summary.service.spec.ts` (3 suites, 8 tests)
- `pnpm run build`

## Related PRs

- Companion admin publication: https://github.com/lulabs-org/nove-admin/pull/106