### PR TITLE
feat(minute): enrich transcript responses

### DIFF
--- a/src/minute/controllers/minute.controller.spec.ts
+++ b/src/minute/controllers/minute.controller.spec.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { PATH_METADATA } from '@nestjs/common/constants';
+import { MinuteService } from '../services/minute.service';
+import { TranscriptService } from '../services/transcript.service';
+import { MinuteController } from './minute.controller';
+
+describe('MinuteController transcript routes', () => {
+  let transcriptService: { getJson: jest.Mock; getText: jest.Mock };
+  let controller: MinuteController;
+
+  beforeEach(() => {
+    transcriptService = {
+      getJson: jest.fn(),
+      getText: jest.fn(),
+    };
+    controller = new MinuteController(
+      {} as MinuteService,
+      transcriptService as unknown as TranscriptService,
+    );
+  });
+
+  it('exposes structured and text transcripts through separate routes', () => {
+    expect(Reflect.getMetadata(PATH_METADATA, controller.getTranscript)).toBe(
+      ':id/transcript',
+    );
+    expect(
+      Reflect.getMetadata(PATH_METADATA, controller.getTranscriptText),
+    ).toBe(':id/transcript/text');
+  });
+
+  it('returns the structured transcript with optional local users', async () => {
+    const response = { transcriptId: 'transcript-1', data: [] };
+    transcriptService.getJson.mockResolvedValue(response);
+
+    await expect(
+      controller.getTranscript('minute-1', { includeLocalUser: true }),
+    ).resolves.toBe(response);
+    expect(transcriptService.getJson).toHaveBeenCalledWith('minute-1', true);
+    expect(transcriptService.getText).not.toHaveBeenCalled();
+  });
+
+  it('returns only rendered text from the text route', async () => {
+    transcriptService.getText.mockResolvedValue('转写文本');
+
+    await expect(controller.getTranscriptText('minute-1')).resolves.toEqual({
+      text: '转写文本',
+    });
+    expect(transcriptService.getText).toHaveBeenCalledWith('minute-1');
+    expect(transcriptService.getJson).not.toHaveBeenCalled();
+  });
+});

--- a/src/minute/controllers/minute.controller.ts
+++ b/src/minute/controllers/minute.controller.ts
@@ -23,8 +23,17 @@ import { RequirePermissions } from '@/admin/permission/decorators/permissions.de
 import { MinuteService } from '../services/minute.service';
 import { TranscriptService } from '../services/transcript.service';
 import { CuidPipe } from '@/common/pipes/cuid.pipe';
