### PR TITLE
fix(meeting): correct resource OpenAPI contracts

### DIFF
--- a/src/meeting/dto/meeting-participant.dto.ts
+++ b/src/meeting/dto/meeting-participant.dto.ts
@@ -34,18 +34,30 @@ export class MeetingParticipantPlatformUserDto {
   @ApiProperty({ description: '平台', enum: Platform })
   platform: Platform;
 
-  @ApiPropertyOptional({ description: '显示名称', nullable: true })
+  @ApiPropertyOptional({
+    description: '显示名称',
+    type: String,
+    nullable: true,
+  })
   displayName: string | null;
 
-  @ApiPropertyOptional({ description: '头像', nullable: true })
+  @ApiPropertyOptional({ description: '头像', type: String, nullable: true })
   avatarUrl: string | null;
 }
 
 export class MeetingParticipantUserProfileDto {
-  @ApiPropertyOptional({ description: '用户资料显示名', nullable: true })
+  @ApiPropertyOptional({
+    description: '用户资料显示名',
+    type: String,
+    nullable: true,
+  })
   displayName: string | null;
 
-  @ApiPropertyOptional({ description: '用户资料头像', nullable: true })
+  @ApiPropertyOptional({
+    description: '用户资料头像',
+    type: String,
+    nullable: true,
+  })
   avatar: string | null;
 }
 
@@ -53,16 +65,24 @@ export class MeetingParticipantUserDto {
   @ApiProperty({ description: '本地用户 ID（users.id）' })
   id: string;
 
-  @ApiPropertyOptional({ description: '登录用户名', nullable: true })
+  @ApiPropertyOptional({
+    description: '登录用户名',
+    type: String,
+    nullable: true,
+  })
   username: string | null;
 
-  @ApiPropertyOptional({ description: '邮箱', nullable: true })
+  @ApiPropertyOptional({ description: '邮箱', type: String, nullable: true })
   email: string | null;
 
-  @ApiPropertyOptional({ description: '国家代码', nullable: true })
+  @ApiPropertyOptional({
+    description: '国家代码',
+    type: String,
+    nullable: true,
+  })
   countryCode: string | null;
 
-  @ApiPropertyOptional({ description: '手机号', nullable: true })
+  @ApiPropertyOptional({ description: '手机号', type: String, nullable: true })
   phone: string | null;
 
   @ApiPropertyOptional({
@@ -79,13 +99,27 @@ export class MeetingParticipantDto {
   @ApiProperty({ description: '会议 ID' })
   meetingId: string;
 
-  @ApiPropertyOptional({ description: '首次入会时间', nullable: true })
+  @ApiPropertyOptional({
+    description: '首次入会时间',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
   firstJoinTime: Date | null;
 
-  @ApiPropertyOptional({ description: '最后离会时间', nullable: true })
+  @ApiPropertyOptional({
+    description: '最后离会时间',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
   lastLeaveTime: Date | null;
 
-  @ApiPropertyOptional({ description: '累计参会时长（秒）', nullable: true })
+  @ApiPropertyOptional({
+    description: '累计参会时长（秒）',
+    type: Number,
+    nullable: true,
+  })
   totalDurationSeconds: number | null;
 
   @ApiPropertyOptional({

--- a/src/minute/dto/speaker-summary.dto.ts
+++ b/src/minute/dto/speaker-summary.dto.ts
@@ -87,12 +87,25 @@ export class UpdateSpeakerSummaryDto {
 }
 
 export class QuerySpeakerSummaryDto {
+  @ApiPropertyOptional({
+    description: '页码',
+    type: Number,
+    default: 1,
+    minimum: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page = 1;
 
+  @ApiPropertyOptional({
+    description: '每页数量',
+    type: Number,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()


### PR DESCRIPTION
## Summary

- describe nullable participant identity fields as strings instead of generic objects
- expose participant join/leave timestamps as `date-time` strings and duration as a number
- publish numeric Swagger schemas for speaker-summary pagination parameters
- keep runtime validation and persistence behavior unchanged

## Validation

- `pnpm build` — passed
- `pnpm test:unit -- --runInBand src/meeting src/minute` — 10 suites, 39 tests passed
- `pnpm test:unit -- --runInBand src/minute/dto/speaker-summary.dto.spec.ts` — 2 tests passed
- `pnpm exec eslint src/meeting/dto/meeting-participant.dto.ts src/minute/dto/speaker-summary.dto.ts --max-warnings=0` — passed
- `git diff --check` — passed
- live `/api-json` inspection confirmed string/date-time/number participant fields and numeric `page`/`limit` query schemas

## Related PRs

- Frontend meeting detail companion: https://github.com/lulabs-org/nove-admin/pull/110
