### PR TITLE
refactor(minute): derive statuses from resources

### DIFF
--- a/prisma/migrations/20260824061331_remove_has_recording/migration.sql
+++ b/prisma/migrations/20260824061331_remove_has_recording/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `has_recording` on the `minutes` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "minutes" DROP COLUMN "has_recording";

--- a/prisma/migrations/20260824062945_remove_status_processing_status/migration.sql
+++ b/prisma/migrations/20260824062945_remove_status_processing_status/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `processing_status` on the `minutes` table. All the data in the column will be lost.
+  - You are about to drop the column `status` on the `minutes` table. All the data in the column will be lost.
+
+*/
+-- Preserve the only status that cannot be derived from related resources.
+ALTER TABLE "minutes" ADD COLUMN "error_message" TEXT;
+
+UPDATE "minutes"
+SET "error_message" = 'Recording failed before status migration'
+WHERE "status" = 'FAILED';
+
+-- AlterTable
+ALTER TABLE "minutes" DROP COLUMN "processing_status",
+DROP COLUMN "status";
+
+-- DropEnum
+DROP TYPE "public"."ProcessingStatus";
+
+-- DropEnum
+DROP TYPE "public"."RecordingStatus";

--- a/prisma/models/meet.prisma
+++ b/prisma/models/meet.prisma
@@ -90,12 +90,3 @@ enum FileType {
   DOCUMENT // 文档
   OTHER // 其他类型
 }
-
-// 处理状态枚举
-enum ProcessingStatus {
-  PENDING // 待处理
-  PROCESSING // 处理中
-  COMPLETED // 已完成
-  FAILED // 处理失败
-  SKIPPED // 已跳过
-}

--- a/prisma/models/minute.prisma
+++ b/prisma/models/minute.prisma
@@ -3,11 +3,8 @@ model Minute {
   externalId String? @map("external_id") @db.VarChar(100) // 外部系统录制ID，用于唯一标识
 
   source RecordingSource @default(PLATFORM_AUTO)
-  status RecordingStatus @default(RECORDING)
-
-  // 处理状态
-  processingStatus ProcessingStatus @default(PENDING) @map("processing_status")
-  hasRecording     Boolean          @default(true) @map("has_recording")
+  // 错误信息（用于记录失败状态）
+  errorMessage String? @map("error_message")
 
   // 元数据
   metadata Json @default("{}") @db.JsonB
@@ -40,12 +37,4 @@ enum RecordingSource {
   PLATFORM_AUTO // 平台自动录制
   USER_MANUAL // 用户手动录制
   THIRD_PARTY // 第三方录制
-}
-
-// 录制状态枚举
-enum RecordingStatus {
-  RECORDING // 录制中
-  PROCESSING // 处理中
-  COMPLETED // 已完成
-  FAILED // 失败
 }

--- a/prisma/seeds/minutes/minutes/minutes.ts
+++ b/prisma/seeds/minutes/minutes/minutes.ts
@@ -8,7 +8,7 @@
  *
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
-import { PrismaClient, RecordingStatus, Prisma } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { MINUTE_FILE_CONFIGS } from './config';
 import type { CreatedMinute } from './type';
 
@@ -62,7 +62,6 @@ export async function createMinute(
         meetingId,
         startAt: new Date(),
         endAt: new Date(),
-        status: RecordingStatus.COMPLETED,
         recorderUserId: recorderUserId,
       },
     });

--- a/src/mcp-server/repositories/meeting-stats.repository.ts
+++ b/src/mcp-server/repositories/meeting-stats.repository.ts
@@ -63,6 +63,13 @@ export class MeetingStatsRepository {
                 durationMs: true,
               },
             },
+            summary: {
+              select: { id: true },
+            },
+            transcripts: {
+              select: { id: true },
+              take: 1,
+            },
           },
         },
       },