-import { ApiGetTranscriptByRecordingIdDocs } from '../decorators/minute.decorators';
-import { CreateTranscriptBodyDto, TranscriptDto } from '../dto/transcript.dto';
+import {
+  ApiGetTranscriptDocs,
+  ApiGetTranscriptTextDocs,
+} from '../decorators/minute.decorators';
+import {
+  CreateTranscriptBodyDto,
+  QueryTranscriptDto,
+  TranscriptDto,
+  TranscriptJsonResponseDto,
+  TranscriptTextResponseDto,
+} from '../dto/transcript.dto';
 import {
   CreateMinuteDto,
   UpdateMinuteDto,
@@ -119,26 +128,51 @@ export class MinuteController {
   }
 
   /**
-   * 获取录制转写
+   * 获取结构化录制转写
    */
   @Get(':id/transcript')
   @RequirePermissions('minute:read')
   @HttpCode(HttpStatus.OK)
-  @ApiGetTranscriptByRecordingIdDocs()
+  @ApiGetTranscriptDocs()
   async getTranscript(
     @Param('id', CuidPipe) minuteId: string,
-    @Query('format') format?: 'text' | 'json',
-  ): Promise<any> {
-    this.logger.log(`获取转写文本: ${minuteId}, format: ${format}`);
+    @Query(new ValidationPipe({ transform: true })) query: QueryTranscriptDto,
+  ): Promise<TranscriptJsonResponseDto> {
+    const { includeLocalUser = false } = query;
+    this.logger.log(
+      `获取结构化转写: ${minuteId}, includeLocalUser: ${includeLocalUser}`,
+    );
 
     try {
-      if (format === 'json') {
-        const data = await this.transcriptService.getJson(minuteId);
+      const result = await this.transcriptService.getJson(
+        minuteId,
+        includeLocalUser,
+      );
 
-        this.logger.log(`获取录制的转写 JSON 成功: ${minuteId}`);
-        return { data };
-      }
+      this.logger.log(`获取结构化录制转写成功: ${minuteId}`);
+      return result;
+    } catch (error: unknown) {
+      this.logger.error(
+        `获取结构化录制转写失败: ${minuteId}`,
+        (error as Error).stack,
+      );
+      throw error;
+    }
+  }
 
+  /**
+   * 获取录制转写文本
+   */
+  @Get(':id/transcript/text')
+  @RequirePermissions('minute:read')
+  @HttpCode(HttpStatus.OK)
+  @ApiGetTranscriptTextDocs()
+  async getTranscriptText(
+    @Param('id', CuidPipe) minuteId: string,
+  ): Promise<TranscriptTextResponseDto> {
+    this.logger.log(`获取录制转写文本: ${minuteId}`);
+
+    try {
       const text = await this.transcriptService.getText(minuteId);
 
       this.logger.log(`获取录制的转写文本成功: ${minuteId}`);

--- a/src/minute/decorators/minute.decorators.ts
+++ b/src/minute/decorators/minute.decorators.ts
@@ -1,32 +1,60 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
-import { TranscriptByRecordingIdResponseDto } from '../dto/transcript.dto';
+import {
+  TranscriptJsonResponseDto,
+  TranscriptTextResponseDto,
+} from '../dto/transcript.dto';
 
-export const ApiGetTranscriptByRecordingIdDocs = () =>
+const transcriptMinuteIdParam = ApiParam({
+  name: 'id',
+  description: '录制记录ID',
+  type: 'string',
+});
+
+const transcriptNotFoundResponse = ApiResponse({
+  status: 404,
+  description: '转写记录不存在',
+});
+
+const transcriptInternalErrorResponse = ApiResponse({
+  status: 500,
+  description: '服务器内部错误',
+});
+
+export const ApiGetTranscriptDocs = () =>
   applyDecorators(
     ApiOperation({
-      summary: '获取录制的转写文本',
-      description: '根据录制记录ID获取其对应的转写文本',
+      summary: '获取结构化录制转写',
+      description: '根据录制记录ID获取转写记录和按时间排序的转写段落',
     }),
-    ApiParam({
-      name: 'id',
-      description: '录制记录ID',
-      type: 'string',
-    }),
+    transcriptMinuteIdParam,
     ApiQuery({
-      name: 'format',
+      name: 'includeLocalUser',
       required: false,
-      description: '返回格式: text (默认) 或 json',
-      enum: ['text', 'json'],
+      type: Boolean,
+      description: '是否同时返回说话人关联的本地用户资料，默认 false',
     }),
     ApiResponse({
       status: 200,
       description: '获取成功',
-      type: TranscriptByRecordingIdResponseDto,
+      type: TranscriptJsonResponseDto,
     }),
+    transcriptNotFoundResponse,
+    transcriptInternalErrorResponse,
+  );
+
+export const ApiGetTranscriptTextDocs = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '获取录制转写文本',
+      description: '根据录制记录ID获取拼接后的可读转写文本',
+    }),
+    transcriptMinuteIdParam,
     ApiResponse({
-      status: 404,
-      description: '转写记录不存在',
+      status: 200,
+      description: '获取成功',
+      type: TranscriptTextResponseDto,
     }),
-    ApiResponse({ status: 500, description: '服务器内部错误' }),
+    transcriptNotFoundResponse,
+    transcriptInternalErrorResponse,
   );

