### PR TITLE
feat(oauth): add OAuth client administration

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,6 +74,10 @@ export default withMermaid(
             { text: '脚本说明', link: '/developer/guides/development/package-scripts' },
             { text: '测试规范', link: '/developer/guides/development/nestjs-testing-standards' },
             { text: '安全规范', link: '/developer/guides/development/security' },
+            {
+              text: 'OAuth 客户端管理',
+              link: '/developer/guides/development/oauth-client-management',
+            },
             { text: '版本控制', link: '/developer/guides/development/version-control' },
             { text: '文档维护', link: '/developer/guides/documentation' },
           ],

--- a/docs/developer/guides/development/oauth-client-management.md
+++ b/docs/developer/guides/development/oauth-client-management.md
@@ -1,0 +1,25 @@
+# OAuth 客户端管理
+
+OAuth 客户端是平台级凭证，只能由具有对应权限的平台管理员在 `nove-admin` 的“平台治理 → OAuth 客户端”中管理。当前不支持组织自助注册，也不提供永久删除。
+
+## 客户端类型
+
+- `PUBLIC`：适用于 CLI、桌面或原生应用，使用 PKCE，不持有 Client Secret。
+- `CONFIDENTIAL`：适用于能安全保存凭证的服务端应用。Secret 只在创建或轮换成功时返回一次，服务端仅保存哈希。
+
+客户端类型和 Client ID 创建后不可修改。系统内置客户端（例如 `nove-cli`）在后台只读，其配置继续通过代码和 seed 管理。
+
+## Scope 与 Redirect URI
+
+只有启用且标记为“OAuth 可委托”的权限才能配置为 Scope。OAuth access token 的 Scope 仍会与用户当前角色权限取交集，不能扩大用户本身的授权范围。
+
+生产环境 Redirect URI 必须使用 HTTPS；`http://127.0.0.1` loopback 是 PUBLIC 客户端本地回调的例外。URI 不支持通配符、fragment 或 userinfo。
+
+## 生命周期与失效语义
+
+- 禁用客户端会立即递增凭证版本、撤销全部 Refresh Token、清理授权码并终止未完成授权请求。
+- OAuth API 请求会实时检查客户端状态和凭证版本，因此禁用前签发的 Access Token 会立即失效，重新启用也不会使旧 Token 恢复。
+- 修改 Scope 会递增凭证版本并撤销全部 Refresh Token。
+- 轮换 CONFIDENTIAL Secret 会使旧 Secret 和已有 Refresh Token 失效；新的明文 Secret 不可再次查询。
+
+管理接口位于 `/admin/oauth-clients`，要求普通 JWT 登录，并使用 `oauth-client:*` 细粒度权限。API Key 和 OAuth 委托 Token 不能调用这些接口。