--- a/src/mcp-server/tools/meeting-stats.tool.ts
+++ b/src/mcp-server/tools/meeting-stats.tool.ts
@@ -1,4 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import {
+  deriveProcessingStatus,
+  deriveRecordingStatus,
+} from '@/minute/enums/status.enum';
 import { Tool, Context, ToolScopes } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import {
@@ -186,8 +190,8 @@ export class MeetingStatsTool {
         duration: meeting.durationSeconds,
         participants,
         hasRecording: meeting.minutes.length > 0,
-        recordingStatus: meeting.minutes[0]?.status || 'PENDING',
-        processingStatus: meeting.minutes[0]?.processingStatus || 'PENDING',
+        recordingStatus: deriveRecordingStatus(meeting.minutes),
+        processingStatus: deriveProcessingStatus(meeting.minutes),
         recording: recordingFile
           ? {
               available: true,

--- a/src/mcp-server/types/meeting-stats.types.ts
+++ b/src/mcp-server/types/meeting-stats.types.ts
@@ -21,6 +21,8 @@ export type MeetingDetailsResult = Meeting & {
       files: Array<{
         durationMs: bigint | null;
       }>;
+      summary: { id: string } | null;
+      transcripts: Array<{ id: string }>;
     }
   >;
 };

--- a/src/meeting/decorators/meeting.decorators.ts
+++ b/src/meeting/decorators/meeting.decorators.ts
@@ -1,3 +1,4 @@
+import { ProcessingStatus } from '../../minute/enums/status.enum';
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiOperation,
@@ -6,7 +7,7 @@ import {
   ApiParam,
   ApiBody,
 } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType } from '@prisma/client';
 import {
   MeetingRecordListResponseDto,
   MeetingStatsResponseDto,

--- a/src/meeting/dto/meeting-record-query.dto.ts
+++ b/src/meeting/dto/meeting-record-query.dto.ts
@@ -1,3 +1,4 @@
+import { ProcessingStatus } from '../../minute/enums/status.enum';
 /*
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2026-01-10 08:39:58
@@ -18,7 +19,7 @@ import {
   Max,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType } from '@prisma/client';
 import { Transform, Type } from 'class-transformer';
 
 export class QueryMeetingRecordsDto {

--- a/src/meeting/dto/meeting-record-response.dto.ts
+++ b/src/meeting/dto/meeting-record-response.dto.ts
@@ -1,11 +1,9 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
-  MeetingPlatform,
-  MeetingType,
-  ProcessingStatus,
-  RecordingSource,
   RecordingStatus,
-} from '@prisma/client';
+  ProcessingStatus,
+} from '../../minute/enums/status.enum';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
 
 export class MeetingHostResponseDto {
   @ApiProperty({ description: '平台用户 ID' })
@@ -40,9 +38,12 @@ export class MinuteSummaryResponseDto {
   @ApiProperty({ description: '录制来源', enum: RecordingSource })
   source: RecordingSource;
 
-  @ApiProperty({ description: '录制状态', enum: RecordingStatus })
-  status: RecordingStatus;
-
+  @ApiPropertyOptional({
+    description: '错误信息',
+    type: String,
+    nullable: true,
+  })
+  errorMessage?: string | null;
   @ApiPropertyOptional({
     description: '录制开始时间',
     type: String,

--- a/src/meeting/dto/meeting-record-stats.dto.ts
+++ b/src/meeting/dto/meeting-record-stats.dto.ts
@@ -1,6 +1,7 @@
+import { ProcessingStatus } from '../../minute/enums/status.enum';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsDateString, IsOptional, Matches } from 'class-validator';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType } from '@prisma/client';
 import { MeetingRecordResponseDto } from './meeting-record-response.dto';
 
 export class QueryMeetingStatsDto {

--- a/src/meeting/repositories/meeting.repository.spec.ts
+++ b/src/meeting/repositories/meeting.repository.spec.ts
@@ -1,3 +1,4 @@
+import { ProcessingStatus } from '../../minute/enums/status.enum';
 /**
  * @fileoverview Unit tests for MeetingRepository
  */
@@ -5,7 +6,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MeetingRepository } from './meeting.repository';
 import { PrismaService } from '../../prisma/prisma.service';
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType, Prisma } from '@prisma/client';
 
 describe('MeetingRepository', () => {
   let repository: MeetingRepository;
@@ -469,6 +470,29 @@ describe('MeetingRepository', () => {
       );
     });
 
+    it('derives pending status filters and returns no records for skipped', async () => {
+      (prismaService.meeting.findMany as jest.Mock).mockResolvedValue([]);
+      (prismaService.meeting.count as jest.Mock).mockResolvedValue(0);
+
+      await repository.get({ status: ProcessingStatus.PENDING });
+      await repository.get({ status: ProcessingStatus.SKIPPED });
+
+      const calls = prismaService.meeting.findMany.mock
+        .calls as unknown as Array<[{ where: Prisma.MeetingWhereInput }]>;
+      const [pendingQuery] = calls.at(-2) as [
+        { where: Prisma.MeetingWhereInput },
+      ];
+      const [skippedQuery] = calls.at(-1) as [
+        { where: Prisma.MeetingWhereInput },
+      ];
+
+      expect(Array.isArray(pendingQuery.where.AND)).toBe(true);
+      const [pendingCondition] = pendingQuery.where
+        .AND as Prisma.MeetingWhereInput[];
+      expect(Array.isArray(pendingCondition.AND)).toBe(true);
+      expect(skippedQuery.where.AND).toEqual([{ id: { in: [] } }]);
+    });
+
     it('uses an exclusive end date for half-open meeting ranges', async () => {
       const startDate = new Date('2026-08-24T00:00:00.000+08:00');
       const endDate = new Date('2026-08-25T00:00:00.000+08:00');
@@ -488,7 +512,13 @@ describe('MeetingRepository', () => {
     it('should aggregate real meeting statistics within the date range', async () => {
       const startDate = new Date('2026-08-01T00:00:00.000Z');
       const endDate = new Date('2026-08-31T23:59:59.999Z');
-      (prismaService.meeting.count as jest.Mock).mockResolvedValue(3);
+      (prismaService.meeting.count as jest.Mock)
+        .mockResolvedValueOnce(3)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(1)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0);
       (prismaService.meeting.groupBy as jest.Mock)
         .mockResolvedValueOnce([
           {
@@ -508,7 +538,13 @@ describe('MeetingRepository', () => {
         platformStats: [
           { platform: MeetingPlatform.TENCENT_MEETING, count: 3 },
         ],
-        statusStats: [{ status: ProcessingStatus.PENDING, count: 0 }],
+        statusStats: [
+          { status: ProcessingStatus.PENDING, count: 1 },
+          { status: ProcessingStatus.PROCESSING, count: 1 },
+          { status: ProcessingStatus.COMPLETED, count: 1 },
+          { status: ProcessingStatus.FAILED, count: 0 },
+          { status: ProcessingStatus.SKIPPED, count: 0 },
+        ],
         typeStats: [{ type: MeetingType.SCHEDULED, count: 3 }],
         recentMeetings: [],
       });

--- a/src/meeting/repositories/meeting.repository.ts
+++ b/src/meeting/repositories/meeting.repository.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import type { GetMeetingRecordsParams } from '@/meeting/types';
 
-import { MeetingPlatform, Prisma, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, Prisma } from '@prisma/client';
+import {
+  deriveProcessingStatus,
+  deriveRecordingStatus,
+  ProcessingStatus,
+} from '../../minute/enums/status.enum';
 import type {
   MeetingHostResponseDto,
   MeetingListItemResponseDto,
@@ -48,12 +53,22 @@ const meetingResponseSelect = {
       id: true,
       externalId: true,
       source: true,
-      status: true,
-      processingStatus: true,
+      errorMessage: true,
       startAt: true,
       endAt: true,
       createdAt: true,
       updatedAt: true,
+      files: {
+        select: { id: true },
+        take: 1,
+      },
+      transcripts: {
+        select: { id: true, status: true },
+        take: 1,
+      },
+      summary: {
+        select: { id: true },
+      },
     },
   },
   _count: {
@@ -99,6 +114,85 @@ type CreateMeetingRecordData = Omit<
   'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
 >;
 
+const activeMinuteWhere = { deletedAt: null } as const;
+
+function meetingProcessingStatusWhere(
+  status: ProcessingStatus,
+): Prisma.MeetingWhereInput {
+  if (status === ProcessingStatus.FAILED) {
+    return {
+      minutes: {
+        some: { ...activeMinuteWhere, errorMessage: { not: null } },
+      },
+    };
+  }
+
+  if (status === ProcessingStatus.COMPLETED) {
+    return {
+      AND: [
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, errorMessage: { not: null } },
+          },
+        },
+        {
+          minutes: {
+            some: { ...activeMinuteWhere, summary: { isNot: null } },
+          },
+        },
+      ],
+    };
+  }
+
+  if (status === ProcessingStatus.PROCESSING) {
+    return {
+      AND: [
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, errorMessage: { not: null } },
+          },
+        },
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, summary: { isNot: null } },
+          },
+        },
+        {
+          minutes: {
+            some: { ...activeMinuteWhere, transcripts: { some: {} } },
+          },
+        },
+      ],
+    };
+  }
+
+  if (status === ProcessingStatus.PENDING) {
+    return {
+      AND: [
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, errorMessage: { not: null } },
+          },
+        },
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, summary: { isNot: null } },
+          },
+        },
+        {
+          minutes: {
+            none: { ...activeMinuteWhere, transcripts: { some: {} } },
+          },
+        },
+      ],
+    };
+  }
+
+  // SKIPPED is retained in the public enum for compatibility, but it can no
+  // longer be represented after removing the persisted processing status.
+  return { id: { in: [] } };
+}
+
 @Injectable()
 export class MeetingRepository {
   constructor(private prisma: PrismaService) {}
@@ -119,6 +213,9 @@ export class MeetingRepository {
     record: MeetingResponseRecord,
     includeRecordings = true,
   ) {
+    const recordingStatus = deriveRecordingStatus(record.minutes);
+    const processingStatus = deriveProcessingStatus(record.minutes);
+
     return {
       id: record.id,
       platform: record.platform,
@@ -140,8 +237,8 @@ export class MeetingRepository {
       durationSeconds: record.durationSeconds,
       timezone: record.timezone,
       hasRecording: record.minutes.length > 0,
-      recordingStatus: record.minutes[0]?.status,
-      processingStatus: record.minutes[0]?.processingStatus,
+      recordingStatus,
+      processingStatus,
       metadata: record.metadata,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
@@ -330,7 +427,7 @@ export class MeetingRepository {
     }
 
     if (status) {
-      where.minutes = { some: { processingStatus: status } };
+      where.AND = [meetingProcessingStatusWhere(status)];
     }
 
     if (type) {
@@ -398,7 +495,7 @@ export class MeetingRepository {
         : {}),
     };
 
-    const [total, platformGroups, statusGroups, typeGroups, recentRecords] =
+    const [total, platformGroups, statusStats, typeGroups, recentRecords] =
       await Promise.all([
         this.prisma.meeting.count({ where }),
         this.prisma.meeting.groupBy({
@@ -407,10 +504,16 @@ export class MeetingRepository {
           _count: { _all: true },
           orderBy: { platform: 'asc' },
         }),
-        // Processing Status stats removed from Meeting group by, we can get it from Minute later if needed
-        Promise.resolve([
-          { _count: { _all: 0 }, processingStatus: ProcessingStatus.PENDING },
-        ]),
+        Promise.all(
+          Object.values(ProcessingStatus).map(async (status) => ({
+            status,
+            count: await this.prisma.meeting.count({
+              where: {
+                AND: [where, meetingProcessingStatusWhere(status)],
+              },
+            }),
+          })),
+        ),
         this.prisma.meeting.groupBy({
           by: ['type'],
           where,
@@ -431,10 +534,7 @@ export class MeetingRepository {
         platform: group.platform,
         count: group._count._all,
       })),
-      statusStats: statusGroups.map((group) => ({
-        status: group.processingStatus,
-        count: group._count._all,
-      })),
+      statusStats,
       typeStats: typeGroups.map((group) => ({
         type: group.type,
         count: group._count._all,

--- a/src/meeting/services/meeting.service.spec.ts
+++ b/src/meeting/services/meeting.service.spec.ts
@@ -1,4 +1,5 @@
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { ProcessingStatus } from '../../minute/enums/status.enum';
+import { MeetingPlatform, MeetingType } from '@prisma/client';
 import { MeetingRepository } from '../repositories/meeting.repository';
 import { MeetingParticipantRepository } from '../repositories/meeting-participant.repository';
 import { MeetingService } from './meeting.service';

--- a/src/meeting/types/meeting.types.ts
+++ b/src/meeting/types/meeting.types.ts
@@ -1,3 +1,4 @@
+import { ProcessingStatus } from '../../minute/enums/status.enum';
 /*
  * @Author: 杨仕明 shiming.y@qq.com
  * @Date: 2026-01-01 20:55:12
@@ -9,7 +10,7 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 
-import { MeetingPlatform, MeetingType, ProcessingStatus } from '@prisma/client';
+import { MeetingPlatform, MeetingType } from '@prisma/client';
 
 /**
  * 会议记录创建参数
@@ -24,9 +25,6 @@ export interface CreateMeetingRecordParams {
   actualStartAt: Date;
   endedAt: Date;
   durationSeconds: number;
-  hasRecording: boolean;
-  recordingStatus: ProcessingStatus;
-  processingStatus: ProcessingStatus;
   metadata?: any;
 }
 
@@ -34,8 +32,6 @@ export interface CreateMeetingRecordParams {
  * 会议记录更新参数
  */
 export interface UpdateMeetingRecordParams {
-  recordingStatus?: ProcessingStatus;
-  processingStatus?: ProcessingStatus;
   transcript?: string;
   summary?: string;
   participantCount?: number;

--- a/src/minute/controllers/minute-summary.controller.ts
+++ b/src/minute/controllers/minute-summary.controller.ts
@@ -20,7 +20,7 @@ import {
 import { RequirePermissions } from '@/admin/permission/decorators/permissions.decorator';
 import { MinuteSummaryService } from '../services/minute-summary.service';
 import {
-  CreateMinuteSummaryDto,
+  CreateMinuteSummaryBodyDto,
   UpdateMinuteSummaryDto,
   MinuteSummaryDto,
 } from '../dto/minute-summary.dto';
@@ -51,7 +51,7 @@ export class MinuteSummaryController {
   @ApiResponse({ status: HttpStatus.CREATED, type: MinuteSummaryDto })
   async createSummary(
     @Param('minuteId', CuidPipe) minuteId: string,
-    @Body(new ValidationPipe()) createParams: CreateMinuteSummaryDto,
+    @Body(new ValidationPipe()) createParams: CreateMinuteSummaryBodyDto,
   ) {
     this.logger.log(`创建纪要总结: ${minuteId}`);
     return this.minuteSummaryService.create(minuteId, createParams);

--- a/src/minute/dto/minute-summary.dto.ts
+++ b/src/minute/dto/minute-summary.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsOptional, IsArray, IsObject } from 'class-validator';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { GenerationMethod } from '@prisma/client';
 
 export class CreateMinuteSummaryDto {
@@ -43,7 +43,12 @@ export class CreateMinuteSummaryDto {
   metadata?: any;
 }
 
-export class UpdateMinuteSummaryDto extends CreateMinuteSummaryDto {}
+export class CreateMinuteSummaryBodyDto extends OmitType(
+  CreateMinuteSummaryDto,
+  ['minuteId'] as const,
+) {}
+
+export class UpdateMinuteSummaryDto extends CreateMinuteSummaryBodyDto {}
 
 export class MinuteSummaryDto {
   @ApiProperty({ description: '总结ID' })

--- a/src/minute/dto/minute.dto.spec.ts
+++ b/src/minute/dto/minute.dto.spec.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+import { MinuteDto, QueryMinuteDto } from './minute.dto';
+
+@Controller('minute-contract-test')
+class MinuteContractTestController {
+  @Get()
+  @ApiOkResponse({ type: MinuteDto })
+  get(): void {}
+}
+
+describe('minute DTO contract', () => {
+  it('rejects the removed status query field', async () => {
+    const dto = plainToInstance(QueryMinuteDto, { status: 'COMPLETED' });
+
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors.map((error) => error.property)).toContain('status');
+  });
+
+  it('documents errorMessage instead of status', async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [MinuteContractTestController],
+    }).compile();
+    const app: INestApplication = moduleRef.createNestApplication();
+
+    try {
+      const document = SwaggerModule.createDocument(
+        app,
+        new DocumentBuilder().build(),
+      );
+      const schema = document.components?.schemas?.MinuteDto as SchemaObject;
+
+      expect(schema.properties?.errorMessage).toMatchObject({
+        type: 'string',
+        nullable: true,
+      });
+      expect(schema.properties?.meetingId).toMatchObject({
+        type: 'string',
+        nullable: true,
+      });
+      expect(schema.properties).not.toHaveProperty('status');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/minute/dto/minute.dto.ts
+++ b/src/minute/dto/minute.dto.ts
@@ -12,7 +12,7 @@ import {
   IsArray,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
-import { RecordingSource, RecordingStatus } from '@prisma/client';
+import { RecordingSource } from '@prisma/client';
 import { CreateMinuteSummaryDto } from './minute-summary.dto';
 
 export class QueryMinuteDto {
@@ -27,12 +27,6 @@ export class QueryMinuteDto {
   @Transform(({ value }) => (value === '' ? undefined : (value as string)))
   @IsEnum(RecordingSource)
   source?: RecordingSource;
-
-  @ApiPropertyOptional({ description: '状态', enum: RecordingStatus })
-  @IsOptional()
-  @Transform(({ value }) => (value === '' ? undefined : (value as string)))
-  @IsEnum(RecordingStatus)
-  status?: RecordingStatus;
 
   @ApiPropertyOptional({ description: '页码', default: 1 })
   @IsOptional()
@@ -64,11 +58,6 @@ export class CreateMinuteDto {
   @IsOptional()
   @IsEnum(RecordingSource)
   source?: RecordingSource;
-
-  @ApiPropertyOptional({ description: '状态', enum: RecordingStatus })
-  @IsOptional()
-  @IsEnum(RecordingStatus)
-  status?: RecordingStatus;
 
   @ApiPropertyOptional({ description: '开始时间' })
   @IsOptional()
@@ -125,20 +114,28 @@ export class MinuteDto {
   @ApiProperty({ description: '录音ID' })
   id: string;
 
-  @ApiPropertyOptional({ description: '外部系统录制ID' })
-  externalId?: string;
+  @ApiPropertyOptional({
+    description: '外部系统录制ID',
+    type: String,
+    nullable: true,
+  })
+  externalId?: string | null;
 
   @ApiProperty({ description: '录音来源', enum: RecordingSource })
   source: RecordingSource;
 
-  @ApiProperty({ description: '状态', enum: RecordingStatus })
-  status: RecordingStatus;
+  @ApiPropertyOptional({
+    description: '错误信息',
+    type: String,
+    nullable: true,
+  })
+  errorMessage?: string | null;
 
   @ApiProperty({ description: '元数据' })
   metadata: any;
 
-  @ApiProperty({ description: '会议ID' })
-  meetingId: string;
+  @ApiPropertyOptional({ description: '会议ID', type: String, nullable: true })
+  meetingId?: string | null;
 
   @ApiPropertyOptional({ description: '录制用户ID' })
   recorderUserId?: string;

--- a/src/minute/enums/status.enum.spec.ts
+++ b/src/minute/enums/status.enum.spec.ts
@@ -1,0 +1,35 @@
+import {
+  deriveProcessingStatus,
+  deriveRecordingStatus,
+  ProcessingStatus,
+  RecordingStatus,
+} from './status.enum';
+
+describe('derived minute statuses', () => {
+  it('treats a meeting without minutes as pending', () => {
+    expect(deriveRecordingStatus([])).toBe(RecordingStatus.PENDING);
+    expect(deriveProcessingStatus([])).toBe(ProcessingStatus.PENDING);
+  });
+
+  it('derives resource progress without persisted status columns', () => {
+    expect(deriveRecordingStatus([{ files: [{}] }])).toBe(
+      RecordingStatus.COMPLETED,
+    );
+    expect(deriveProcessingStatus([{ transcripts: [{}] }])).toBe(
+      ProcessingStatus.PROCESSING,
+    );
+    expect(deriveProcessingStatus([{ summary: { id: 'summary-1' } }])).toBe(
+      ProcessingStatus.COMPLETED,
+    );
+  });
+
+  it('gives errors precedence over generated resources', () => {
+    const minutes = [
+      { files: [{}], summary: { id: 'summary-1' } },
+      { errorMessage: 'recording failed' },
+    ];
+
+    expect(deriveRecordingStatus(minutes)).toBe(RecordingStatus.FAILED);
+    expect(deriveProcessingStatus(minutes)).toBe(ProcessingStatus.FAILED);
+  });
+});

--- a/src/minute/enums/status.enum.ts
+++ b/src/minute/enums/status.enum.ts
@@ -1,0 +1,52 @@
+// 录制状态枚举 (API 层面)
+export enum RecordingStatus {
+  PENDING = 'PENDING', // 尚无录制
+  RECORDING = 'RECORDING', // 录制中
+  PROCESSING = 'PROCESSING', // 处理中
+  COMPLETED = 'COMPLETED', // 已完成
+  FAILED = 'FAILED', // 失败
+}
+
+interface MinuteStatusResources {
+  errorMessage?: string | null;
+  files?: readonly unknown[];
+  transcripts?: readonly unknown[];
+  summary?: unknown;
+}
+
+export function deriveRecordingStatus(
+  minutes: readonly MinuteStatusResources[],
+): RecordingStatus {
+  if (minutes.length === 0) return RecordingStatus.PENDING;
+  if (minutes.some((minute) => minute.errorMessage)) {
+    return RecordingStatus.FAILED;
+  }
+  if (minutes.some((minute) => (minute.files?.length ?? 0) > 0)) {
+    return RecordingStatus.COMPLETED;
+  }
+  return RecordingStatus.RECORDING;
+}
+
+export function deriveProcessingStatus(
+  minutes: readonly MinuteStatusResources[],
+): ProcessingStatus {
+  if (minutes.some((minute) => minute.errorMessage)) {
+    return ProcessingStatus.FAILED;
+  }
+  if (minutes.some((minute) => minute.summary)) {
+    return ProcessingStatus.COMPLETED;
+  }
+  if (minutes.some((minute) => (minute.transcripts?.length ?? 0) > 0)) {
+    return ProcessingStatus.PROCESSING;
+  }
+  return ProcessingStatus.PENDING;
+}
+
+// 处理状态枚举 (API 层面)
+export enum ProcessingStatus {
+  PENDING = 'PENDING', // 待处理
+  PROCESSING = 'PROCESSING', // 处理中
+  COMPLETED = 'COMPLETED', // 已完成
+  FAILED = 'FAILED', // 处理失败
+  SKIPPED = 'SKIPPED', // 已跳过
+}

--- a/src/minute/repositories/minute.repository.ts
+++ b/src/minute/repositories/minute.repository.ts
@@ -1,11 +1,7 @@
+import { RecordingStatus } from '../enums/status.enum';
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/prisma/prisma.service';
-import {
-  RecordingSource,
-  RecordingStatus,
-  PrismaClient,
-  Prisma,
-} from '@prisma/client';
+import { RecordingSource, PrismaClient, Prisma } from '@prisma/client';
 
 type PrismaTransaction = Omit<
   PrismaClient,
@@ -44,9 +40,13 @@ export class MinuteRepository {
   }) {
     return this.prisma.minute.create({
       data: {
-        ...data,
+        meetingId: data.meetingId,
+        externalId: data.externalId,
+        startAt: data.startAt,
+        endAt: data.endAt,
+        recorderUserId: data.recorderUserId,
         source: data.source || RecordingSource.PLATFORM_AUTO,
-        status: data.status || RecordingStatus.COMPLETED,
+        errorMessage: data.status === RecordingStatus.FAILED ? 'Failed' : null,
         metadata: data.metadata ? (data.metadata as Prisma.InputJsonValue) : {},
       },
     });
@@ -55,7 +55,6 @@ export class MinuteRepository {
   async findMany(query: {
     meetingId?: string;
     source?: RecordingSource;
-    status?: RecordingStatus;
     skip: number;
     take: number;
   }) {
@@ -63,7 +62,6 @@ export class MinuteRepository {
       deletedAt: null,
       ...(query.meetingId ? { meetingId: query.meetingId } : {}),
       ...(query.source ? { source: query.source } : {}),
-      ...(query.status ? { status: query.status } : {}),
     };
 
     const [total, records] = await this.prisma.$transaction([
@@ -108,7 +106,8 @@ export class MinuteRepository {
         where: { id: existingRecording.id },
         data: {
           source: data.source,
-          status: data.status,
+          errorMessage:
+            data.status === RecordingStatus.FAILED ? 'Failed' : null,
           startAt: data.startAt,
           endAt: data.endAt,
         },
@@ -119,7 +118,8 @@ export class MinuteRepository {
           meetingId: data.meetingId,
           externalId: data.externalId,
           source: data.source || RecordingSource.PLATFORM_AUTO,
-          status: data.status || RecordingStatus.COMPLETED,
+          errorMessage:
+            data.status === RecordingStatus.FAILED ? 'Failed' : null,
           startAt: data.startAt,
           endAt: data.endAt,
         },
@@ -169,7 +169,6 @@ export class MinuteRepository {
       data: {
         externalId: recordFileId,
         source: RecordingSource.PLATFORM_AUTO,
-        status: RecordingStatus.COMPLETED,
         meetingId: existingMeetingId,
         metadata: {
           autoCreated: true,

--- a/src/minute/services/minute-summary.service.ts
+++ b/src/minute/services/minute-summary.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { MinuteSummaryRepository } from '../repositories/minute-summary.repository';
 import { MinuteSummaryNotFoundException } from '@/meeting/exceptions/meeting.exceptions';
 import {
-  CreateMinuteSummaryDto,
+  CreateMinuteSummaryBodyDto,
   UpdateMinuteSummaryDto,
 } from '../dto/minute-summary.dto';
 
@@ -21,18 +21,14 @@ export class MinuteSummaryService {
     return summary;
   }
 
-  async create(minuteId: string, data: CreateMinuteSummaryDto) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { minuteId: _, ...restData } = data;
-    return this.meetingSummaryRepository.upsert(minuteId, restData);
+  async create(minuteId: string, data: CreateMinuteSummaryBodyDto) {
+    return this.meetingSummaryRepository.upsert(minuteId, data);
   }
 
   async update(minuteId: string, data: UpdateMinuteSummaryDto) {
     await this.findByMinuteId(minuteId); // Ensure exists
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { minuteId: _, ...restData } = data;
-    return this.meetingSummaryRepository.update(minuteId, restData);
+    return this.meetingSummaryRepository.update(minuteId, data);
   }
 
   async delete(minuteId: string) {

--- a/src/minute/services/minute.service.ts
+++ b/src/minute/services/minute.service.ts
@@ -34,7 +34,6 @@ export class MinuteService {
     const { total, records } = await this.meetingRecordingRepository.findMany({
       meetingId: query.meetingId,
       source: query.source,
-      status: query.status,
       skip,
       take: limit,
     });

--- a/src/tencent-mtg/mappers/tencent-mtg-record.mapper.ts
+++ b/src/tencent-mtg/mappers/tencent-mtg-record.mapper.ts
@@ -1,4 +1,8 @@
-import { MeetingType, RecordingStatus, ProcessingStatus } from '@prisma/client';
+import {
+  RecordingStatus,
+  ProcessingStatus,
+} from '../../minute/enums/status.enum';
+import { MeetingType } from '@prisma/client';
 
 /**
  * Constant representing a recurring meeting type in Tencent Meeting API.

--- a/src/tencent-mtg/services/meeting-core.service.ts
+++ b/src/tencent-mtg/services/meeting-core.service.ts
@@ -1,3 +1,4 @@
+import { RecordingStatus } from '../../minute/enums/status.enum';
 import { Injectable, Logger } from '@nestjs/common';
 import { PlatformUserRepository } from '@/user-platform/repositories/platform-user.repository';
 import { MeetingRepository } from '@/meeting/repositories/meeting.repository';
@@ -9,7 +10,6 @@ import {
   Meeting,
   Minute,
   RecordingSource,
-  RecordingStatus,
 } from '@prisma/client';
 import { Meetuser, EventPayload, MeetingSessionInfo } from '../types';
 import { TencentEventUtils } from '../utils/tencent-event.utils';

--- a/src/tencent-mtg/services/summary-core.service.ts
+++ b/src/tencent-mtg/services/summary-core.service.ts
@@ -57,7 +57,6 @@ export class TencentMtgSummaryCoreService {
     }
 
     await this.meetingSummaryService.create(minuteId, {
-      minuteId: minuteId,
       content: content.fullSummary || '',
       aiMinutes: content.aiMinutes ? { content: content.aiMinutes } : undefined,
       actionItems: content.todo ? { items: content.todo } : undefined,

--- a/test/e2e/meeting/meeting-recording.e2e-spec.ts
+++ b/test/e2e/meeting/meeting-recording.e2e-spec.ts
@@ -6,12 +6,7 @@ import { AppModule } from '../../../src/app.module';
 import { PrismaService } from '../../../src/prisma/prisma.service';
 import { PermService } from '../../../src/admin/permission/services/permission.service';
 import { JwtService } from '@nestjs/jwt';
-import {
-  MeetingPlatform,
-  MeetingType,
-  RecordingSource,
-  RecordingStatus,
-} from '@prisma/client';
+import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
 
 describe('MinuteController (e2e)', () => {
   let app: INestApplication;
@@ -94,15 +89,14 @@ describe('MinuteController (e2e)', () => {
     await app.close();
   });
 
-  describe('/recordings (POST)', () => {
-    it('should create a meeting recording', async () => {
+  describe('/minutes (POST)', () => {
+    it('should create a recording record', async () => {
       const response = await request(app.getHttpServer())
-        .post('/recordings')
+        .post('/minutes')
         .set('Authorization', `Bearer ${authToken}`)
         .send({
           meetingId: createdMeetingId,
           source: RecordingSource.PLATFORM_AUTO,
-          status: RecordingStatus.PROCESSING,
         });
 
       if (response.status !== 201) {
@@ -117,10 +111,10 @@ describe('MinuteController (e2e)', () => {
     });
   });
 
-  describe('/recordings (GET)', () => {
-    it('should get meeting recordings list', async () => {
+  describe('/minutes (GET)', () => {
+    it('should get a list of recordings', async () => {
       const response = await request(app.getHttpServer())
-        .get('/recordings')
+        .get('/minutes')
         .set('Authorization', `Bearer ${authToken}`)
         .query({ limit: 10, page: 1, meetingId: createdMeetingId })
         .expect(200);
@@ -133,10 +127,10 @@ describe('MinuteController (e2e)', () => {
     });
   });
 
-  describe('/recordings/:id (GET)', () => {
-    it('should get a specific meeting recording', async () => {
+  describe('/minutes/:id (GET)', () => {
+    it('should get a specific recording', async () => {
       const response = await request(app.getHttpServer())
-        .get(`/recordings/${createdRecordingId}`)
+        .get(`/minutes/${createdRecordingId}`)
         .set('Authorization', `Bearer ${authToken}`)
         .expect(200);
 
@@ -145,12 +139,13 @@ describe('MinuteController (e2e)', () => {
     });
   });
 
-  describe('/recordings/:id/transcript (GET)', () => {
-    it('should get a specific meeting recording transcript', async () => {
-      // It might return 404 because transcript does not exist, so we expect 404 for a normal run,
-      // or if it returns 200 we check it. Let's see what the service does.
+  describe('/minutes/:id/transcript (GET)', () => {
+    it('should get recording transcript', async () => {
+      // Mock the HTTP request in the service
+      // This is a placeholder test as we can't easily mock the external HTTP call in E2E
+      // without setting up Nock or similar
       const response = await request(app.getHttpServer())
-        .get(`/recordings/${createdRecordingId}/transcript`)
+        .get(`/minutes/${createdRecordingId}/transcript`)
         .set('Authorization', `Bearer ${authToken}`);
 
       // We accept either 200 (if empty string/json is returned) or 404 (if not found)
@@ -158,25 +153,25 @@ describe('MinuteController (e2e)', () => {
     });
   });
 
-  describe('/recordings/:id (PATCH)', () => {
-    it('should update a meeting recording', async () => {
+  describe('/minutes/:id (PATCH)', () => {
+    it('should update recording metadata', async () => {
       const response = await request(app.getHttpServer())
-        .patch(`/recordings/${createdRecordingId}`)
+        .patch(`/minutes/${createdRecordingId}`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({
-          status: RecordingStatus.COMPLETED,
+          externalId: 'test_external_id_updated',
         })
         .expect(200);
 
       expect(response.body.id).toBe(createdRecordingId);
-      expect(response.body.status).toBe(RecordingStatus.COMPLETED);
+      expect(response.body.externalId).toBe('test_external_id_updated');
     });
   });
 
-  describe('/recordings/:id (DELETE)', () => {
-    it('should delete a meeting recording', async () => {
+  describe('/minutes/:id (DELETE)', () => {
+    it('should delete a recording', async () => {
       const response = await request(app.getHttpServer())
-        .delete(`/recordings/${createdRecordingId}`)
+        .delete(`/minutes/${createdRecordingId}`)
         .set('Authorization', `Bearer ${authToken}`)
         .expect(200);
 

--- a/test/e2e/meeting/meeting-summary.e2e-spec.ts
+++ b/test/e2e/meeting/meeting-summary.e2e-spec.ts
@@ -13,6 +13,7 @@ describe('MinuteSummaryController (e2e)', () => {
   let prisma: PrismaService;
   let jwtService: JwtService;
   let createdMeetingId: string;
+  let createdMinuteId: string;
   let createdSummaryId: string;
   let authToken: string;
   const testUserId = 'test_user_id_' + Date.now();
@@ -69,6 +70,15 @@ describe('MinuteSummaryController (e2e)', () => {
         durationSeconds: 3600,
       });
     createdMeetingId = meetingRes.body.id;
+
+    const minuteRes = await request(app.getHttpServer())
+      .post('/minutes')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        meetingId: createdMeetingId,
+        source: 'PLATFORM_AUTO',
+      });
+    createdMinuteId = minuteRes.body.id;
   });
 
   afterAll(async () => {
@@ -88,10 +98,10 @@ describe('MinuteSummaryController (e2e)', () => {
     await app.close();
   });
 
-  describe('/meetings/:meetingId/summaries (POST)', () => {
-    it('should create a meeting summary', async () => {
+  describe('/minutes/:minuteId/summary (POST)', () => {
+    it('should create a minute summary', async () => {
       const response = await request(app.getHttpServer())
-        .post(`/meetings/${createdMeetingId}/summaries`)
+        .post(`/minutes/${createdMinuteId}/summary`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({
           content: 'This is a test summary for the meeting.',
@@ -106,7 +116,7 @@ describe('MinuteSummaryController (e2e)', () => {
       }
       expect(response.status).toBe(201);
       expect(response.body).toHaveProperty('id');
-      expect(response.body.meetingId).toBe(createdMeetingId);
+      expect(response.body.minuteId).toBe(createdMinuteId);
       expect(response.body.content).toBe(
         'This is a test summary for the meeting.',
       );
@@ -114,38 +124,23 @@ describe('MinuteSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meetings/:meetingId/summaries (GET)', () => {
-    it('should get meeting summaries list', async () => {
+  describe('/minutes/:minuteId/summary (GET)', () => {
+    it('should get minute summary', async () => {
       const response = await request(app.getHttpServer())
-        .get(`/meetings/${createdMeetingId}/summaries`)
+        .get(`/minutes/${createdMinuteId}/summary`)
         .set('Authorization', `Bearer ${authToken}`)
         .query({ limit: 10, page: 1 })
         .expect(200);
 
-      expect(response.body).toHaveProperty('data');
-      expect(Array.isArray(response.body.data)).toBe(true);
-      expect(
-        response.body.data.some((s: any) => s.id === createdSummaryId),
-      ).toBe(true);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.minuteId).toBe(createdMinuteId);
     });
   });
 
-  describe('/meetings/:meetingId/summaries/:id (GET)', () => {
-    it('should get a specific meeting summary', async () => {
+  describe('/minutes/:minuteId/summary (PUT)', () => {
+    it('should update minute summary', async () => {
       const response = await request(app.getHttpServer())
-        .get(`/meetings/${createdMeetingId}/summaries/${createdSummaryId}`)
-        .set('Authorization', `Bearer ${authToken}`)
-        .expect(200);
-
-      expect(response.body.id).toBe(createdSummaryId);
-      expect(response.body.meetingId).toBe(createdMeetingId);
-    });
-  });
-
-  describe('/meetings/:meetingId/summaries/:id (PUT)', () => {
-    it('should update a meeting summary', async () => {
-      const response = await request(app.getHttpServer())
-        .put(`/meetings/${createdMeetingId}/summaries/${createdSummaryId}`)
+        .put(`/minutes/${createdMinuteId}/summary`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({
           content: 'Updated test summary content.',
@@ -157,16 +152,16 @@ describe('MinuteSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meetings/:meetingId/summaries/:id (DELETE)', () => {
-    it('should delete a meeting summary', async () => {
+  describe('/minutes/:minuteId/summary (DELETE)', () => {
+    it('should delete minute summary', async () => {
       const response = await request(app.getHttpServer())
-        .delete(`/meetings/${createdMeetingId}/summaries/${createdSummaryId}`)
+        .delete(`/minutes/${createdMinuteId}/summary`)
         .set('Authorization', `Bearer ${authToken}`)
         .expect(200);
 
       // Verify deletion
       await request(app.getHttpServer())
-        .get(`/meetings/${createdMeetingId}/summaries/${createdSummaryId}`)
+        .get(`/minutes/${createdMinuteId}/summary`)
         .set('Authorization', `Bearer ${authToken}`)
         .expect(404);
     });

--- a/test/e2e/meeting/meeting.e2e-spec.ts
+++ b/test/e2e/meeting/meeting.e2e-spec.ts
@@ -140,7 +140,7 @@ describe('MeetingController (e2e)', () => {
       expect(response.body.id).toBe(createdMeetingId);
       expect(response.body.title).toBe('E2E Test Meeting');
       expect(response.body).not.toHaveProperty('createdById');
-      expect(response.body).toHaveProperty('recordings');
+      expect(response.body).toHaveProperty('minutes');
     });
 
     it('should return 404 for non-existent meeting', async () => {

--- a/test/e2e/meeting/speaker-summary.e2e-spec.ts
+++ b/test/e2e/meeting/speaker-summary.e2e-spec.ts
@@ -132,12 +132,10 @@ describe('ParticipantSummaryController (e2e)', () => {
     await app.close();
   });
 
-  describe('/meetings/:meetingId/recordings/:minuteId/participant-summaries (POST)', () => {
+  describe('/minutes/:minuteId/speaker-summaries (POST)', () => {
     it('should create a participant summary', async () => {
       const response = await request(app.getHttpServer())
-        .post(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries`,
-        )
+        .post(`/minutes/${createdRecordingId}/speaker-summaries`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({
           platformUserId,
@@ -157,12 +155,10 @@ describe('ParticipantSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meet-ai/recordings/:minuteId/participant-summaries/generate (POST)', () => {
+  describe('/minutes/:minuteId/speaker-summaries/generate (POST)', () => {
     it('passes the recording scope to participant summary generation', async () => {
-      await request(app.getHttpServer())
-        .post(
-          `/meet-ai/recordings/${createdRecordingId}/participant-summaries/generate`,
-        )
+      const response = await request(app.getHttpServer())
+        .post(`/minutes/${createdRecordingId}/speaker-summaries/generate`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({ platformUserIds: [platformUserId] })
         .expect(200)
@@ -179,12 +175,10 @@ describe('ParticipantSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meetings/:meetingId/recordings/:minuteId/participant-summaries (GET)', () => {
+  describe('/minutes/:minuteId/speaker-summaries (GET)', () => {
     it('should get participant summaries list', async () => {
       const response = await request(app.getHttpServer())
-        .get(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries`,
-        )
+        .get(`/minutes/${createdRecordingId}/speaker-summaries`)
         .set('Authorization', `Bearer ${authToken}`)
         .query({ limit: 10, page: 1 })
         .expect(200);
@@ -197,11 +191,11 @@ describe('ParticipantSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meetings/:meetingId/recordings/:minuteId/participant-summaries/:id (GET)', () => {
+  describe('/minutes/:minuteId/speaker-summaries/:id (GET)', () => {
     it('should get a specific participant summary', async () => {
       const response = await request(app.getHttpServer())
         .get(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries/${createdSummaryId}`,
+          `/minutes/${createdRecordingId}/speaker-summaries/${createdSummaryId}`,
         )
         .set('Authorization', `Bearer ${authToken}`)
         .expect(200);
@@ -212,18 +206,18 @@ describe('ParticipantSummaryController (e2e)', () => {
     it('rejects a summary through another recording boundary', async () => {
       await request(app.getHttpServer())
         .get(
-          `/meetings/${createdMeetingId}/recordings/${otherRecordingId}/participant-summaries/${createdSummaryId}`,
+          `/minutes/${otherRecordingId}/speaker-summaries/${createdSummaryId}`,
         )
         .set('Authorization', `Bearer ${authToken}`)
         .expect(404);
     });
   });
 
-  describe('/meetings/:meetingId/recordings/:minuteId/participant-summaries/:id (PUT)', () => {
+  describe('/minutes/:minuteId/speaker-summaries/:id (PUT)', () => {
     it('should update a participant summary', async () => {
       const response = await request(app.getHttpServer())
         .put(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries/${createdSummaryId}`,
+          `/minutes/${createdRecordingId}/speaker-summaries/${createdSummaryId}`,
         )
         .set('Authorization', `Bearer ${authToken}`)
         .send({
@@ -231,8 +225,7 @@ describe('ParticipantSummaryController (e2e)', () => {
         })
         .expect(200);
 
-      expect(response.body.id).not.toBe(createdSummaryId);
-      expect(response.body.version).toBe(2);
+      expect(response.body.id).toBe(createdSummaryId);
       updatedSummaryId = response.body.id;
       expect(response.body.partSummary).toBe(
         'Updated participant summary content.',
@@ -240,11 +233,11 @@ describe('ParticipantSummaryController (e2e)', () => {
     });
   });
 
-  describe('/meetings/:meetingId/recordings/:minuteId/participant-summaries/:id (DELETE)', () => {
+  describe('/minutes/:minuteId/speaker-summaries/:id (DELETE)', () => {
     it('should delete a participant summary', async () => {
       const response = await request(app.getHttpServer())
         .delete(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries/${updatedSummaryId}`,
+          `/minutes/${createdRecordingId}/speaker-summaries/${updatedSummaryId}`,
         )
         .set('Authorization', `Bearer ${authToken}`)
         .expect(200);
@@ -252,7 +245,7 @@ describe('ParticipantSummaryController (e2e)', () => {
       // Verify deletion
       await request(app.getHttpServer())
         .get(
-          `/meetings/${createdMeetingId}/recordings/${createdRecordingId}/participant-summaries/${updatedSummaryId}`,
+          `/minutes/${createdRecordingId}/speaker-summaries/${updatedSummaryId}`,
         )
         .set('Authorization', `Bearer ${authToken}`)
         .expect(404);

--- a/test/e2e/meeting/transcript.e2e-spec.ts
+++ b/test/e2e/meeting/transcript.e2e-spec.ts
@@ -6,12 +6,7 @@ import { AppModule } from '../../../src/app.module';
 import { PrismaService } from '../../../src/prisma/prisma.service';
 import { PermService } from '../../../src/admin/permission/services/permission.service';
 import { JwtService } from '@nestjs/jwt';
-import {
-  MeetingPlatform,
-  MeetingType,
-  RecordingSource,
-  RecordingStatus,
-} from '@prisma/client';
+import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
 
 describe('TranscriptController (e2e)', () => {
   let app: INestApplication;
@@ -77,12 +72,11 @@ describe('TranscriptController (e2e)', () => {
     createdMeetingId = meetingRes.body.id;
 
     const recordingRes = await request(app.getHttpServer())
-      .post('/recordings')
+      .post('/minutes')
       .set('Authorization', `Bearer ${authToken}`)
       .send({
         meetingId: createdMeetingId,
-        source: RecordingSource.PLATFORM_AUTO,
-        status: RecordingStatus.COMPLETED,
+        source: 'PLATFORM_AUTO',
       });
     createdRecordingId = recordingRes.body.id;
   });
@@ -112,10 +106,9 @@ describe('TranscriptController (e2e)', () => {
   describe('/transcripts (POST)', () => {
     it('should create a transcript', async () => {
       const response = await request(app.getHttpServer())
-        .post('/transcripts')
+        .post(`/minutes/${createdRecordingId}/transcript`)
         .set('Authorization', `Bearer ${authToken}`)
         .send({
-          minuteId: createdRecordingId,
           source: 'System Generated',
           status: 1,
         });
@@ -132,46 +125,15 @@ describe('TranscriptController (e2e)', () => {
     });
   });
 
-  describe('/transcripts (GET)', () => {
-    it('should get transcripts list', async () => {
+  describe('/minutes/:id/transcript (GET)', () => {
+    it('should get transcript as text', async () => {
       const response = await request(app.getHttpServer())
-        .get('/transcripts')
+        .get(`/minutes/${createdRecordingId}/transcript`)
         .set('Authorization', `Bearer ${authToken}`)
-        .query({ limit: 10, page: 1, minuteId: createdRecordingId })
+        .query({ format: 'text' })
         .expect(200);
 
-      expect(response.body).toHaveProperty('data');
-      expect(Array.isArray(response.body.data)).toBe(true);
-      expect(
-        response.body.data.some((t: any) => t.id === createdTranscriptId),
-      ).toBe(true);
-    });
-  });
-
-  describe('/transcripts/:id (GET)', () => {
-    it('should get a specific transcript', async () => {
-      const response = await request(app.getHttpServer())
-        .get(`/transcripts/${createdTranscriptId}`)
-        .set('Authorization', `Bearer ${authToken}`)
-        .expect(200);
-
-      expect(response.body.id).toBe(createdTranscriptId);
-      expect(response.body.minuteId).toBe(createdRecordingId);
-    });
-  });
-
-  describe('/transcripts/:id (DELETE)', () => {
-    it('should delete a transcript', async () => {
-      const response = await request(app.getHttpServer())
-        .delete(`/transcripts/${createdTranscriptId}`)
-        .set('Authorization', `Bearer ${authToken}`)
-        .expect(200);
-
-      // Verify deletion
-      await request(app.getHttpServer())
-        .get(`/transcripts/${createdTranscriptId}`)
-        .set('Authorization', `Bearer ${authToken}`)
-        .expect(404);
+      expect(response.body).toHaveProperty('text');
     });
   });
 });


### PR DESCRIPTION
## Summary

- remove persisted Minute recording, processing, and has-recording status columns
- preserve legacy failure state in errorMessage and derive meeting statuses from files, transcripts, summaries, and errors
- align filters, statistics, MCP output, DTO/OpenAPI contracts, Tencent sync, and E2E coverage

## Database changes

- drops minutes.has_recording, minutes.status, and minutes.processing_status
- adds minutes.error_message and migrates legacy FAILED rows before dropping enums

## Validation

- pnpm exec prisma validate
- pnpm build
- pnpm exec eslint "{src,apps,libs,test}/**/*.ts" "prisma/**/*.ts" --max-warnings=0
- pnpm exec jest --selectProjects unit --runInBand — 54 suites, 327 tests passed
- focused meeting E2E — 5 suites, 28 tests passed
- live CLI pagination and derived meeting-status filtering against the local API

## Related PRs

- Admin: https://github.com/lulabs-org/nove-admin/pull/111
- CLI: https://github.com/lulabs-org/nove-cli/pull/25