--- a/src/minute/dto/minute.dto.spec.ts
+++ b/src/minute/dto/minute.dto.spec.ts
@@ -4,13 +4,17 @@ import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
-import { MinuteDto, QueryMinuteDto } from './minute.dto';
+import { MinuteDto, MinuteListResponseDto, QueryMinuteDto } from './minute.dto';
 
 @Controller('minute-contract-test')
 class MinuteContractTestController {
   @Get()
   @ApiOkResponse({ type: MinuteDto })
   get(): void {}
+
+  @Get('list')
+  @ApiOkResponse({ type: MinuteListResponseDto })
+  list(): void {}
 }
 
 describe('minute DTO contract', () => {
@@ -46,7 +50,35 @@ describe('minute DTO contract', () => {
         type: 'string',
         nullable: true,
       });
+      expect(schema.properties?.recorderUserId).toMatchObject({
+        type: 'string',
+        nullable: true,
+      });
+      expect(schema.properties?.startAt).toMatchObject({
+        type: 'string',
+        format: 'date-time',
+        nullable: true,
+      });
+      expect(schema.properties?.endAt).toMatchObject({
+        type: 'string',
+        format: 'date-time',
+        nullable: true,
+      });
+      expect(schema.properties?.deletedAt).toMatchObject({
+        type: 'string',
+        format: 'date-time',
+        nullable: true,
+      });
       expect(schema.properties).not.toHaveProperty('status');
+
+      const listSchema = document.components?.schemas
+        ?.MinuteListResponseDto as SchemaObject;
+      expect(listSchema.properties?.data).toMatchObject({
+        type: 'array',
+        items: {
+          $ref: '#/components/schemas/MinuteDto',
+        },
+      });
     } finally {
       await app.close();
     }

--- a/src/minute/dto/minute.dto.ts
+++ b/src/minute/dto/minute.dto.ts
@@ -137,14 +137,28 @@ export class MinuteDto {
   @ApiPropertyOptional({ description: '会议ID', type: String, nullable: true })
   meetingId?: string | null;
 
-  @ApiPropertyOptional({ description: '录制用户ID' })
-  recorderUserId?: string;
+  @ApiPropertyOptional({
+    description: '录制用户ID',
+    type: String,
+    nullable: true,
+  })
+  recorderUserId?: string | null;
 
-  @ApiPropertyOptional({ description: '开始时间' })
-  startAt?: Date;
+  @ApiPropertyOptional({
+    description: '开始时间',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
+  startAt?: Date | null;
 
-  @ApiPropertyOptional({ description: '结束时间' })
-  endAt?: Date;
+  @ApiPropertyOptional({
+    description: '结束时间',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
+  endAt?: Date | null;
 
   @ApiProperty({ description: '创建时间' })
   createdAt: Date;
@@ -152,13 +166,18 @@ export class MinuteDto {
   @ApiProperty({ description: '更新时间' })
   updatedAt: Date;
 
-  @ApiPropertyOptional({ description: '删除时间' })
-  deletedAt?: Date;
+  @ApiPropertyOptional({
+    description: '删除时间',
+    type: String,
+    format: 'date-time',
+    nullable: true,
+  })
+  deletedAt?: Date | null;
 }
 
 export class MinuteListResponseDto {
   @ApiProperty({ description: '列表数据', type: [MinuteDto] })
-  data: any[];
+  data: MinuteDto[];
 
   @ApiProperty({ description: '总数' })
   total: number;

--- a/src/minute/dto/transcript.dto.spec.ts
+++ b/src/minute/dto/transcript.dto.spec.ts
@@ -1,0 +1,70 @@
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+import { TranscriptJsonResponseDto } from './transcript.dto';
+
+@Controller('transcript-contract-test')
+class TranscriptContractTestController {
+  @Get()
+  @ApiOkResponse({ type: TranscriptJsonResponseDto })
+  get(): void {}
+}
+
+describe('Transcript response OpenAPI contract', () => {
+  let app: INestApplication;
+  let schemas: Record<string, SchemaObject>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TranscriptContractTestController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+
+    const document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().build(),
+    );
+    schemas = document.components?.schemas as Record<string, SchemaObject>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('documents platform and local users as required nullable objects', () => {
+    const paragraph = schemas.TranscriptParagraphDto;
+    const platformUser = paragraph.properties?.platformUser as SchemaObject;
+    const user = paragraph.properties?.user as SchemaObject;
+
+    expect(platformUser).toMatchObject({
+      type: 'object',
+      nullable: true,
+    });
+    expect(platformUser).not.toHaveProperty('allOf');
+    expect(platformUser.properties?.id).toMatchObject({ type: 'string' });
+    expect(platformUser.properties?.displayName).toMatchObject({
+      type: 'string',
+      nullable: true,
+    });
+
+    expect(user).toMatchObject({
+      type: 'object',
+      nullable: true,
+    });
+    expect(user).not.toHaveProperty('allOf');
+    expect(user.properties?.id).toMatchObject({ type: 'string' });
+    expect(user.properties?.displayName).toMatchObject({
+      type: 'string',
+      nullable: true,
+    });
+    expect(user.properties?.fullName).toMatchObject({
+      type: 'string',
+      nullable: true,
+    });
+
+    expect(paragraph.required).toEqual(
+      expect.arrayContaining(['platformUser', 'user']),
+    );
+  });
+});

--- a/src/minute/dto/transcript.dto.ts
+++ b/src/minute/dto/transcript.dto.ts
@@ -1,11 +1,30 @@
 import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import {
+  IsBoolean,
   IsString,
   IsOptional,
   IsNumber,
   IsDateString,
   IsNotEmpty,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class QueryTranscriptDto {
+  @ApiPropertyOptional({
+    description: '是否同时返回转写说话人关联的本地用户资料',
+    type: Boolean,
+    default: false,
+  })
+  @IsOptional()
+  @Transform(({ value }) => {
+    const rawValue: unknown = value;
+    if (rawValue === true || rawValue === 'true') return true;
+    if (rawValue === false || rawValue === 'false') return false;
+    return rawValue;
+  })
+  @IsBoolean()
+  includeLocalUser?: boolean = false;
+}
 
 export class CreateTranscriptDto {
   @ApiProperty({ description: '转写来源/文件名' })
@@ -92,27 +111,108 @@ export class TranscriptListResponseDto {
   totalPages: number;
 }
 
-export class TranscriptParagraphDto {
-  @ApiPropertyOptional({ description: '说话人名称' })
-  speakerName?: string;
+export class TranscriptPlatformUserDto {
+  @ApiProperty({ description: '平台用户记录 ID' })
+  id: string;
 
-  @ApiPropertyOptional({ description: '开始时间, 格式 hh:mm:ss' })
-  startTime?: string;
-
-  @ApiPropertyOptional({ description: '结束时间, 格式 hh:mm:ss' })
-  endTime?: string;
-
-  @ApiPropertyOptional({ description: '文本内容' })
-  text?: string;
+  @ApiProperty({
+    description: '平台用户显示名称',
+    type: String,
+    nullable: true,
+  })
+  displayName: string | null;
 }
 
-export class TranscriptByRecordingIdResponseDto {
-  @ApiPropertyOptional({ description: '拼接后的转写文本 (format=text 时返回)' })
-  text?: string;
+export class TranscriptLocalUserDto {
+  @ApiProperty({ description: '本地用户 ID' })
+  id: string;
 
-  @ApiPropertyOptional({
-    type: [TranscriptParagraphDto],
-    description: '转写段落 JSON 数组 (format=json 时返回)',
+  @ApiProperty({
+    description: '本地用户资料显示名称',
+    type: String,
+    nullable: true,
   })
-  data?: TranscriptParagraphDto[];
+  displayName: string | null;
+
+  @ApiProperty({
+    description: '本地用户填写的完整姓名（未经实名认证）',
+    type: String,
+    nullable: true,
+  })
+  fullName: string | null;
+}
+
+export class TranscriptParagraphDto {
+  @ApiProperty({ description: '转写段落 ID' })
+  id: string;
+
+  @ApiProperty({ description: '说话人名称' })
+  speakerName: string;
+
+  @ApiProperty({ description: '开始时间, 格式 hh:mm:ss' })
+  startTime: string;
+
+  @ApiProperty({ description: '结束时间, 格式 hh:mm:ss' })
+  endTime: string;
+
+  @ApiProperty({ description: '文本内容' })
+  text: string;
+
+  @ApiProperty({
+    description: '说话人关联的平台用户；未关联时为 null',
+    type: 'object',
+    nullable: true,
+    properties: {
+      id: {
+        type: 'string',
+        description: '平台用户记录 ID',
+      },
+      displayName: {
+        type: 'string',
+        description: '平台用户显示名称',
+        nullable: true,
+      },
+    },
+  })
+  platformUser: TranscriptPlatformUserDto | null;
+
+  @ApiProperty({
+    description:
+      '说话人关联的本地用户；includeLocalUser=false 或未关联时为 null',
+    type: 'object',
+    nullable: true,
+    properties: {
+      id: {
+        type: 'string',
+        description: '本地用户 ID',
+      },
+      displayName: {
+        type: 'string',
+        description: '本地用户资料显示名称',
+        nullable: true,
+      },
+      fullName: {
+        type: 'string',
+        description: '本地用户填写的完整姓名（未经实名认证）',
+        nullable: true,
+      },
+    },
+  })
+  user: TranscriptLocalUserDto | null;
+}
+
+export class TranscriptTextResponseDto {
+  @ApiProperty({ description: '拼接后的转写文本' })
+  text: string;
+}
+
+export class TranscriptJsonResponseDto {
+  @ApiProperty({ description: '转写记录 ID' })
+  transcriptId: string;
+
+  @ApiProperty({
+    type: [TranscriptParagraphDto],
+    description: '转写段落 JSON 数组',
+  })
+  data: TranscriptParagraphDto[];
 }

--- a/src/minute/repositories/transcript.repository.spec.ts
+++ b/src/minute/repositories/transcript.repository.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+import { PrismaService } from '@/prisma/prisma.service';
+import { TranscriptRepository } from './transcript.repository';
+
+describe('TranscriptRepository', () => {
+  const createRepository = () => {
+    const findFirst = jest.fn().mockResolvedValue(null);
+    const repository = new TranscriptRepository({
+      transcript: { findFirst },
+    } as unknown as PrismaService);
+    return { findFirst, repository };
+  };
+
+  it('uses a minimal speaker projection by default', async () => {
+    const { findFirst, repository } = createRepository();
+
+    await repository.findDetails('minute-1');
+
+    const query = findFirst.mock.calls[0][0];
+    const speakerSelect = query.select.segments.select.speaker.select;
+    expect(query.where).toEqual({ minuteId: 'minute-1' });
+    expect(speakerSelect).toEqual({ id: true, displayName: true });
+  });
+
+  it('selects only the requested local user profile fields', async () => {
+    const { findFirst, repository } = createRepository();
+
+    await repository.findDetailsWithLocalUser('minute-1');
+
+    const query = findFirst.mock.calls[0][0];
+    expect(query.select.segments.select.speaker.select.user).toEqual({
+      select: {
+        id: true,
+        profile: {
+          select: {
+            displayName: true,
+            fullName: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/minute/repositories/transcript.repository.ts
+++ b/src/minute/repositories/transcript.repository.ts
@@ -9,8 +9,60 @@
  * Copyright (c) 2026 by LuLab-Team, All Rights Reserved.
  */
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '@/prisma/prisma.service';
 import { PrismaTransaction } from '@/tencent-mtg/types';
+
+const transcriptDetailsSelect = {
+  id: true,
+  segments: {
+    orderBy: { startTimeMs: 'asc' },
+    select: {
+      id: true,
+      speakerName: true,
+      startTimeMs: true,
+      endTimeMs: true,
+      text: true,
+      speaker: {
+        select: {
+          id: true,
+          displayName: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.TranscriptSelect;
+
+const transcriptDetailsWithLocalUserSelect = {
+  id: true,
+  segments: {
+    orderBy: { startTimeMs: 'asc' },
+    select: {
+      id: true,
+      speakerName: true,
+      startTimeMs: true,
+      endTimeMs: true,
+      text: true,
+      speaker: {
+        select: {
+          id: true,
+          displayName: true,
+          user: {
+            select: {
+              id: true,
+              profile: {
+                select: {
+                  displayName: true,
+                  fullName: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.TranscriptSelect;
 
 @Injectable()
 export class TranscriptRepository {
@@ -103,16 +155,14 @@ export class TranscriptRepository {
   async findDetails(minuteId: string) {
     return this.prisma.transcript.findFirst({
       where: { minuteId },
-      include: {
-        segments: {
-          orderBy: {
-            startTimeMs: 'asc',
-          },
-          include: {
-            speaker: true,
-          },
-        },
-      },
+      select: transcriptDetailsSelect,
+    });
+  }
+
+  async findDetailsWithLocalUser(minuteId: string) {
+    return this.prisma.transcript.findFirst({
+      where: { minuteId },
+      select: transcriptDetailsWithLocalUserSelect,
     });
   }
 

--- a/src/minute/services/transcript.service.spec.ts
+++ b/src/minute/services/transcript.service.spec.ts
@@ -1,0 +1,109 @@
+import { NotFoundException } from '@nestjs/common';
+import { TranscriptRepository } from '../repositories/transcript.repository';
+import { TranscriptService } from './transcript.service';
+
+describe('TranscriptService', () => {
+  let repository: {
+    findDetails: jest.Mock;
+    findDetailsWithLocalUser: jest.Mock;
+  };
+  let service: TranscriptService;
+
+  beforeEach(() => {
+    repository = {
+      findDetails: jest.fn(),
+      findDetailsWithLocalUser: jest.fn(),
+    };
+    service = new TranscriptService(
+      repository as unknown as TranscriptRepository,
+    );
+  });
+
+  describe('getJson', () => {
+    it('returns the transcript id and mapped platform and local users', async () => {
+      repository.findDetailsWithLocalUser.mockResolvedValue({
+        id: 'transcript-1',
+        segments: [
+          {
+            id: 'segment-1',
+            speakerName: '平台姓名快照',
+            startTimeMs: 104_000n,
+            endTimeMs: 109_000n,
+            text: '老师，我下载 hermes 遇到了点困难。',
+            speaker: {
+              id: 'platform-user-1',
+              displayName: '王奕舒',
+              user: {
+                id: 'local-user-1',
+                profile: {
+                  displayName: '王奕舒',
+                  fullName: '王奕舒',
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      await expect(service.getJson('minute-1', true)).resolves.toEqual({
+        transcriptId: 'transcript-1',
+        data: [
+          {
+            id: 'segment-1',
+            speakerName: '平台姓名快照',
+            startTime: '00:01:44',
+            endTime: '00:01:49',
+            text: '老师，我下载 hermes 遇到了点困难。',
+            platformUser: {
+              id: 'platform-user-1',
+              displayName: '王奕舒',
+            },
+            user: {
+              id: 'local-user-1',
+              displayName: '王奕舒',
+              fullName: '王奕舒',
+            },
+          },
+        ],
+      });
+      expect(repository.findDetailsWithLocalUser).toHaveBeenCalledWith(
+        'minute-1',
+      );
+      expect(repository.findDetails).not.toHaveBeenCalled();
+    });
+
+    it('returns null identities when a segment has no linked speaker', async () => {
+      repository.findDetails.mockResolvedValue({
+        id: 'transcript-1',
+        segments: [
+          {
+            id: 'segment-1',
+            speakerName: '未绑定说话人',
+            startTimeMs: 0n,
+            endTimeMs: 1_000n,
+            text: '发言内容',
+            speaker: null,
+          },
+        ],
+      });
+
+      const result = await service.getJson('minute-1');
+
+      expect(result.data[0]).toMatchObject({
+        speakerName: '未绑定说话人',
+        platformUser: null,
+        user: null,
+      });
+      expect(repository.findDetails).toHaveBeenCalledWith('minute-1');
+      expect(repository.findDetailsWithLocalUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when the minute has no transcript', async () => {
+      repository.findDetailsWithLocalUser.mockResolvedValue(null);
+
+      await expect(service.getJson('minute-1', true)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/minute/services/transcript.service.ts
+++ b/src/minute/services/transcript.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { TranscriptRepository } from '../repositories/transcript.repository';
-import { CreateTranscriptDto } from '../dto/transcript.dto';
+import {
+  CreateTranscriptDto,
+  TranscriptJsonResponseDto,
+} from '../dto/transcript.dto';
+import { formatTimeMs } from '@/common/utils/time.util';
 
 /**
  * 转写相关服务
@@ -46,18 +50,9 @@ export class TranscriptService {
 
     let fullText = '';
     for (const segment of transcript.segments) {
-      if (!segment.text) continue;
-
-      const speakerName =
-        segment.speaker?.displayName || segment.speakerName || '未知发言人';
+      const speakerName = segment.speakerName || '未知发言人';
       const startMs = Number(segment.startTimeMs);
-      const hh = String(Math.floor(startMs / 3600000)).padStart(2, '0');
-      const mm = String(Math.floor((startMs % 3600000) / 60000)).padStart(
-        2,
-        '0',
-      );
-      const ss = String(Math.floor((startMs % 60000) / 1000)).padStart(2, '0');
-      const timeStr = `${hh}:${mm}:${ss}`;
+      const timeStr = formatTimeMs(startMs);
 
       fullText += `${speakerName}(${timeStr}): ${segment.text}\n\n`;
     }
@@ -68,35 +63,53 @@ export class TranscriptService {
   /**
    * 基于段落（Segment）获取录制的转写 JSON
    */
-  async getJson(minuteId: string): Promise<any[]> {
-    const transcript = await this.transcriptRepository.findDetails(minuteId);
+  async getJson(
+    minuteId: string,
+    includeLocalUser = false,
+  ): Promise<TranscriptJsonResponseDto> {
+    const transcript = includeLocalUser
+      ? await this.transcriptRepository.findDetailsWithLocalUser(minuteId)
+      : await this.transcriptRepository.findDetails(minuteId);
+
     if (!transcript) {
       throw new NotFoundException(`转录记录不存在: ${minuteId}`);
     }
-    if (!transcript.segments) {
-      return [];
-    }
 
-    return transcript.segments
-      .filter((segment) => segment.text)
-      .map((segment) => {
-        const formatTime = (ms: number) => {
-          const hh = String(Math.floor(ms / 3600000)).padStart(2, '0');
-          const mm = String(Math.floor((ms % 3600000) / 60000)).padStart(
-            2,
-            '0',
-          );
-          const ss = String(Math.floor((ms % 60000) / 1000)).padStart(2, '0');
-          return `${hh}:${mm}:${ss}`;
+    return {
+      transcriptId: transcript.id,
+      data: transcript.segments.map((segment) => {
+        type SpeakerWithUser = {
+          id: string;
+          displayName: string | null;
+          user?: {
+            id: string;
+            profile: {
+              displayName: string | null;
+              fullName: string | null;
+            } | null;
+          } | null;
         };
+        const speaker = segment.speaker as SpeakerWithUser | null;
+        const user = includeLocalUser ? speaker?.user : null;
 
         return {
-          speakerName:
-            segment.speaker?.displayName || segment.speakerName || '未知发言人',
-          startTime: formatTime(Number(segment.startTimeMs)),
-          endTime: formatTime(Number(segment.endTimeMs)),
+          id: segment.id,
+          speakerName: segment.speakerName || '未知发言人',
+          startTime: formatTimeMs(Number(segment.startTimeMs)),
+          endTime: formatTimeMs(Number(segment.endTimeMs)),
           text: segment.text,
+          platformUser: speaker
+            ? { id: speaker.id, displayName: speaker.displayName }
+            : null,
+          user: user
+            ? {
+                id: user.id,
+                displayName: user.profile?.displayName ?? null,
+                fullName: user.profile?.fullName ?? null,
+              }
+            : null,
         };
-      });
+      }),
+    };
   }
 }


### PR DESCRIPTION
## Summary

- return structured transcript metadata and ordered segment IDs from `GET /minutes/:id/transcript`
- optionally include linked platform and local user details through `includeLocalUser`
- expose plain text through `GET /minutes/:id/transcript/text`
- align nullable minute response fields, including `recorderUserId`, with actual data

## Validation

- `pnpm build`
- `pnpm exec prettier --check <changed minute files>`
- `pnpm exec eslint <changed minute files>`
- unit project: 62 suites and 353 tests passed
- `pnpm test:ci` was attempted but is not green locally: real Tencent API fixtures returned empty/invalid responses, and e2e app initialization timed out while waiting on Redis/database/Lark services

## Related PRs

- https://github.com/lulabs-org/nove-admin/pull/120
- https://github.com/lulabs-org/nove-cli/pull/31