### PR TITLE
feat(auth): align CLI validation and meeting query contracts

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,25 @@
+import { RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { AuthController } from './auth.controller';
+import { REQUIRE_AUTH_KEY } from './decorators/require-auth.decorator';
+
+describe('AuthController API key validation', () => {
+  it('exposes an API-key-only validation endpoint', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      AuthController.prototype,
+      'validateApiKey',
+    );
+    const handler = descriptor?.value as () => { authenticated: true };
+
+    expect(Reflect.getMetadata(PATH_METADATA, handler)).toBe(
+      'api-key/validate',
+    );
+    expect(Reflect.getMetadata(METHOD_METADATA, handler)).toBe(
+      RequestMethod.GET,
+    );
+    expect(Reflect.getMetadata(REQUIRE_AUTH_KEY, handler)).toEqual(['api_key']);
+    expect(handler()).toEqual({
+      authenticated: true,
+    });
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -374,6 +374,14 @@ export class AuthController {
     };
   }
 
+  @Get('api-key/validate')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @RequireAuth('api_key')
+  validateApiKey(): { authenticated: true } {
+    return { authenticated: true };
+  }
+
   @Get('permissions')
   @HttpCode(HttpStatus.OK)
   @ApiGetPermissionsDocs()

--- a/src/meeting/controllers/meeting.controller.spec.ts
+++ b/src/meeting/controllers/meeting.controller.spec.ts
@@ -38,6 +38,16 @@ describe('MeetingController', () => {
     expect(meetingService.getStats).not.toHaveBeenCalled();
   });
 
+  it('rejects an empty statistics date range before querying', async () => {
+    await expect(
+      controller.getMeetingStats({
+        startDate: '2026-08-24T00:00:00.000+08:00',
+        endDate: '2026-08-24T00:00:00.000+08:00',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(meetingService.getStats).not.toHaveBeenCalled();
+  });
+
   it('returns the persisted soft-delete timestamp', async () => {
     const deletedAt = new Date('2026-08-13T01:00:00.000Z');
     const deletedRecord = { id: 'meeting-1', deletedAt };

--- a/src/meeting/controllers/meeting.controller.ts
+++ b/src/meeting/controllers/meeting.controller.ts
@@ -187,8 +187,8 @@ export class MeetingController {
     const startDate = query.startDate ? new Date(query.startDate) : undefined;
     const endDate = query.endDate ? new Date(query.endDate) : undefined;
 
-    if (startDate && endDate && startDate > endDate) {
-      throw new BadRequestException('startDate 不能晚于 endDate');
+    if (startDate && endDate && startDate >= endDate) {
+      throw new BadRequestException('startDate 必须早于 endDate');
     }
 
     this.logger.log('获取会议统计信息', query);

--- a/src/meeting/dto/meeting-record-update.dto.ts
+++ b/src/meeting/dto/meeting-record-update.dto.ts
@@ -7,7 +7,7 @@ import {
   Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingType } from '@prisma/client';
 import { Type } from 'class-transformer';
 
 export class UpdateMeetingRecordDto {
@@ -74,24 +74,6 @@ export class UpdateMeetingRecordDto {
   @IsInt({ message: '持续时间必须是整数' })
   @Min(0, { message: '持续时间不能小于0' })
   durationSeconds?: number;
-
-  @ApiPropertyOptional({
-    description: '录制状态',
-    enum: ProcessingStatus,
-    example: ProcessingStatus.COMPLETED,
-  })
-  @IsOptional()
-  @IsEnum(ProcessingStatus, { message: '无效的录制状态' })
-  recordingStatus?: ProcessingStatus;
-
-  @ApiPropertyOptional({
-    description: '处理状态',
-    enum: ProcessingStatus,
-    example: ProcessingStatus.COMPLETED,
-  })
-  @IsOptional()
-  @IsEnum(ProcessingStatus, { message: '无效的处理状态' })
-  processingStatus?: ProcessingStatus;
 
   @ApiPropertyOptional({
     description: '参会人数',

--- a/src/meeting/dto/meeting-record.dto.spec.ts
+++ b/src/meeting/dto/meeting-record.dto.spec.ts
@@ -57,6 +57,8 @@ describe('meeting record DTO contracts', () => {
       participantCount: 0,
       hostUserName: 'Ignored Host',
       participantList: [],
+      processingStatus: 'COMPLETED',
+      recordingStatus: 'COMPLETED',
     });
 
     const errors = await validateRequest(dto);
@@ -64,7 +66,12 @@ describe('meeting record DTO contracts', () => {
     expect(dto.durationSeconds).toBe(0);
     expect(dto.participantCount).toBe(0);
     expect(errors.map((error) => error.property)).toEqual(
-      expect.arrayContaining(['hostUserName', 'participantList']),
+      expect.arrayContaining([
+        'hostUserName',
+        'participantList',
+        'processingStatus',
+        'recordingStatus',
+      ]),
     );
   });
 });

--- a/src/meeting/repositories/meeting.repository.spec.ts
+++ b/src/meeting/repositories/meeting.repository.spec.ts
@@ -468,6 +468,20 @@ describe('MeetingRepository', () => {
         }),
       );
     });
+
+    it('uses an exclusive end date for half-open meeting ranges', async () => {
+      const startDate = new Date('2026-08-24T00:00:00.000+08:00');
+      const endDate = new Date('2026-08-25T00:00:00.000+08:00');
+      (prismaService.meeting.findMany as jest.Mock).mockResolvedValue([]);
+      (prismaService.meeting.count as jest.Mock).mockResolvedValue(0);
+
+      await repository.get({ startDate, endDate });
+
+      const [query] = prismaService.meeting.findMany.mock.calls.at(
+        -1,
+      ) as unknown as [{ where: { startAt: unknown } }];
+      expect(query.where.startAt).toEqual({ gte: startDate, lt: endDate });
+    });
   });
 
   describe('getStats', () => {
@@ -501,7 +515,7 @@ describe('MeetingRepository', () => {
       expect(prismaService.meeting.count).toHaveBeenCalledWith({
         where: {
           deletedAt: null,
-          startAt: { gte: startDate, lte: endDate },
+          startAt: { gte: startDate, lt: endDate },
         },
       });
       expect(prismaService.meeting.findMany).toHaveBeenCalledWith(

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -343,7 +343,7 @@ export class MeetingRepository {
         where.startAt.gte = startDate;
       }
       if (endDate) {
-        where.startAt.lte = endDate;
+        where.startAt.lt = endDate;
       }
     }
 
@@ -392,7 +392,7 @@ export class MeetingRepository {
         ? {
             startAt: {
               ...(params.startDate ? { gte: params.startDate } : {}),
-              ...(params.endDate ? { lte: params.endDate } : {}),
+              ...(params.endDate ? { lt: params.endDate } : {}),
             },
           }
         : {}),


### PR DESCRIPTION
## Summary

- add an API-key-only validation endpoint so CLI login can verify credentials before persisting them
- make meeting list and statistics date ranges consistently half-open (`startDate <= value < endDate`)
- reject empty date ranges and remove writable derived processing/recording status fields from meeting updates
- add focused controller, DTO, and repository coverage for these contracts

## Risk and compatibility

- clients that attempted to write derived meeting processing or recording statuses will now receive validation errors
- no database migration or environment variable changes are required

## Validation

- `pnpm exec jest --selectProjects unit --runInBand --runTestsByPath src/auth/auth.controller.spec.ts src/meeting/controllers/meeting.controller.spec.ts src/meeting/dto/meeting-record.dto.spec.ts src/meeting/repositories/meeting.repository.spec.ts` — 4 suites, 24 tests passed
- `pnpm exec eslint` on all 8 changed TypeScript files — passed
- `pnpm build` — passed
- `git diff --check` — passed

## Related PRs

- CLI: https://github.com/lulabs-org/nove-cli/pull/24