--- a/prisma/migrations/20260825083844_add_oauth_client_admin_management/migration.sql
+++ b/prisma/migrations/20260825083844_add_oauth_client_admin_management/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "OAuthClientStatus" AS ENUM ('ACTIVE', 'DISABLED');
+
+-- AlterTable
+ALTER TABLE "oauth_clients" ADD COLUMN     "created_by" TEXT,
+ADD COLUMN     "credential_version" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "disabled_at" TIMESTAMPTZ(6),
+ADD COLUMN     "is_system" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "status" "OAuthClientStatus" NOT NULL DEFAULT 'ACTIVE',
+ADD COLUMN     "updated_by" TEXT;
+
+-- AlterTable
+ALTER TABLE "permissions" ADD COLUMN     "oauth_delegatable" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "oauth_client_audit_logs" (
+    "id" TEXT NOT NULL,
+    "oauth_client_id" TEXT NOT NULL,
+    "actor_user_id" TEXT,
+    "action" TEXT NOT NULL,
+    "metadata" JSONB,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "oauth_client_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "oauth_client_audit_logs_oauth_client_id_created_at_idx" ON "oauth_client_audit_logs"("oauth_client_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "oauth_client_audit_logs_actor_user_id_idx" ON "oauth_client_audit_logs"("actor_user_id");
+
+-- AddForeignKey
+ALTER TABLE "oauth_clients" ADD CONSTRAINT "oauth_clients_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "oauth_clients" ADD CONSTRAINT "oauth_clients_updated_by_fkey" FOREIGN KEY ("updated_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "oauth_client_audit_logs" ADD CONSTRAINT "oauth_client_audit_logs_oauth_client_id_fkey" FOREIGN KEY ("oauth_client_id") REFERENCES "oauth_clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "oauth_client_audit_logs" ADD CONSTRAINT "oauth_client_audit_logs_actor_user_id_fkey" FOREIGN KEY ("actor_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/models/oauth.prisma
+++ b/prisma/models/oauth.prisma
@@ -1,39 +1,64 @@
 model OAuthClient {
-  id           String   @id @default(uuid())
-  clientId     String   @unique @map("client_id")
-  clientSecret String?  @map("client_secret") // confidential client only, hashed
-  clientType   OAuthClientType @default(CONFIDENTIAL) @map("client_type")
-  name         String
-  description  String?
-  logoUri      String?  @map("logo_uri")
-  redirectUris String[] @map("redirect_uris") // 允许的回调地址列表
-  grants       String[] // 允许的授权模式, 例如 ["authorization_code", "refresh_token"]
-  scopes       String[] // 允许请求的权限范围列表
+  id                String            @id @default(uuid())
+  clientId          String            @unique @map("client_id")
+  clientSecret      String?           @map("client_secret") // confidential client only, hashed
+  clientType        OAuthClientType   @default(CONFIDENTIAL) @map("client_type")
+  name              String
+  description       String?
+  logoUri           String?           @map("logo_uri")
+  redirectUris      String[]          @map("redirect_uris") // 允许的回调地址列表
+  grants            String[] // 允许的授权模式, 例如 ["authorization_code", "refresh_token"]
+  scopes            String[] // 允许请求的权限范围列表
+  status            OAuthClientStatus @default(ACTIVE)
+  isSystem          Boolean           @default(false) @map("is_system")
+  credentialVersion Int               @default(1) @map("credential_version")
+  disabledAt        DateTime?         @map("disabled_at") @db.Timestamptz(6)
+  createdBy         String?           @map("created_by")
+  updatedBy         String?           @map("updated_by")
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
 
-  authCodes OAuthAuthCode[]
-  tokens    OAuthToken[]
+  authCodes             OAuthAuthCode[]
+  tokens                OAuthToken[]
   authorizationRequests OAuthAuthorizationRequest[]
+  auditLogs             OAuthClientAuditLog[]
+  creator               User?                       @relation("OAuthClientCreator", fields: [createdBy], references: [id], onDelete: SetNull)
+  updater               User?                       @relation("OAuthClientUpdater", fields: [updatedBy], references: [id], onDelete: SetNull)
 
   @@map("oauth_clients")
 }
 
-model OAuthAuthCode {
-  codeHash    String   @id @map("code_hash")
-  clientId    String   @map("client_id")
-  userId      String   @map("user_id")
-  organizationId String @map("organization_id")
-  redirectUri String   @map("redirect_uri")
-  scopes      String[]
-  codeChallenge String @map("code_challenge")
-  codeChallengeMethod String @default("S256") @map("code_challenge_method")
-  expiresAt   DateTime @map("expires_at") @db.Timestamptz(6)
+model OAuthClientAuditLog {
+  id            String   @id @default(uuid())
+  oauthClientId String   @map("oauth_client_id")
+  actorUserId   String?  @map("actor_user_id")
+  action        String
+  metadata      Json?
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
-  client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
-  user   User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization Org   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  client OAuthClient @relation(fields: [oauthClientId], references: [id], onDelete: Cascade)
+  actor  User?       @relation("OAuthClientAuditActor", fields: [actorUserId], references: [id], onDelete: SetNull)
+
+  @@index([oauthClientId, createdAt])
+  @@index([actorUserId])
+  @@map("oauth_client_audit_logs")
+}
+
+model OAuthAuthCode {
+  codeHash            String   @id @map("code_hash")
+  clientId            String   @map("client_id")
+  userId              String   @map("user_id")
+  organizationId      String   @map("organization_id")
+  redirectUri         String   @map("redirect_uri")
+  scopes              String[]
+  codeChallenge       String   @map("code_challenge")
+  codeChallengeMethod String   @default("S256") @map("code_challenge_method")
+  expiresAt           DateTime @map("expires_at") @db.Timestamptz(6)
+
+  client       OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+  user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Org         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
@@ -43,21 +68,21 @@ model OAuthAuthCode {
 }
 
 model OAuthToken {
-  id           String   @id @default(uuid())
-  refreshTokenHash String @unique @map("refresh_token_hash")
-  familyId     String   @map("family_id")
-  clientId     String   @map("client_id")
-  userId       String   @map("user_id")
-  organizationId String @map("organization_id")
-  scopes       String[]
-  expiresAt    DateTime @map("expires_at") @db.Timestamptz(6)
-  revoked      Boolean  @default(false)
-  revokedAt    DateTime? @map("revoked_at") @db.Timestamptz(6)
-  rotatedAt    DateTime? @map("rotated_at") @db.Timestamptz(6)
+  id               String    @id @default(uuid())
+  refreshTokenHash String    @unique @map("refresh_token_hash")
+  familyId         String    @map("family_id")
+  clientId         String    @map("client_id")
+  userId           String    @map("user_id")
+  organizationId   String    @map("organization_id")
+  scopes           String[]
+  expiresAt        DateTime  @map("expires_at") @db.Timestamptz(6)
+  revoked          Boolean   @default(false)
+  revokedAt        DateTime? @map("revoked_at") @db.Timestamptz(6)
+  rotatedAt        DateTime? @map("rotated_at") @db.Timestamptz(6)
 
-  client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
-  user   User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  organization Org   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  client       OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
+  user         User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Org         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
@@ -69,16 +94,16 @@ model OAuthToken {
 }
 
 model OAuthAuthorizationRequest {
-  id            String   @id @default(uuid())
-  clientId      String   @map("client_id")
-  redirectUri   String   @map("redirect_uri")
-  requestedScopes String[] @map("requested_scopes")
-  state         String
-  codeChallenge String   @map("code_challenge")
-  codeChallengeMethod String @default("S256") @map("code_challenge_method")
-  expiresAt     DateTime @map("expires_at") @db.Timestamptz(6)
-  consumedAt    DateTime? @map("consumed_at") @db.Timestamptz(6)
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  id                  String    @id @default(uuid())
+  clientId            String    @map("client_id")
+  redirectUri         String    @map("redirect_uri")
+  requestedScopes     String[]  @map("requested_scopes")
+  state               String
+  codeChallenge       String    @map("code_challenge")
+  codeChallengeMethod String    @default("S256") @map("code_challenge_method")
+  expiresAt           DateTime  @map("expires_at") @db.Timestamptz(6)
+  consumedAt          DateTime? @map("consumed_at") @db.Timestamptz(6)
+  createdAt           DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
 
   client OAuthClient @relation(fields: [clientId], references: [clientId], onDelete: Cascade)
 
@@ -90,4 +115,9 @@ model OAuthAuthorizationRequest {
 enum OAuthClientType {
   PUBLIC
   CONFIDENTIAL
+}
+
+enum OAuthClientStatus {
+  ACTIVE
+  DISABLED
 }

--- a/prisma/models/permission.prisma
+++ b/prisma/models/permission.prisma
@@ -1,16 +1,17 @@
 // 权限表
 model Permission {
-  id          String         @id @default(cuid())
-  name        String // 权限名称
-  code        String         @unique // 权限编码
-  description String? // 权限描述
-  resource    String // 资源标识
-  action      String // 操作类型
-  type        PermissionType @default(MENU) // 权限类型
-  parentId    String? // 父权限ID
-  level       Int            @default(1) // 权限层级
-  sortOrder   Int            @default(0) // 排序
-  active      Boolean        @default(true) // 是否启用
+  id               String         @id @default(cuid())
+  name             String // 权限名称
+  code             String         @unique // 权限编码
+  description      String? // 权限描述
+  resource         String // 资源标识
+  action           String // 操作类型
+  type             PermissionType @default(MENU) // 权限类型
+  parentId         String? // 父权限ID
+  level            Int            @default(1) // 权限层级
+  sortOrder        Int            @default(0) // 排序
+  active           Boolean        @default(true) // 是否启用
+  oauthDelegatable Boolean        @default(false) @map("oauth_delegatable")
 
   // 自关联
   parent   Permission?  @relation("PermissionHierarchy", fields: [parentId], references: [id], onDelete: Restrict)

--- a/prisma/models/user.prisma
+++ b/prisma/models/user.prisma
@@ -29,15 +29,18 @@ model User {
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6) // 软删除时间戳
 
   // 认证相关关联
-  accounts       Account[]
-  sessions       Session[]
-  Authenticator  Authenticator[]
-  refreshTokens  RefreshToken[] // User's refresh tokens
-  oauthAuthCodes OAuthAuthCode[] // User's OAuth auth codes
-  oauthTokens    OAuthToken[] // User's OAuth tokens
+  accounts             Account[]
+  sessions             Session[]
+  Authenticator        Authenticator[]
+  refreshTokens        RefreshToken[] // User's refresh tokens
+  oauthAuthCodes       OAuthAuthCode[] // User's OAuth auth codes
+  oauthTokens          OAuthToken[] // User's OAuth tokens
+  createdOAuthClients  OAuthClient[]         @relation("OAuthClientCreator")
+  updatedOAuthClients  OAuthClient[]         @relation("OAuthClientUpdater")
+  oauthClientAuditLogs OAuthClientAuditLog[] @relation("OAuthClientAuditActor")
   // 组织成员关联
-  orgMembers     OrgMember[] // 用户所属的组织成员关系
-  ledDepartments Dept[]          @relation("DepartmentLeader")
+  orgMembers           OrgMember[] // 用户所属的组织成员关系
+  ledDepartments       Dept[]                @relation("DepartmentLeader")
 
   // 个人详细信息
   profile     UserProfile?

--- a/prisma/seeds/core/oauth-clients/oauth-client.ts
+++ b/prisma/seeds/core/oauth-clients/oauth-client.ts
@@ -1,8 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 
-export async function createOAuthClients(
-  prisma: PrismaClient,
-): Promise<void> {
+export async function createOAuthClients(prisma: PrismaClient): Promise<void> {
   console.log(`🔑 开始创建 OAuth Clients 数据...`);
 
   try {
@@ -13,6 +11,8 @@ export async function createOAuthClients(
         clientType: 'PUBLIC',
         name: 'Nove CLI',
         description: 'Official Nove command line client',
+        isSystem: true,
+        status: 'ACTIVE',
         redirectUris: ['http://127.0.0.1/oauth/callback'],
         grants: ['authorization_code', 'refresh_token'],
         scopes: [
@@ -43,6 +43,7 @@ export async function createOAuthClients(
         clientType: 'PUBLIC',
         name: 'Nove CLI',
         description: 'Official Nove command line client',
+        isSystem: true,
         redirectUris: ['http://127.0.0.1/oauth/callback'],
         grants: ['authorization_code', 'refresh_token'],
         scopes: [

--- a/prisma/seeds/permissions/permissions.ts
+++ b/prisma/seeds/permissions/permissions.ts
@@ -12,6 +12,66 @@
 import { PrismaClient, Permission } from '@prisma/client';
 import { PERMISSION_CONFIGS, REAL_PERMISSION_CONFIGS } from './config';
 
+const OAUTH_DELEGATABLE_PERMISSION_CODES = new Set([
+  'meeting:read',
+  'meeting:create',
+  'meeting:update',
+  'meeting:delete',
+  'meeting:stats_view',
+  'minute:read',
+  'minute:delete',
+  'speaker-summary:read',
+  'speaker-summary:create',
+  'speaker-summary:update',
+  'speaker-summary:delete',
+  'tracking-report:read',
+  'tracking-report:create',
+  'tracking-report:update',
+  'tracking-report:delete',
+  'user:read',
+  'user:create',
+  'user:update',
+  'user:delete',
+]);
+
+const OAUTH_CLIENT_PERMISSION_CONFIGS = [
+  {
+    name: '查看 OAuth 客户端',
+    code: 'oauth-client:read',
+    description: '查看 OAuth 客户端',
+    resource: 'oauth-client',
+    action: 'read',
+  },
+  {
+    name: '创建 OAuth 客户端',
+    code: 'oauth-client:create',
+    description: '创建 OAuth 客户端',
+    resource: 'oauth-client',
+    action: 'create',
+  },
+  {
+    name: '编辑 OAuth 客户端',
+    code: 'oauth-client:update',
+    description: '编辑 OAuth 客户端',
+    resource: 'oauth-client',
+    action: 'update',
+  },
+  {
+    name: '禁用 OAuth 客户端',
+    code: 'oauth-client:disable',
+    description: '禁用或启用 OAuth 客户端',
+    resource: 'oauth-client',
+    action: 'disable',
+  },
+  {
+    name: '轮换 OAuth 客户端密钥',
+    code: 'oauth-client:rotate-secret',
+    description: '轮换 OAuth 客户端密钥',
+    resource: 'oauth-client',
+    action: 'rotate-secret',
+  },
+] as const;
+
 export async function createPermissions(
   prisma: PrismaClient,
   useRealData = false,
@@ -20,16 +80,20 @@ export async function createPermissions(
   console.log(`🔐 开始创建权限数据，使用${dataSource}...`);
 
   try {
-    const permissionConfigs = useRealData
-      ? REAL_PERMISSION_CONFIGS
-      : PERMISSION_CONFIGS;
+    const permissionConfigs = [
+      ...(useRealData ? REAL_PERMISSION_CONFIGS : PERMISSION_CONFIGS),
+      ...OAUTH_CLIENT_PERMISSION_CONFIGS,
+    ];
     const permissions: Permission[] = [];
 
     for (const permissionData of permissionConfigs) {
+      const oauthDelegatable = OAUTH_DELEGATABLE_PERMISSION_CODES.has(
+        permissionData.code,
+      );
       const permission = await prisma.permission.upsert({
         where: { code: permissionData.code },
-        update: {},
-        create: permissionData,
+        update: { oauthDelegatable },
+        create: { ...permissionData, oauthDelegatable },
       });
       permissions.push(permission);
       console.log(`✅ 创建权限: ${permission.name}`);

--- a/src/admin/oauth-client/dto/index.ts
+++ b/src/admin/oauth-client/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './oauth-client.dto';

--- a/src/admin/oauth-client/dto/oauth-client.dto.ts
+++ b/src/admin/oauth-client/dto/oauth-client.dto.ts
@@ -1,0 +1,162 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { OAuthClientStatus, OAuthClientType } from '@prisma/client';
+
+export class QueryOAuthClientsDto {
+  @ApiPropertyOptional({ default: 1, type: Number })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page: number = 1;
+
+  @ApiPropertyOptional({ default: 20, maximum: 100, type: Number })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  pageSize: number = 20;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  keyword?: string;
+
+  @ApiPropertyOptional({ enum: OAuthClientType })
+  @IsEnum(OAuthClientType)
+  @IsOptional()
+  clientType?: OAuthClientType;
+
+  @ApiPropertyOptional({ enum: OAuthClientStatus })
+  @IsEnum(OAuthClientStatus)
+  @IsOptional()
+  status?: OAuthClientStatus;
+}
+
+export class CreateOAuthClientDto {
+  @ApiProperty({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  name: string;
+
+  @ApiPropertyOptional({ maxLength: 1000 })
+  @IsString()
+  @MaxLength(1000)
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  logoUri?: string;
+
+  @ApiProperty({ enum: OAuthClientType })
+  @IsEnum(OAuthClientType)
+  clientType: OAuthClientType;
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  redirectUris: string[];
+
+  @ApiProperty({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  scopes: string[];
+}
+
+export class UpdateOAuthClientDto {
+  @ApiPropertyOptional({ maxLength: 120 })
+  @IsString()
+  @MaxLength(120)
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({ maxLength: 1000, nullable: true })
+  @IsString()
+  @MaxLength(1000)
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  @IsString()
+  @IsOptional()
+  logoUri?: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @IsOptional()
+  redirectUris?: string[];
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @IsOptional()
+  scopes?: string[];
+}
+
+export class OAuthClientDto {
+  @ApiProperty() id: string;
+  @ApiProperty() clientId: string;
+  @ApiProperty({ enum: OAuthClientType }) clientType: OAuthClientType;
+  @ApiProperty({ enum: OAuthClientStatus }) status: OAuthClientStatus;
+  @ApiProperty() isSystem: boolean;
+  @ApiProperty() name: string;
+  @ApiPropertyOptional({ nullable: true, type: String }) description:
+    | string
+    | null;
+  @ApiPropertyOptional({ nullable: true, type: String }) logoUri: string | null;
+  @ApiProperty({ type: [String] }) redirectUris: string[];
+  @ApiProperty({ type: [String] }) grants: string[];
+  @ApiProperty({ type: [String] }) scopes: string[];
+  @ApiProperty() credentialVersion: number;
+  @ApiPropertyOptional({ nullable: true, type: Date }) disabledAt: Date | null;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+}
+
+export class OAuthClientListResponseDto {
+  @ApiProperty({ type: [OAuthClientDto] }) items: OAuthClientDto[];
+  @ApiProperty() total: number;
+  @ApiProperty() page: number;
+  @ApiProperty() pageSize: number;
+}
+
+export class CreateOAuthClientResponseDto extends OAuthClientDto {
+  @ApiPropertyOptional({
+    description: 'Returned once for confidential clients',
+  })
+  clientSecret?: string;
+}
+
+export class RotateOAuthClientSecretResponseDto {
+  @ApiProperty() clientSecret: string;
+  @ApiProperty() rotatedAt: Date;
+}
+
+export class DelegatableScopeDto {
+  @ApiProperty() code: string;
+  @ApiProperty() name: string;
+  @ApiProperty() resource: string;
+  @ApiProperty() action: string;
+  @ApiPropertyOptional({ nullable: true, type: String }) description:
+    | string
+    | null;
+}

--- a/src/admin/oauth-client/oauth-client-admin.controller.spec.ts
+++ b/src/admin/oauth-client/oauth-client-admin.controller.spec.ts
@@ -1,0 +1,34 @@
+import { Test } from '@nestjs/testing';
+
+import { PERMISSIONS_KEY } from '@/admin/permission/decorators/permissions.decorator';
+import { REQUIRE_AUTH_KEY } from '@/auth/decorators/require-auth.decorator';
+import { OAuthClientAdminController } from './oauth-client-admin.controller';
+import { OAuthClientAdminService } from './oauth-client-admin.service';
+
+/* eslint-disable @typescript-eslint/unbound-method -- Metadata assertions intentionally inspect controller methods without invoking them. */
+
+describe('OAuthClientAdminController', () => {
+  it('requires normal JWT auth and dedicated operation permissions', async () => {
+    const module = await Test.createTestingModule({
+      controllers: [OAuthClientAdminController],
+      providers: [{ provide: OAuthClientAdminService, useValue: {} }],
+    }).compile();
+    const controller = module.get(OAuthClientAdminController);
+
+    expect(
+      Reflect.getMetadata(REQUIRE_AUTH_KEY, OAuthClientAdminController),
+    ).toEqual(['jwt']);
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.create)).toEqual([
+      'oauth-client:create',
+    ]);
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.update)).toEqual([
+      'oauth-client:update',
+    ]);
+    expect(Reflect.getMetadata(PERMISSIONS_KEY, controller.disable)).toEqual([
+      'oauth-client:disable',
+    ]);
+    expect(
+      Reflect.getMetadata(PERMISSIONS_KEY, controller.rotateSecret),
+    ).toEqual(['oauth-client:rotate-secret']);
+  });
+});

--- a/src/admin/oauth-client/oauth-client-admin.controller.ts
+++ b/src/admin/oauth-client/oauth-client-admin.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { RequirePermissions } from '@/admin/permission/decorators/permissions.decorator';
+import { RequireAuth } from '@/auth/decorators/require-auth.decorator';
+import { CurrentUser, User } from '@/auth/decorators/user.decorator';
+import {
+  CreateOAuthClientDto,
+  CreateOAuthClientResponseDto,
+  DelegatableScopeDto,
+  OAuthClientDto,
+  OAuthClientListResponseDto,
+  QueryOAuthClientsDto,
+  RotateOAuthClientSecretResponseDto,
+  UpdateOAuthClientDto,
+} from './dto';
+import { OAuthClientAdminService } from './oauth-client-admin.service';
+
+@ApiTags('Admin / OAuth Clients')
+@ApiBearerAuth()
+@RequireAuth('jwt')
+@Controller('admin/oauth-clients')
+export class OAuthClientAdminController {
+  constructor(private readonly service: OAuthClientAdminService) {}
+
+  @Get()
+  @RequirePermissions('oauth-client:read')
+  @ApiResponse({ type: OAuthClientListResponseDto })
+  list(@Query() query: QueryOAuthClientsDto) {
+    return this.service.list(query);
+  }
+
+  @Post()
+  @RequirePermissions('oauth-client:create')
+  @ApiResponse({ type: CreateOAuthClientResponseDto })
+  create(@Body() dto: CreateOAuthClientDto, @User() user: CurrentUser) {
+    return this.service.create(dto, user.id);
+  }
+
+  @Get('delegatable-scopes')
+  @RequirePermissions('oauth-client:read')
+  @ApiResponse({ type: [DelegatableScopeDto] })
+  listDelegatableScopes() {
+    return this.service.listDelegatableScopes();
+  }
+
+  @Get(':id')
+  @RequirePermissions('oauth-client:read')
+  @ApiResponse({ type: OAuthClientDto })
+  getById(@Param('id') id: string) {
+    return this.service.getById(id);
+  }
+
+  @Patch(':id')
+  @RequirePermissions('oauth-client:update')
+  @ApiResponse({ type: OAuthClientDto })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateOAuthClientDto,
+    @User() user: CurrentUser,
+  ) {
+    return this.service.update(id, dto, user.id);
+  }
+
+  @Post(':id/disable')
+  @RequirePermissions('oauth-client:disable')
+  @ApiOperation({ summary: 'Disable a client and revoke all delegated grants' })
+  @ApiResponse({ type: OAuthClientDto })
+  disable(@Param('id') id: string, @User() user: CurrentUser) {
+    return this.service.disable(id, user.id);
+  }
+
+  @Post(':id/enable')
+  @RequirePermissions('oauth-client:disable')
+  @ApiResponse({ type: OAuthClientDto })
+  enable(@Param('id') id: string, @User() user: CurrentUser) {
+    return this.service.enable(id, user.id);
+  }
+
+  @Post(':id/rotate-secret')
+  @RequirePermissions('oauth-client:rotate-secret')
+  @ApiResponse({ type: RotateOAuthClientSecretResponseDto })
+  rotateSecret(@Param('id') id: string, @User() user: CurrentUser) {
+    return this.service.rotateSecret(id, user.id);
+  }
+}

--- a/src/admin/oauth-client/oauth-client-admin.module.ts
+++ b/src/admin/oauth-client/oauth-client-admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '@/prisma/prisma.module';
+import { OAuthClientAdminController } from './oauth-client-admin.controller';
+import { OAuthClientAdminService } from './oauth-client-admin.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [OAuthClientAdminController],
+  providers: [OAuthClientAdminService],
+})
+export class OAuthClientAdminModule {}

--- a/src/admin/oauth-client/oauth-client-admin.service.spec.ts
+++ b/src/admin/oauth-client/oauth-client-admin.service.spec.ts
@@ -1,0 +1,127 @@
+import { ForbiddenException } from '@nestjs/common';
+import { OAuthClientStatus, OAuthClientType } from '@prisma/client';
+
+import { PrismaService } from '@/prisma/prisma.service';
+import { OAuthClientAdminService } from './oauth-client-admin.service';
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matchers are intentionally untyped. */
+
+describe('OAuthClientAdminService', () => {
+  const tx = {
+    oAuthClient: { create: jest.fn(), update: jest.fn() },
+    oAuthClientAuditLog: { create: jest.fn() },
+    oAuthToken: { updateMany: jest.fn() },
+    oAuthAuthCode: { deleteMany: jest.fn() },
+    oAuthAuthorizationRequest: { updateMany: jest.fn() },
+  };
+  const prisma = {
+    oAuthClient: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    permission: { findMany: jest.fn() },
+    $transaction: jest.fn(),
+  };
+  const service = new OAuthClientAdminService(
+    prisma as unknown as PrismaService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.$transaction.mockImplementation(
+      (callback: (client: typeof tx) => unknown) => callback(tx),
+    );
+    prisma.permission.findMany.mockResolvedValue([{ code: 'meeting:read' }]);
+    tx.oAuthClientAuditLog.create.mockResolvedValue({});
+  });
+
+  it.each([
+    [OAuthClientType.PUBLIC, false],
+    [OAuthClientType.CONFIDENTIAL, true],
+  ])(
+    'creates a %s client with one-time secret=%s',
+    async (clientType, hasSecret) => {
+      tx.oAuthClient.create.mockImplementation(({ data }) =>
+        Promise.resolve({
+          id: 'client-1',
+          ...data,
+          status: OAuthClientStatus.ACTIVE,
+          isSystem: false,
+          credentialVersion: 1,
+          disabledAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      );
+
+      const result = await service.create(
+        {
+          name: 'Example',
+          clientType,
+          redirectUris: ['https://example.com/callback'],
+          scopes: ['meeting:read'],
+        },
+        'user-1',
+      );
+
+      expect('clientSecret' in result).toBe(hasSecret);
+      expect(tx.oAuthClientAuditLog.create).toHaveBeenCalledWith({
+        data: expect.not.objectContaining({ clientSecret: expect.anything() }),
+      });
+    },
+  );
+
+  it('rejects writes to a system client', async () => {
+    prisma.oAuthClient.findUnique.mockResolvedValue({
+      id: 'client-1',
+      isSystem: true,
+    });
+
+    await expect(service.disable('client-1', 'user-1')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('increments credential version and revokes grants when disabled', async () => {
+    prisma.oAuthClient.findUnique.mockResolvedValue({
+      id: 'client-1',
+      clientId: 'client-id',
+      isSystem: false,
+      status: OAuthClientStatus.ACTIVE,
+    });
+    tx.oAuthClient.update.mockResolvedValue({
+      id: 'client-1',
+      clientId: 'client-id',
+      clientSecret: null,
+      clientType: OAuthClientType.PUBLIC,
+      status: OAuthClientStatus.DISABLED,
+      isSystem: false,
+      credentialVersion: 2,
+      disabledAt: new Date(),
+      name: 'Example',
+      description: null,
+      logoUri: null,
+      redirectUris: ['https://example.com/callback'],
+      grants: ['authorization_code', 'refresh_token'],
+      scopes: ['meeting:read'],
+      createdBy: 'user-1',
+      updatedBy: 'user-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await service.disable('client-1', 'user-1');
+
+    expect(tx.oAuthClient.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ credentialVersion: { increment: 1 } }),
+      }),
+    );
+    expect(tx.oAuthToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clientId: 'client-id', revoked: false },
+      }),
+    );
+  });
+});

--- a/src/admin/oauth-client/oauth-client-admin.service.ts
+++ b/src/admin/oauth-client/oauth-client-admin.service.ts
@@ -1,0 +1,319 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  OAuthClient,
+  OAuthClientStatus,
+  OAuthClientType,
+  Prisma,
+} from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+import * as crypto from 'crypto';
+
+import { PrismaService } from '@/prisma/prisma.service';
+import {
+  CreateOAuthClientDto,
+  QueryOAuthClientsDto,
+  UpdateOAuthClientDto,
+} from './dto';
+
+const OAUTH_GRANTS = ['authorization_code', 'refresh_token'];
+
+@Injectable()
+export class OAuthClientAdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async list(query: QueryOAuthClientsDto) {
+    const where: Prisma.OAuthClientWhereInput = {
+      clientType: query.clientType,
+      status: query.status,
+    };
+    const keyword = query.keyword?.trim();
+    if (keyword) {
+      where.OR = [
+        { name: { contains: keyword, mode: 'insensitive' } },
+        { clientId: { contains: keyword, mode: 'insensitive' } },
+      ];
+    }
+    const skip = (query.page - 1) * query.pageSize;
+    const [items, total] = await Promise.all([
+      this.prisma.oAuthClient.findMany({
+        where,
+        skip,
+        take: query.pageSize,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.oAuthClient.count({ where }),
+    ]);
+    return {
+      items: items.map((client) => this.toDto(client)),
+      total,
+      page: query.page,
+      pageSize: query.pageSize,
+    };
+  }
+
+  async getById(id: string) {
+    return this.toDto(await this.requireClient(id));
+  }
+
+  async listDelegatableScopes() {
+    return this.prisma.permission.findMany({
+      where: { active: true, oauthDelegatable: true },
+      select: {
+        code: true,
+        name: true,
+        resource: true,
+        action: true,
+        description: true,
+      },
+      orderBy: [{ resource: 'asc' }, { action: 'asc' }],
+    });
+  }
+
+  async create(dto: CreateOAuthClientDto, actorUserId: string) {
+    const redirectUris = this.validateRedirectUris(dto.redirectUris);
+    const scopes = await this.validateScopes(dto.scopes);
+    const clientSecret =
+      dto.clientType === OAuthClientType.CONFIDENTIAL
+        ? crypto.randomBytes(32).toString('base64url')
+        : undefined;
+    const client = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.oAuthClient.create({
+        data: {
+          clientId: crypto.randomBytes(32).toString('hex'),
+          clientSecret: clientSecret
+            ? await bcrypt.hash(clientSecret, 10)
+            : null,
+          clientType: dto.clientType,
+          name: dto.name.trim(),
+          description: dto.description?.trim() || null,
+          logoUri: dto.logoUri?.trim() || null,
+          redirectUris,
+          scopes,
+          grants: OAUTH_GRANTS,
+          createdBy: actorUserId,
+          updatedBy: actorUserId,
+        },
+      });
+      await this.audit(tx, created.id, actorUserId, 'CREATE', {
+        clientType: created.clientType,
+        scopes: created.scopes,
+        redirectUris: created.redirectUris,
+      });
+      return created;
+    });
+    return { ...this.toDto(client), ...(clientSecret ? { clientSecret } : {}) };
+  }
+
+  async update(id: string, dto: UpdateOAuthClientDto, actorUserId: string) {
+    const existing = await this.requireMutableClient(id);
+    const scopes = dto.scopes
+      ? await this.validateScopes(dto.scopes)
+      : existing.scopes;
+    const redirectUris = dto.redirectUris
+      ? this.validateRedirectUris(dto.redirectUris)
+      : existing.redirectUris;
+    const scopesChanged = !this.sameSet(scopes, existing.scopes);
+    const client = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.oAuthClient.update({
+        where: { id },
+        data: {
+          name: dto.name?.trim(),
+          description:
+            dto.description === undefined
+              ? undefined
+              : dto.description.trim() || null,
+          logoUri:
+            dto.logoUri === undefined ? undefined : dto.logoUri.trim() || null,
+          redirectUris,
+          scopes,
+          updatedBy: actorUserId,
+          credentialVersion: scopesChanged ? { increment: 1 } : undefined,
+        },
+      });
+      if (scopesChanged) await this.revokeRefreshTokens(tx, existing.clientId);
+      await this.audit(tx, id, actorUserId, 'UPDATE', {
+        changedFields: Object.keys(dto),
+        scopesChanged,
+      });
+      return updated;
+    });
+    return this.toDto(client);
+  }
+
+  async disable(id: string, actorUserId: string) {
+    const existing = await this.requireMutableClient(id);
+    if (existing.status === OAuthClientStatus.DISABLED)
+      return this.toDto(existing);
+    const now = new Date();
+    const client = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.oAuthClient.update({
+        where: { id },
+        data: {
+          status: OAuthClientStatus.DISABLED,
+          disabledAt: now,
+          credentialVersion: { increment: 1 },
+          updatedBy: actorUserId,
+        },
+      });
+      await Promise.all([
+        this.revokeRefreshTokens(tx, existing.clientId),
+        tx.oAuthAuthCode.deleteMany({ where: { clientId: existing.clientId } }),
+        tx.oAuthAuthorizationRequest.updateMany({
+          where: { clientId: existing.clientId, consumedAt: null },
+          data: { consumedAt: now },
+        }),
+      ]);
+      await this.audit(tx, id, actorUserId, 'DISABLE');
+      return updated;
+    });
+    return this.toDto(client);
+  }
+
+  async enable(id: string, actorUserId: string) {
+    const existing = await this.requireMutableClient(id);
+    if (existing.status === OAuthClientStatus.ACTIVE)
+      return this.toDto(existing);
+    const client = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.oAuthClient.update({
+        where: { id },
+        data: {
+          status: OAuthClientStatus.ACTIVE,
+          disabledAt: null,
+          updatedBy: actorUserId,
+        },
+      });
+      await this.audit(tx, id, actorUserId, 'ENABLE');
+      return updated;
+    });
+    return this.toDto(client);
+  }
+
+  async rotateSecret(id: string, actorUserId: string) {
+    const existing = await this.requireMutableClient(id);
+    if (existing.clientType !== OAuthClientType.CONFIDENTIAL) {
+      throw new BadRequestException(
+        'Public OAuth clients do not have a secret',
+      );
+    }
+    const clientSecret = crypto.randomBytes(32).toString('base64url');
+    const rotatedAt = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      await tx.oAuthClient.update({
+        where: { id },
+        data: {
+          clientSecret: await bcrypt.hash(clientSecret, 10),
+          updatedBy: actorUserId,
+        },
+      });
+      await this.revokeRefreshTokens(tx, existing.clientId);
+      await this.audit(tx, id, actorUserId, 'ROTATE_SECRET');
+    });
+    return { clientSecret, rotatedAt };
+  }
+
+  private validateRedirectUris(values: string[]) {
+    const normalized = [...new Set(values.map((value) => value.trim()))];
+    for (const value of normalized) {
+      let url: URL;
+      try {
+        url = new URL(value);
+      } catch {
+        throw new BadRequestException(`Invalid redirect URI: ${value}`);
+      }
+      if (value.includes('*') || url.hash || url.username || url.password) {
+        throw new BadRequestException(`Unsafe redirect URI: ${value}`);
+      }
+      const isLoopback =
+        url.protocol === 'http:' && url.hostname === '127.0.0.1';
+      const allowDevelopmentHttp =
+        process.env.NODE_ENV !== 'production' && url.protocol === 'http:';
+      if (url.protocol !== 'https:' && !isLoopback && !allowDevelopmentHttp) {
+        throw new BadRequestException(`Redirect URI must use HTTPS: ${value}`);
+      }
+    }
+    return normalized;
+  }
+
+  private async validateScopes(values: string[]) {
+    const scopes = [
+      ...new Set(values.map((value) => value.trim()).filter(Boolean)),
+    ];
+    const permissions = await this.prisma.permission.findMany({
+      where: { code: { in: scopes }, active: true, oauthDelegatable: true },
+      select: { code: true },
+    });
+    const allowed = new Set(permissions.map(({ code }) => code));
+    const invalid = scopes.filter((scope) => !allowed.has(scope));
+    if (invalid.length) {
+      throw new BadRequestException(
+        `Scopes are not OAuth delegatable: ${invalid.join(', ')}`,
+      );
+    }
+    return scopes;
+  }
+
+  private async requireClient(id: string) {
+    const client = await this.prisma.oAuthClient.findUnique({ where: { id } });
+    if (!client) throw new NotFoundException('OAuth client not found');
+    return client;
+  }
+
+  private async requireMutableClient(id: string) {
+    const client = await this.requireClient(id);
+    if (client.isSystem) {
+      throw new ForbiddenException('System OAuth clients are read-only');
+    }
+    return client;
+  }
+
+  private revokeRefreshTokens(tx: Prisma.TransactionClient, clientId: string) {
+    return tx.oAuthToken.updateMany({
+      where: { clientId, revoked: false },
+      data: { revoked: true, revokedAt: new Date() },
+    });
+  }
+
+  private audit(
+    tx: Prisma.TransactionClient,
+    oauthClientId: string,
+    actorUserId: string,
+    action: string,
+    metadata?: Prisma.InputJsonValue,
+  ) {
+    return tx.oAuthClientAuditLog.create({
+      data: { oauthClientId, actorUserId, action, metadata },
+    });
+  }
+
+  private sameSet(first: string[], second: string[]) {
+    return (
+      first.length === second.length &&
+      first.every((value) => second.includes(value))
+    );
+  }
+
+  private toDto(client: OAuthClient) {
+    return {
+      id: client.id,
+      clientId: client.clientId,
+      clientType: client.clientType,
+      status: client.status,
+      isSystem: client.isSystem,
+      name: client.name,
+      description: client.description,
+      logoUri: client.logoUri,
+      redirectUris: client.redirectUris,
+      grants: client.grants,
+      scopes: client.scopes,
+      credentialVersion: client.credentialVersion,
+      disabledAt: client.disabledAt,
+      createdAt: client.createdAt,
+      updatedAt: client.updatedAt,
+    };
+  }
+}

--- a/src/admin/permission/dto/create-permission.dto.ts
+++ b/src/admin/permission/dto/create-permission.dto.ts
@@ -84,4 +84,13 @@ export class CreatePermissionDto {
     return value as boolean;
   })
   active?: boolean;
+
+  @ApiProperty({
+    description: '是否允许作为 OAuth 委托 Scope',
+    example: false,
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  oauthDelegatable?: boolean;
 }

--- a/src/admin/permission/dto/permission-tree.dto.ts
+++ b/src/admin/permission/dto/permission-tree.dto.ts
@@ -35,6 +35,9 @@ export class PermissionTreeDto {
   @ApiProperty({ description: '是否启用' })
   active: boolean;
 
+  @ApiProperty({ description: '是否允许作为 OAuth 委托 Scope' })
+  oauthDelegatable: boolean;
+
   @ApiProperty({ description: '创建时间' })
   createdAt: Date;
 

--- a/src/admin/permission/dto/permission.dto.ts
+++ b/src/admin/permission/dto/permission.dto.ts
@@ -21,4 +21,7 @@ export class PermissionDto {
 
   @ApiProperty({ description: '权限类型' })
   type: string;
+
+  @ApiProperty({ description: '是否允许作为 OAuth 委托 Scope' })
+  oauthDelegatable: boolean;
 }

--- a/src/admin/permission/dto/update-permission.dto.ts
+++ b/src/admin/permission/dto/update-permission.dto.ts
@@ -63,4 +63,9 @@ export class UpdatePermissionDto {
     return value as boolean;
   })
   active?: boolean;
+
+  @ApiPropertyOptional({ description: '是否允许作为 OAuth 委托 Scope' })
+  @IsBoolean()
+  @IsOptional()
+  oauthDelegatable?: boolean;
 }

--- a/src/admin/permission/repositories/permission.repository.ts
+++ b/src/admin/permission/repositories/permission.repository.ts
@@ -71,6 +71,7 @@ export class PermRepository {
         resource: true,
         action: true,
         type: true,
+        oauthDelegatable: true,
       },
       orderBy: [
         {
@@ -177,6 +178,7 @@ export class PermRepository {
     level?: number;
     sortOrder?: number;
     active?: boolean;
+    oauthDelegatable?: boolean;
   }) {
     return this.prisma.permission.create({
       data,
@@ -195,6 +197,7 @@ export class PermRepository {
       level?: number;
       sortOrder?: number;
       active?: boolean;
+      oauthDelegatable?: boolean;
     },
   ) {
     return this.prisma.permission.update({

--- a/src/admin/permission/services/permission.service.ts
+++ b/src/admin/permission/services/permission.service.ts
@@ -79,6 +79,7 @@ export class PermService {
       resource: string;
       action: string;
       type: string;
+      oauthDelegatable: boolean;
     }>
   > {
     try {
@@ -299,6 +300,7 @@ export class PermService {
       level: permission.level,
       sortOrder: permission.sortOrder,
       active: permission.active,
+      oauthDelegatable: permission.oauthDelegatable,
       createdAt: permission.createdAt,
       updatedAt: permission.updatedAt,
       children: permission.children?.map((child) => this.toTreeDto(child)),

--- a/src/admin/role/services/role.service.ts
+++ b/src/admin/role/services/role.service.ts
@@ -209,6 +209,7 @@ export class RoleService {
       resource: permission.resource,
       action: permission.action,
       type: permission.type,
+      oauthDelegatable: permission.oauthDelegatable,
     };
   }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,6 +57,7 @@ import { ProductModule } from './product/product.module';
 import { ChannelModule } from './channel/channel.module';
 import { OrderRefundModule } from './order-refund/order-refund.module';
 import { TrackingReportModule } from './tracking-report/tracking-report.module';
+import { OAuthClientAdminModule } from './admin/oauth-client/oauth-client-admin.module';
 
 @Module({
   imports: [
@@ -130,6 +131,7 @@ import { TrackingReportModule } from './tracking-report/tracking-report.module';
     ChannelModule,
     OrderRefundModule,
     TrackingReportModule,
+    OAuthClientAdminModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/auth/guards/unified-auth.guard.spec.ts
+++ b/src/auth/guards/unified-auth.guard.spec.ts
@@ -10,6 +10,7 @@ import { ApiKeyService } from '@/admin/api-key/services/api-key.service';
 import { UserOrgService } from '@/admin/api-key/services/user-organization.service';
 import { PermService } from '@/admin/permission/services/permission.service';
 import { REQUIRE_AUTH_KEY } from '../decorators/require-auth.decorator';
+import { PrismaService } from '@/prisma/prisma.service';
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
@@ -84,6 +85,10 @@ describe('UnifiedAuthGuard', () => {
         { provide: ApiKeyService, useValue: mockApiKeyService },
         { provide: UserOrgService, useValue: mockUserOrgService },
         { provide: PermService, useValue: mockPermService },
+        {
+          provide: PrismaService,
+          useValue: { oAuthClient: { findUnique: jest.fn() } },
+        },
       ],
     }).compile();
 

--- a/src/auth/guards/unified-auth.guard.ts
+++ b/src/auth/guards/unified-auth.guard.ts
@@ -31,6 +31,8 @@ import { ApiKeyService } from '@/admin/api-key/services/api-key.service';
 import { UserOrgService } from '@/admin/api-key/services/user-organization.service';
 import { PermService } from '@/admin/permission/services/permission.service';
 import type { AuthenticatedUser } from '@/auth/types/jwt.types';
+import { PrismaService } from '@/prisma/prisma.service';
+import { OAuthClientStatus } from '@prisma/client';
 
 @Injectable()
 export class UnifiedAuthGuard extends AuthGuard('jwt') implements CanActivate {
@@ -41,6 +43,7 @@ export class UnifiedAuthGuard extends AuthGuard('jwt') implements CanActivate {
     private readonly apiKeyService: ApiKeyService,
     private readonly userOrgService: UserOrgService,
     private readonly permService: PermService,
+    private readonly prisma: PrismaService,
   ) {
     super();
   }
@@ -80,7 +83,7 @@ export class UnifiedAuthGuard extends AuthGuard('jwt') implements CanActivate {
       );
     }
 
-    return this.handleJwtAuth(context, request);
+    return this.handleJwtAuth(context, request, requiredMethods);
   }
 
   /**
@@ -131,6 +134,7 @@ export class UnifiedAuthGuard extends AuthGuard('jwt') implements CanActivate {
   private async handleJwtAuth(
     context: ExecutionContext,
     request: Request,
+    requiredMethods?: AuthMethod[],
   ): Promise<boolean> {
     // 委托给 Passport JWT strategy
     const result = await (super.canActivate(context) as Promise<boolean>);
@@ -143,11 +147,38 @@ export class UnifiedAuthGuard extends AuthGuard('jwt') implements CanActivate {
     // OAuth access tokens are delegated credentials: their scopes and
     // organization are an upper bound, not the user's complete role set.
     if (user.tokenUse === 'oauth_access') {
+      if (requiredMethods && !requiredMethods.includes('oauth')) {
+        throw new ForbiddenException(
+          'This endpoint does not accept OAuth delegated authentication',
+        );
+      }
+      const client = user.clientId
+        ? await this.prisma.oAuthClient.findUnique({
+            where: { clientId: user.clientId },
+            select: {
+              status: true,
+              credentialVersion: true,
+              scopes: true,
+            },
+          })
+        : null;
+      if (
+        !client ||
+        client.status !== OAuthClientStatus.ACTIVE ||
+        client.credentialVersion !== (user.credentialVersion ?? 1)
+      ) {
+        throw new UnauthorizedException(
+          'OAuth client credential is no longer active',
+        );
+      }
+      const currentScopes = (user.scopes ?? []).filter((scope) =>
+        client.scopes.includes(scope),
+      );
       request.authContext = {
         authMethod: 'oauth',
         userId: user.id,
         orgId: user.organizationId ?? null,
-        permissions: user.scopes ?? [],
+        permissions: currentScopes,
         oauthClientId: user.clientId,
       };
       return true;

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -72,6 +72,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       authUser.tokenUse = payload.token_use;
       authUser.clientId = payload.client_id;
       authUser.organizationId = payload.org_id;
+      authUser.credentialVersion = payload.credential_version ?? 1;
     }
 
     return authUser;

--- a/src/auth/types/jwt.types.ts
+++ b/src/auth/types/jwt.types.ts
@@ -25,6 +25,7 @@ export interface AuthenticatedUser {
   tokenUse?: 'oauth_access';
   clientId?: string;
   organizationId?: string;
+  credentialVersion?: number;
 }
 
 export interface JwtPayload {
@@ -38,6 +39,7 @@ export interface JwtPayload {
   token_use?: 'oauth_access';
   client_id?: string;
   org_id?: string;
+  credential_version?: number;
 }
 
 export enum TokenBlacklistScope {

--- a/src/oauth/controllers/oauth.controller.ts
+++ b/src/oauth/controllers/oauth.controller.ts
@@ -91,7 +91,11 @@ export class OAuthController {
   @Public()
   @HttpCode(HttpStatus.OK)
   async token(@Body(ValidationPipe) body: TokenDto) {
-    await this.clientService.validateClient(body.client_id, body.client_secret);
+    const client = await this.clientService.validateClient(
+      body.client_id,
+      body.client_secret,
+    );
+    this.clientService.requireGrant(client.grants, body.grant_type);
     if (body.grant_type === 'authorization_code') {
       if (!body.code || !body.redirect_uri || !body.code_verifier) {
         throw new BadRequestException(
@@ -115,7 +119,7 @@ export class OAuthController {
   @Public()
   @HttpCode(HttpStatus.OK)
   async revoke(@Body(ValidationPipe) body: RevokeTokenDto) {
-    await this.clientService.validateClient(body.client_id);
+    await this.clientService.validateClient(body.client_id, body.client_secret);
     await this.grantService.revokeRefreshToken(body.client_id, body.token);
     return {};
   }

--- a/src/oauth/dto/oauth.dto.ts
+++ b/src/oauth/dto/oauth.dto.ts
@@ -112,6 +112,11 @@ export class RevokeTokenDto {
   @IsString()
   @IsNotEmpty()
   client_id: string;
+
+  @ApiPropertyOptional({ description: 'Confidential clients only' })
+  @IsString()
+  @IsOptional()
+  client_secret?: string;
 }
 
 export class CreateClientDto {

--- a/src/oauth/services/oauth-client.service.spec.ts
+++ b/src/oauth/services/oauth-client.service.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { OAuthClientType } from '@prisma/client';
+import { OAuthClientStatus, OAuthClientType } from '@prisma/client';
 
 import { PrismaService } from '@/prisma/prisma.service';
 import { OAuthClientService } from './oauth-client.service';
@@ -17,6 +17,7 @@ describe('OAuthClientService', () => {
     findUnique.mockResolvedValue({
       clientId: 'nove-cli',
       clientType: OAuthClientType.PUBLIC,
+      status: OAuthClientStatus.ACTIVE,
       redirectUris: ['http://127.0.0.1/oauth/callback'],
     });
 
@@ -37,6 +38,7 @@ describe('OAuthClientService', () => {
     findUnique.mockResolvedValue({
       clientId: 'nove-cli',
       clientType: OAuthClientType.PUBLIC,
+      status: OAuthClientStatus.ACTIVE,
       redirectUris: ['http://127.0.0.1/oauth/callback'],
     });
 
@@ -50,6 +52,7 @@ describe('OAuthClientService', () => {
       clientId: 'nove-cli',
       clientSecret: null,
       clientType: OAuthClientType.PUBLIC,
+      status: OAuthClientStatus.ACTIVE,
       scopes: ['meeting:read'],
     });
 

--- a/src/oauth/services/oauth-client.service.ts
+++ b/src/oauth/services/oauth-client.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { OAuthClientType } from '@prisma/client';
+import { OAuthClientStatus } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import * as crypto from 'crypto';
 
@@ -50,6 +51,7 @@ export class OAuthClientService {
 
   async validateClient(clientId: string, clientSecret?: string) {
     const client = await this.findClient(clientId);
+    this.requireActive(client.status);
     if (client.clientType === OAuthClientType.PUBLIC) return client;
     if (!clientSecret || !client.clientSecret) {
       throw new BadRequestException('Client credentials are required');
@@ -62,6 +64,7 @@ export class OAuthClientService {
 
   async validateRedirectUri(clientId: string, redirectUri: string) {
     const client = await this.findClient(clientId);
+    this.requireActive(client.status);
     const matches = client.redirectUris.some((registered) =>
       this.redirectUriMatches(registered, redirectUri),
     );
@@ -81,6 +84,18 @@ export class OAuthClientService {
       throw new BadRequestException('At least one scope is required');
     }
     return requested;
+  }
+
+  requireGrant(grants: string[], grant: string) {
+    if (!grants.includes(grant)) {
+      throw new BadRequestException(`Grant type is not allowed: ${grant}`);
+    }
+  }
+
+  private requireActive(status: OAuthClientStatus) {
+    if (status !== OAuthClientStatus.ACTIVE) {
+      throw new BadRequestException('OAuth client is disabled');
+    }
   }
 
   private redirectUriMatches(registeredValue: string, requestedValue: string) {

--- a/src/oauth/services/oauth-grant.service.spec.ts
+++ b/src/oauth/services/oauth-grant.service.spec.ts
@@ -25,6 +25,7 @@ describe('OAuthGrantService', () => {
       findUnique: jest.fn(),
       updateMany: jest.fn(),
     },
+    oAuthClient: { findUnique: jest.fn() },
     orgMember: { count: jest.fn(), findMany: jest.fn() },
     permission: { findMany: jest.fn() },
     $transaction: jest.fn(),
@@ -33,6 +34,7 @@ describe('OAuthGrantService', () => {
   const clientService = {
     validateRedirectUri: jest.fn(),
     validateRequestedScopes: jest.fn(),
+    requireGrant: jest.fn(),
   };
   const permService = { getPermByUserId: jest.fn() };
   const service = new OAuthGrantService(
@@ -51,6 +53,12 @@ describe('OAuthGrantService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.$transaction.mockImplementation((callback) => callback(prisma));
+    prisma.oAuthClient.findUnique.mockResolvedValue({
+      status: 'ACTIVE',
+      credentialVersion: 1,
+      grants: ['authorization_code', 'refresh_token'],
+      scopes: ['meeting:read'],
+    });
   });
 
   it('persists only client-approved requested scopes and the PKCE challenge', async () => {
@@ -86,7 +94,7 @@ describe('OAuthGrantService', () => {
     prisma.oAuthAuthorizationRequest.findUnique.mockResolvedValue({
       id: 'request-1',
       clientId: 'nove-cli',
-      client: {},
+      client: { status: 'ACTIVE' },
       consumedAt: null,
       expiresAt: new Date(Date.now() + 60_000),
       requestedScopes: ['meeting:read'],

--- a/src/oauth/services/oauth-grant.service.ts
+++ b/src/oauth/services/oauth-grant.service.ts
@@ -323,7 +323,12 @@ export class OAuthGrantService {
       where: { id: requestId },
       include: { client: true },
     });
-    if (!request || request.consumedAt || request.expiresAt <= new Date()) {
+    if (
+      !request ||
+      request.client.status !== 'ACTIVE' ||
+      request.consumedAt ||
+      request.expiresAt <= new Date()
+    ) {
       throw new BadRequestException(
         'Authorization request is invalid or expired',
       );
@@ -352,6 +357,22 @@ export class OAuthGrantService {
       familyId: string;
     },
   ) {
+    const client = await tx.oAuthClient.findUnique({
+      where: { clientId: grant.clientId },
+      select: {
+        status: true,
+        credentialVersion: true,
+        grants: true,
+        scopes: true,
+      },
+    });
+    if (!client || client.status !== 'ACTIVE') {
+      throw new UnauthorizedException('OAuth client is disabled');
+    }
+    this.clientService.requireGrant(client.grants, 'refresh_token');
+    const effectiveScopes = grant.scopes.filter((scope) =>
+      client.scopes.includes(scope),
+    );
     const expiresIn = parseAccessTokenTtl(this.config.accessExpiresIn);
     const accessToken = this.jwtService.sign(
       {
@@ -359,7 +380,8 @@ export class OAuthGrantService {
         client_id: grant.clientId,
         token_use: 'oauth_access',
         org_id: grant.organizationId,
-        scopes: grant.scopes,
+        scopes: effectiveScopes,
+        credential_version: client.credentialVersion,
       },
       {
         secret: this.config.accessSecret,
@@ -375,7 +397,7 @@ export class OAuthGrantService {
         clientId: grant.clientId,
         userId: grant.userId,
         organizationId: grant.organizationId,
-        scopes: grant.scopes,
+        scopes: effectiveScopes,
         expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
       },
     });
@@ -385,7 +407,7 @@ export class OAuthGrantService {
       token_type: 'Bearer',
       expires_in: expiresIn,
       refresh_token: refreshToken,
-      scope: grant.scopes.join(' '),
+      scope: effectiveScopes.join(' '),
       organization_id: grant.organizationId,
     };
   }


### PR DESCRIPTION
## Summary

- add platform-level OAuth client list, create, detail, update, disable, enable, and secret rotation APIs
- enforce JWT-only fine-grained administration permissions and keep built-in clients read-only
- add credential-version based immediate access-token invalidation and refresh-token revocation for lifecycle changes
- add delegatable permission scopes, audit logs, deterministic seeds, and a Prisma-generated schema-only migration
- document OAuth client management and lifecycle semantics

## Validation

- `pnpm db:generate`
- `pnpm exec prisma validate`
- isolated PostgreSQL migration apply from the full migration history
- real seed executed twice successfully to verify idempotency
- `pnpm test:unit --runInBand` — 58 suites, 343 tests passed
- `pnpm build`
- `pnpm lint`
- `pnpm lint:prisma`
- `pnpm docs:build`
- `git diff --check`

## Related PRs

- Admin UI: https://github.com/lulabs-org/nove-admin/pull/114
