### PR TITLE
feat(auth): add token version to invalidate all access tokens globally

### DIFF
--- a/prisma/migrations/20260826100000_add_user_token_version/migration.sql
+++ b/prisma/migrations/20260826100000_add_user_token_version/migration.sql
@@ -1,0 +1,2 @@
+-- 令牌版本：递增后使该用户所有已签发的 access token 立即失效
+ALTER TABLE "users" ADD COLUMN "token_version" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/models/user.prisma
+++ b/prisma/models/user.prisma
@@ -22,6 +22,9 @@ model User {
   // 用户状态
   active Boolean @default(true) // 用户状态：true=活跃，false=禁用
 
+  // 令牌版本：递增后使该用户所有已签发的 access token 立即失效（用于全部设备登出等全局撤销场景）
+  tokenVersion Int @default(0) @map("token_version")
+
   // 系统时间戳字段
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)

--- a/src/auth/services/jwt-user-lookup.service.ts
+++ b/src/auth/services/jwt-user-lookup.service.ts
@@ -50,6 +50,7 @@ export class JwtUserLookupService implements JwtUserLookup {
       phoneVerified: !!user.phoneVerifiedAt,
       createdAt: user.createdAt,
       lastLoginAt: user.lastLoginAt,
+      tokenVersion: user.tokenVersion,
     };
   }
 }

