### PR TITLE
feat(tracking-report): add generic report hub schema

### DIFF
--- a/prisma/migrations/20260823115932_generic_tracking_report_hub/migration.sql
+++ b/prisma/migrations/20260823115932_generic_tracking_report_hub/migration.sql
@@ -1,0 +1,81 @@
+-- CreateEnum
+CREATE TYPE "TrackingTargetType" AS ENUM ('USER', 'PLATFORM_USER', 'PROJECT', 'ORGANIZATION');
+
+-- CreateEnum
+CREATE TYPE "TargetTrackingReportType" AS ENUM ('MEETING_SUMMARY', 'TRAINING_PLAN', 'DEVELOPMENT_PLAN', 'PROJECT_PROGRESS', 'USER_PROFILE');
+
+-- CreateEnum
+CREATE TYPE "TrackingSourceType" AS ENUM ('SPEAKER_SUMMARY', 'TRACKING_REPORT', 'DOCUMENT', 'MEETING');
+
+-- CreateEnum
+CREATE TYPE "TrackingReportCadence" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY');
+
+-- CreateTable
+CREATE TABLE "tracking_reports" (
+    "id" TEXT NOT NULL,
+    "target_id" TEXT NOT NULL,
+    "tracking_type" "TargetTrackingReportType" NOT NULL,
+    "cadence" "TrackingReportCadence" NOT NULL,
+    "period_key" VARCHAR(50),
+    "period_start" TIMESTAMPTZ(6) NOT NULL,
+    "period_end" TIMESTAMPTZ(6) NOT NULL,
+    "timezone" VARCHAR(100) NOT NULL DEFAULT 'Asia/Shanghai',
+    "content" TEXT NOT NULL,
+    "generated_by" "GenerationMethod",
+    "ai_model" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+    "deleted_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "tracking_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tracking_report_sources" (
+    "id" TEXT NOT NULL,
+    "report_id" TEXT NOT NULL,
+    "source_type" "TrackingSourceType" NOT NULL,
+    "source_id" TEXT NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "tracking_report_sources_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tracking_targets" (
+    "id" TEXT NOT NULL,
+    "target_type" "TrackingTargetType" NOT NULL,
+    "target_id" TEXT NOT NULL,
+    "name_snapshot" VARCHAR(100) NOT NULL,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "tracking_targets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "tracking_reports_target_id_tracking_type_period_start_idx" ON "tracking_reports"("target_id", "tracking_type", "period_start");
+
+-- CreateIndex
+CREATE INDEX "tracking_reports_tracking_type_cadence_period_start_idx" ON "tracking_reports"("tracking_type", "cadence", "period_start");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_tracking_report_period" ON "tracking_reports"("target_id", "tracking_type", "period_key");
+
+-- CreateIndex
+CREATE INDEX "tracking_report_sources_source_type_source_id_idx" ON "tracking_report_sources"("source_type", "source_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tracking_report_sources_report_id_source_type_source_id_key" ON "tracking_report_sources"("report_id", "source_type", "source_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tracking_targets_target_type_target_id_key" ON "tracking_targets"("target_type", "target_id");
+
+-- AddForeignKey
+ALTER TABLE "tracking_reports" ADD CONSTRAINT "tracking_reports_target_id_fkey" FOREIGN KEY ("target_id") REFERENCES "tracking_targets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tracking_report_sources" ADD CONSTRAINT "tracking_report_sources_report_id_fkey" FOREIGN KEY ("report_id") REFERENCES "tracking_reports"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/models/tracking_report.prisma
+++ b/prisma/models/tracking_report.prisma
@@ -1,0 +1,116 @@
+model TrackingReport {
+  id String @id @default(cuid())
+
+  targetId String         @map("target_id")
+  target   TrackingTarget @relation(fields: [targetId], references: [id], onDelete: Cascade)
+
+  trackingType TargetTrackingReportType @map("tracking_type")
+  cadence      TrackingReportCadence
+  /// 周期标识，用于防重和分组查询。例如："2026-08-15" (日), "2026-W34" (周), "2026-08" (月), "2026-Q3" (季), "2026" (年)
+  periodKey    String?                  @map("period_key") @db.VarChar(50)
+  periodStart  DateTime                 @map("period_start") @db.Timestamptz(6)
+  periodEnd    DateTime                 @map("period_end") @db.Timestamptz(6)
+  timezone     String                   @default("Asia/Shanghai") @db.VarChar(100)
+  content      String                   @db.Text
+  generatedBy  GenerationMethod?        @map("generated_by")
+  aiModel      String?                  @map("ai_model")
+
+  sources TrackingReportSource[]
+
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+
+  @@unique([targetId, trackingType, periodKey], map: "uq_tracking_report_period")
+  @@index([targetId, trackingType, periodStart])
+  @@index([trackingType, cadence, periodStart])
+  @@map("tracking_reports")
+}
+
+model TrackingReportSource {
+  id String @id @default(cuid())
+
+  reportId String         @map("report_id")
+  report   TrackingReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+
+  sourceType TrackingSourceType @map("source_type")
+  sourceId   String             @map("source_id")
+
+  metadata  Json     @default("{}") @db.JsonB
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@unique([reportId, sourceType, sourceId])
+  @@index([sourceType, sourceId])
+  @@map("tracking_report_sources")
+}
+
+model TrackingTarget {
+  id String @id @default(cuid())
+
+  targetType TrackingTargetType @map("target_type")
+  targetId   String             @map("target_id")
+
+  nameSnapshot String @map("name_snapshot") @db.VarChar(100)
+  metadata     Json   @default("{}") @db.JsonB
+
+  reports TrackingReport[]
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@unique([targetType, targetId])
+  @@map("tracking_targets")
+}
+
+/// 追踪目标类型（Hub的聚焦点）
+enum TrackingTargetType {
+  /// 本地用户
+  USER
+  /// 平台用户（外部接入）
+  PLATFORM_USER
+  /// 项目
+  PROJECT
+  /// 组织/团队
+  ORGANIZATION
+}
+
+/// 追踪报告类型
+enum TargetTrackingReportType {
+  /// 会议总结
+  MEETING_SUMMARY
+  /// 培训计划
+  TRAINING_PLAN
+  /// 培养方案
+  DEVELOPMENT_PLAN
+  /// 项目进度
+  PROJECT_PROGRESS
+  /// 用户画像
+  USER_PROFILE
+}
+
+/// 追踪引用来源的类型
+enum TrackingSourceType {
+  /// 个人发言总结
+  SPEAKER_SUMMARY
+  /// 历史追踪报告
+  TRACKING_REPORT
+  /// 文档/文件
+  DOCUMENT
+  /// 会议记录
+  MEETING
+}
+
+/// 追踪频率（周期）
+enum TrackingReportCadence {
+  /// 每日
+  DAILY
+  /// 每周
+  WEEKLY
+  /// 每月
+  MONTHLY
+  /// 每季度
+  QUARTERLY
+  /// 每年
+  YEARLY
+}

--- a/prisma/models/user_tracking_report.prisma
+++ b/prisma/models/user_tracking_report.prisma
@@ -1,19 +1,3 @@
-enum TrackingReportType {
-  PERIODIC_MEETING_SUMMARY
-  TRAINING_PLAN
-  PROJECT_PROGRESS
-  USER_PROFILE
-}
-
-enum TrackingCadence {
-  DAILY
-  WEEKLY
-  MONTHLY
-  QUARTERLY
-  YEARLY
-  CUSTOM
-}
-
 model UserTrackingReport {
   id             String        @id @default(cuid())
   subjectUserId  String?       @map("subject_user_id")
@@ -83,4 +67,27 @@ model TrackingReportSourceReport {
   @@unique([reportId, sourceReportId])
   @@index([sourceReportId])
   @@map("tracking_report_source_reports")
+}
+
+/// 追踪频率（周期）
+enum TrackingCadence {
+  /// 每日
+  DAILY
+  /// 每周
+  WEEKLY
+  /// 每月
+  MONTHLY
+  /// 每季度
+  QUARTERLY
+  /// 每年
+  YEARLY
+  /// 自定义
+  CUSTOM
+}
+
+enum TrackingReportType {
+  PERIODIC_MEETING_SUMMARY
+  TRAINING_PLAN
+  PROJECT_PROGRESS
+  USER_PROFILE
 }

--- a/prisma/seeds/refunds/refunds.ts
+++ b/prisma/seeds/refunds/refunds.ts
@@ -41,8 +41,10 @@ export async function createRefunds(
     const refundPromises = REFUND_CONFIGS.map((config) => {
       const createInput = convertToRefundCreateInput(config);
 
-      return prisma.orderRefund.create({
-        data: createInput,
+      return prisma.orderRefund.upsert({
+        where: { afterSaleCode: createInput.afterSaleCode },
+        create: createInput,
+        update: createInput,
       });
     });
 

--- a/scripts/ts/migrate-to-generic-tracking-reports.ts
+++ b/scripts/ts/migrate-to-generic-tracking-reports.ts
@@ -1,0 +1,175 @@
+/*
+ * @FilePath: /nove_api/scripts/ts/migrate-to-generic-tracking-reports.ts
+ * @Description: 数据迁移脚本，用于将旧的 user_tracking_reports 迁移为 Hub 模式的 tracking_targets 和 tracking_reports
+ *
+ * 运行方式:
+ * pnpm dlx tsx scripts/ts/migrate-to-generic-tracking-reports.ts
+ */
+
+import {
+  PrismaClient,
+  TrackingTargetType,
+  TrackingSourceType,
+  TrackingReportCadence,
+  TargetTrackingReportType,
+  TrackingReportType,
+} from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('开始迁移 Tracking Reports 数据...');
+
+  // 1. 获取所有旧的追踪报告
+  const oldReports = await prisma.userTrackingReport.findMany({
+    include: {
+      minuteSummarySources: true,
+      sourceReports: true,
+      derivedReports: true,
+    },
+  });
+
+  console.log(`共找到 ${oldReports.length} 条需要迁移的数据。`);
+
+  if (oldReports.length === 0) {
+    console.log('没有需要迁移的数据。');
+    return;
+  }
+
+  // 2. 遍历迁移数据
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const oldReport of oldReports) {
+    try {
+      // 确定 targetType 和 originalTargetId
+      let targetType: TrackingTargetType;
+      let targetId: string;
+
+      if (oldReport.subjectUserId) {
+        targetType = TrackingTargetType.USER;
+        targetId = oldReport.subjectUserId;
+      } else if (oldReport.platformUserId) {
+        targetType = TrackingTargetType.PLATFORM_USER;
+        targetId = oldReport.platformUserId;
+      } else if (oldReport.projectId) {
+        targetType = TrackingTargetType.PROJECT;
+        targetId = oldReport.projectId;
+      } else {
+        console.warn(`报告 ${oldReport.id} 没有关联任何主体，跳过迁移。`);
+        failCount++;
+        continue;
+      }
+
+      // 使用事务来确保数据一致性
+      await prisma.$transaction(async (tx) => {
+        // 第一步：确保 TrackingTarget 存在 (Hub)
+        const trackingTarget = await tx.trackingTarget.upsert({
+          where: {
+            targetType_targetId: {
+              targetType,
+              targetId,
+            },
+          },
+          update: {
+            // 如果存在，可以决定是否更新 nameSnapshot
+            nameSnapshot: oldReport.subjectNameSnapshot,
+          },
+          create: {
+            targetType,
+            targetId,
+            nameSnapshot: oldReport.subjectNameSnapshot,
+            metadata: {}, // 可以扩展存入其他信息
+          },
+        });
+
+        const trackingTypeMap: Record<
+          TrackingReportType,
+          TargetTrackingReportType
+        > = {
+          [TrackingReportType.PERIODIC_MEETING_SUMMARY]:
+            TargetTrackingReportType.MEETING_SUMMARY,
+          [TrackingReportType.TRAINING_PLAN]:
+            TargetTrackingReportType.TRAINING_PLAN,
+          [TrackingReportType.PROJECT_PROGRESS]:
+            TargetTrackingReportType.PROJECT_PROGRESS,
+          [TrackingReportType.USER_PROFILE]:
+            TargetTrackingReportType.USER_PROFILE,
+        };
+
+        // 提取通用字段，并构造新的 TrackingReport 记录
+        const newReportData = {
+          id: oldReport.id, // 保持 ID 一致
+          targetId: trackingTarget.id, // 使用真实的代理外键
+          trackingType: trackingTypeMap[oldReport.trackingType],
+          cadence: oldReport.cadence as string as TrackingReportCadence,
+          periodStart: oldReport.periodStart,
+          periodEnd: oldReport.periodEnd,
+          timezone: oldReport.timezone,
+          content: oldReport.content,
+          generatedBy: oldReport.generatedBy,
+          aiModel: oldReport.aiModel,
+          createdAt: oldReport.createdAt,
+          updatedAt: oldReport.updatedAt,
+          deletedAt: oldReport.deletedAt,
+        };
+
+        // 插入主报告表
+        await tx.trackingReport.create({
+          data: newReportData,
+        });
+
+        // 迁移 MinuteSummarySources 关联表
+        if (oldReport.minuteSummarySources.length > 0) {
+          await tx.trackingReportSource.createMany({
+            data: oldReport.minuteSummarySources.map((source) => ({
+              id: source.id,
+              reportId: source.reportId,
+              sourceType: TrackingSourceType.SPEAKER_SUMMARY,
+              sourceId: source.minuteSummaryId,
+              metadata: source.metadata as object,
+              createdAt: source.createdAt,
+            })),
+            skipDuplicates: true,
+          });
+        }
+
+        // 迁移 SourceReports 关联表
+        if (oldReport.sourceReports.length > 0) {
+          await tx.trackingReportSource.createMany({
+            data: oldReport.sourceReports.map((source) => ({
+              id: source.id,
+              reportId: source.reportId,
+              sourceType: TrackingSourceType.TRACKING_REPORT,
+              sourceId: source.sourceReportId,
+              metadata: source.metadata as object,
+              createdAt: source.createdAt,
+            })),
+            skipDuplicates: true,
+          });
+        }
+      });
+
+      successCount++;
+      if (successCount % 100 === 0) {
+        console.log(`已成功迁移 ${successCount} 条记录...`);
+      }
+    } catch (error) {
+      console.error(`迁移报告 ${oldReport.id} 失败:`, error);
+      failCount++;
+    }
+  }
+
+  console.log('数据迁移完成！');
+  console.log(`成功: ${successCount}`);
+  console.log(`失败/跳过: ${failCount}`);
+}
+
+main()
+  .catch((e) => {
+    console.error('迁移脚本执行出错:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

- add generic tracking targets, reports, sources, and cadence/type enums
- add the Prisma migration and a legacy user tracking report migration script
- make refund seed creation idempotent through upsert

## Validation

- pnpm exec prisma format --check
- pnpm db:generate
- pnpm build
- pnpm exec prisma validate
- pnpm test:e2e -- --runInBand test/e2e/tracking-report.e2e-spec.ts (5 tests passed; existing Feishu WebSocket handle warning after completion)
- git diff --cached --check

## Related PRs

- None (API-only change)