### PR TITLE
feat(minute): allow updating speaker summary metadata

### DIFF
--- a/src/minute/dto/speaker-summary.dto.ts
+++ b/src/minute/dto/speaker-summary.dto.ts
@@ -70,6 +70,20 @@ export class UpdateSpeakerSummaryDto {
   @IsArray()
   @IsString({ each: true })
   keywords?: string[];
+
+  @ApiPropertyOptional({
+    description: '生成方式',
+    enum: GenerationMethod,
+    example: GenerationMethod.AI,
+  })
+  @IsOptional()
+  @IsEnum(GenerationMethod)
+  generatedBy?: GenerationMethod;
+
+  @ApiPropertyOptional({ description: '使用的 AI 模型', example: 'gpt-4o' })
+  @IsOptional()
+  @IsString()
+  aiModel?: string;
 }
 
 export class QuerySpeakerSummaryDto {

--- a/src/minute/services/speaker-summary-crud.service.ts
+++ b/src/minute/services/speaker-summary-crud.service.ts
@@ -52,7 +52,8 @@ export class SpeakerSummaryCrudService {
     return this.summaries.update(summaryId, {
       partSummary: data.partSummary ?? current.partSummary,
       keywords: data.keywords ?? current.keywords,
-      generatedBy: GenerationMethod.MANUAL,
+      generatedBy: data.generatedBy ?? current.generatedBy,
+      aiModel: data.aiModel ?? current.aiModel,
     });
   }
 


### PR DESCRIPTION
## Summary

- expose `generatedBy` and `aiModel` on speaker-summary updates
- preserve existing generation metadata when those fields are omitted
- allow external AI workflows to update summary content together with generation metadata

## Validation

- `pnpm exec prettier --check src/minute/dto/speaker-summary.dto.ts src/minute/services/speaker-summary-crud.service.ts`
- `pnpm exec eslint src/minute/dto/speaker-summary.dto.ts src/minute/services/speaker-summary-crud.service.ts`
- `pnpm build`
- `pnpm test:unit --runInBand` (51 suites, 315 tests passed)
- `git diff --cached --check`

## Related PRs

- None; no corresponding changes were found in the other Nove repositories.