--- a/src/auth/services/token.service.spec.ts
+++ b/src/auth/services/token.service.spec.ts
@@ -1,0 +1,116 @@
+import { JwtService } from '@nestjs/jwt';
+import { ConfigType } from '@nestjs/config';
+
+import { jwtConfig } from '@/configs/jwt.config';
+import { UserQueryRepository } from '@/user/repositories/user-query.repository';
+import { UserCommandRepository } from '@/user/repositories/user-command.repository';
+import { RefreshTokenRepository } from '@/auth/repositories/refresh-token.repository';
+import { TokenBlacklistService } from './token-blacklist.service';
+import { TokenService } from './token.service';
+
+describe('TokenService (token version)', () => {
+  const jwtService = {
+    sign: jest.fn().mockReturnValue('signed-access-token'),
+    decode: jest.fn(),
+  };
+  const userRepo = { byId: jest.fn() };
+  const userCommandRepo = { incrementTokenVersion: jest.fn() };
+  const refreshTokenRepo = {
+    createRefreshToken: jest.fn(),
+    findByToken: jest.fn(),
+    revokeToken: jest.fn(),
+    revokeAllTokensByUserId: jest.fn(),
+    revokeTokensByDeviceId: jest.fn(),
+  };
+  const tokenBlacklist = { add: jest.fn() };
+  const service = new TokenService(
+    jwtService as unknown as JwtService,
+    userRepo as unknown as UserQueryRepository,
+    userCommandRepo as unknown as UserCommandRepository,
+    refreshTokenRepo as unknown as RefreshTokenRepository,
+    {
+      accessSecret: 'test-secret',
+      accessExpiresIn: '15m',
+      refreshExpiresIn: '7d',
+    } as ConfigType<typeof jwtConfig>,
+    tokenBlacklist as unknown as TokenBlacklistService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jwtService.sign.mockReturnValue('signed-access-token');
+    jwtService.decode.mockReturnValue({
+      jti: 'jti-1',
+      exp: Math.floor(Date.now() / 1000) + 900,
+    });
+    tokenBlacklist.add.mockResolvedValue({ jti: 'jti-1', added: true });
+  });
+
+  it('generateTokens signs the access token with the current token version', async () => {
+    userRepo.byId.mockResolvedValue({ id: 'user-1', tokenVersion: 3 });
+    refreshTokenRepo.createRefreshToken.mockResolvedValue({});
+
+    await service.generateTokens('user-1');
+
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      { sub: 'user-1', token_version: 3 },
+      expect.objectContaining({ secret: 'test-secret' }),
+    );
+  });
+
+  it('refreshToken signs the access token with the current token version', async () => {
+    refreshTokenRepo.findByToken.mockResolvedValue({
+      userId: 'user-1',
+      revokedAt: null,
+    });
+    userRepo.byId.mockResolvedValue({ id: 'user-1', tokenVersion: 5 });
+    refreshTokenRepo.createRefreshToken.mockResolvedValue({});
+    refreshTokenRepo.revokeToken.mockResolvedValue({});
+
+    await service.refreshToken('old-refresh-token');
+
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      { sub: 'user-1', token_version: 5 },
+      expect.objectContaining({ secret: 'test-secret' }),
+    );
+  });
+
+  it('logout with revokeAllDevices increments the token version to invalidate all access tokens', async () => {
+    refreshTokenRepo.revokeAllTokensByUserId.mockResolvedValue(4);
+    userCommandRepo.incrementTokenVersion.mockResolvedValue({});
+
+    const result = await service.logout('user-1', 'access-token', {
+      revokeAllDevices: true,
+    });
+
+    expect(refreshTokenRepo.revokeAllTokensByUserId).toHaveBeenCalledWith(
+      'user-1',
+    );
+    expect(userCommandRepo.incrementTokenVersion).toHaveBeenCalledWith('user-1');
+    expect(result.allDevicesLoggedOut).toBe(true);
+    expect(result.revokedTokensCount).toBe(4);
+  });
+
+  it('logout scoped to a device does not increment the token version', async () => {
+    refreshTokenRepo.revokeTokensByDeviceId.mockResolvedValue(2);
+
+    await service.logout('user-1', 'access-token', { deviceId: 'device-1' });
+
+    expect(refreshTokenRepo.revokeTokensByDeviceId).toHaveBeenCalledWith(
+      'user-1',
+      'device-1',
+    );
+    expect(userCommandRepo.incrementTokenVersion).not.toHaveBeenCalled();
+  });
+
+  it('logout of the current session only does not increment the token version', async () => {
+    refreshTokenRepo.revokeToken.mockResolvedValue({});
+
+    await service.logout('user-1', 'access-token', {
+      refreshToken: 'refresh-token',
+    });
+
+    expect(refreshTokenRepo.revokeToken).toHaveBeenCalledWith('refresh-token');
+    expect(userCommandRepo.incrementTokenVersion).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/services/token.service.ts
+++ b/src/auth/services/token.service.ts
@@ -20,6 +20,7 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigType } from '@nestjs/config';
 import { jwtConfig } from '@/configs/jwt.config';
 import { UserQueryRepository } from '@/user/repositories/user-query.repository';
+import { UserCommandRepository } from '@/user/repositories/user-command.repository';
 import { RefreshTokenRepository } from '@/auth/repositories/refresh-token.repository';
 import { randomUUID } from 'node:crypto';
 import { TokenBlacklistService } from './token-blacklist.service';
@@ -41,6 +42,7 @@ export class TokenService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly userRepo: UserQueryRepository,
+    private readonly userCommandRepo: UserCommandRepository,
     private readonly refreshTokenRepo: RefreshTokenRepository,
     @Inject(jwtConfig.KEY)
     private readonly config: ConfigType<typeof jwtConfig>,
@@ -63,7 +65,8 @@ export class TokenService {
     refreshToken: string;
     refreshExpiresIn: number;
   }> {
-    const payload = { sub: userId };
+    const user = await this.userRepo.byId(userId);
+    const payload = { sub: userId, token_version: user?.tokenVersion ?? 0 };
     const accessJti = randomUUID();
 
     const accessToken = this.jwtService.sign(payload, {
@@ -130,7 +133,7 @@ export class TokenService {
       }
 
       const accessToken = this.jwtService.sign(
-        { sub: user.id },
+        { sub: user.id, token_version: user.tokenVersion },
         {
           secret: this.accessSecret,
           expiresIn: this.accessExpiresIn,
@@ -230,6 +233,8 @@ export class TokenService {
       if (options.revokeAllDevices) {
         const revokedCount =
           await this.refreshTokenRepo.revokeAllTokensByUserId(userId);
+        // 递增令牌版本，使所有设备已签发的 access token 立即失效
+        await this.userCommandRepo.incrementTokenVersion(userId);
         result.allDevicesLoggedOut = true;
         result.revokedTokensCount = revokedCount;
       } else if (options.deviceId) {

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -64,6 +64,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('用户不存在');
     }
 
+    // 令牌版本校验：版本不匹配说明令牌签发后发生过全局撤销（如全部设备登出）
+    if ((payload.token_version ?? 0) !== (authUser.tokenVersion ?? 0)) {
+      throw new UnauthorizedException('访问令牌已失效，请重新登录');
+    }
+
     // 如果 JWT 中带有 scope 权限范围（OAuth 2.0 场景），则将其附加到 authUser 上
     if (payload.scopes) {
       authUser.scopes = payload.scopes;

--- a/src/auth/types/jwt.types.ts
+++ b/src/auth/types/jwt.types.ts
@@ -26,6 +26,7 @@ export interface AuthenticatedUser {
   clientId?: string;
   organizationId?: string;
   credentialVersion?: number;
+  tokenVersion?: number;
 }
 
 export interface JwtPayload {
@@ -40,6 +41,7 @@ export interface JwtPayload {
   client_id?: string;
   org_id?: string;
   credential_version?: number;
+  token_version?: number;
 }
 
 export enum TokenBlacklistScope {

--- a/src/oauth/services/oauth-grant.service.spec.ts
+++ b/src/oauth/services/oauth-grant.service.spec.ts
@@ -26,6 +26,7 @@ describe('OAuthGrantService', () => {
       updateMany: jest.fn(),
     },
     oAuthClient: { findUnique: jest.fn() },
+    user: { findUnique: jest.fn() },
     orgMember: { count: jest.fn(), findMany: jest.fn() },
     permission: { findMany: jest.fn() },
     $transaction: jest.fn(),
@@ -59,6 +60,7 @@ describe('OAuthGrantService', () => {
       grants: ['authorization_code', 'refresh_token'],
       scopes: ['meeting:read'],
     });
+    prisma.user.findUnique.mockResolvedValue({ tokenVersion: 0 });
   });
 
   it('persists only client-approved requested scopes and the PKCE challenge', async () => {
@@ -146,6 +148,7 @@ describe('OAuthGrantService', () => {
         org_id: 'org-1',
         scopes: ['meeting:read'],
         token_use: 'oauth_access',
+        token_version: 0,
       }),
       expect.any(Object),
     );

--- a/src/oauth/services/oauth-grant.service.ts
+++ b/src/oauth/services/oauth-grant.service.ts
@@ -373,6 +373,11 @@ export class OAuthGrantService {
     const effectiveScopes = grant.scopes.filter((scope) =>
       client.scopes.includes(scope),
     );
+    // 令牌版本需随令牌下发，用户全局撤销（如全部设备登出）后旧令牌立即失效
+    const user = await tx.user.findUnique({
+      where: { id: grant.userId },
+      select: { tokenVersion: true },
+    });
     const expiresIn = parseAccessTokenTtl(this.config.accessExpiresIn);
     const accessToken = this.jwtService.sign(
       {
@@ -382,6 +387,7 @@ export class OAuthGrantService {
         org_id: grant.organizationId,
         scopes: effectiveScopes,
         credential_version: client.credentialVersion,
+        token_version: user?.tokenVersion ?? 0,
       },
       {
         secret: this.config.accessSecret,

--- a/src/user/repositories/user-command.repository.ts
+++ b/src/user/repositories/user-command.repository.ts
@@ -89,6 +89,16 @@ export class UserCommandRepository {
     });
   }
 
+  /**
+   * 递增令牌版本，使该用户所有已签发的 access token 立即失效
+   */
+  incrementTokenVersion(id: string): Promise<User> {
+    return this.prisma.user.update({
+      where: { id },
+      data: { tokenVersion: { increment: 1 } },
+    });
+  }
+
   updateProfile(
     id: string,
     data: {


### PR DESCRIPTION
新增用户令牌版本字段，实现全局登出功能：递增令牌版本可使该用户所有已签发的access token立即失效。 具体变更包括：
1. 新增数据库迁移和User模型的token_version字段
2. 在JWT载荷中携带token版本信息
3. 在JWT校验时验证令牌版本匹配性
4. 新增用户令牌版本递增方法
5. 完善token生成、刷新逻辑携带版本信息
6. 添加相关单元测试