### PR TITLE
feat(minute): add platform user transcript queries

### DIFF
--- a/src/minute/controllers/index.ts
+++ b/src/minute/controllers/index.ts
@@ -1,3 +1,4 @@
 export * from './minute.controller';
 export * from './minute-summary.controller';
+export * from './platform-user-transcript.controller';
 export * from './speaker-summary.controller';

--- a/src/minute/controllers/platform-user-transcript.controller.spec.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.spec.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { PATH_METADATA } from '@nestjs/common/constants';
+import {
+  PERMISSIONS_KEY,
+  PERMISSION_MODE_KEY,
+  PermissionMode,
+} from '@/admin/permission/decorators/permissions.decorator';
+import { PlatformUserTranscriptService } from '../services/platform-user-transcript.service';
+import { PlatformUserTranscriptController } from './platform-user-transcript.controller';
+
+describe('PlatformUserTranscriptController', () => {
+  const service = {
+    getMeetingTranscripts: jest.fn(),
+    getTranscriptContext: jest.fn(),
+  };
+  const controller = new PlatformUserTranscriptController(
+    service as unknown as PlatformUserTranscriptService,
+  );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('exposes both transcript query routes', () => {
+    expect(
+      Reflect.getMetadata(PATH_METADATA, controller.getMeetingTranscripts),
+    ).toBe('platform-users/:platformUserId/meeting-transcripts');
+    expect(
+      Reflect.getMetadata(PATH_METADATA, controller.getTranscriptContext),
+    ).toBe(
+      'minutes/:minuteId/platform-users/:platformUserId/transcript-context',
+    );
+  });
+
+  it.each([['getMeetingTranscripts'], ['getTranscriptContext']] as const)(
+    'requires both platform-user and minute read permissions for %s',
+    (method) => {
+      expect(Reflect.getMetadata(PERMISSIONS_KEY, controller[method])).toEqual([
+        'platform-user:read',
+        'minute:read',
+      ]);
+      expect(Reflect.getMetadata(PERMISSION_MODE_KEY, controller[method])).toBe(
+        PermissionMode.ALL,
+      );
+    },
+  );
+
+  it('delegates meeting transcript queries', async () => {
+    service.getMeetingTranscripts.mockResolvedValue({ meetings: [] });
+
+    await controller.getMeetingTranscripts('platform-user-1', {
+      startDate: '2026-08-01T00:00:00Z',
+      endDate: '2026-09-01T00:00:00Z',
+    });
+
+    expect(service.getMeetingTranscripts).toHaveBeenCalledWith(
+      'platform-user-1',
+      '2026-08-01T00:00:00Z',
+      '2026-09-01T00:00:00Z',
+    );
+  });
+});

--- a/src/minute/controllers/platform-user-transcript.controller.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.ts
@@ -1,0 +1,71 @@
+import { Controller, Get, Param, Query, ValidationPipe } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RequireAllPermissions } from '@/admin/permission/decorators/permissions.decorator';
+import { CuidPipe } from '@/common/pipes/cuid.pipe';
+import {
+  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserTranscriptContextResponseDto,
+  QueryPlatformUserMeetingTranscriptsDto,
+  QueryPlatformUserTranscriptContextDto,
+} from '../dto/platform-user-transcript.dto';
+import { PlatformUserTranscriptService } from '../services/platform-user-transcript.service';
+
+@ApiTags('Minute')
+@ApiBearerAuth()
+@Controller()
+export class PlatformUserTranscriptController {
+  constructor(private readonly service: PlatformUserTranscriptService) {}
+
+  @Get('platform-users/:platformUserId/meeting-transcripts')
+  @RequireAllPermissions('platform-user:read', 'minute:read')
+  @ApiOperation({ summary: '查询用户会议记录及发言' })
+  @ApiParam({ name: 'platformUserId', description: '平台用户记录 ID' })
+  @ApiOkResponse({ type: PlatformUserMeetingTranscriptsResponseDto })
+  @ApiBadRequestResponse({ description: '时间格式、顺序或跨度无效' })
+  @ApiForbiddenResponse({ description: '缺少所需读取权限' })
+  @ApiNotFoundResponse({ description: '平台用户不存在' })
+  getMeetingTranscripts(
+    @Param('platformUserId', CuidPipe) platformUserId: string,
+    @Query(new ValidationPipe({ transform: true }))
+    query: QueryPlatformUserMeetingTranscriptsDto,
+  ) {
+    return this.service.getMeetingTranscripts(
+      platformUserId,
+      query.startDate,
+      query.endDate,
+    );
+  }
+
+  @Get('minutes/:minuteId/platform-users/:platformUserId/transcript-context')
+  @RequireAllPermissions('platform-user:read', 'minute:read')
+  @ApiOperation({ summary: '获取用户转写上下文' })
+  @ApiParam({ name: 'platformUserId', description: '平台用户记录 ID' })
+  @ApiParam({ name: 'minuteId', description: 'Minute ID' })
+  @ApiOkResponse({ type: PlatformUserTranscriptContextResponseDto })
+  @ApiBadRequestResponse({ description: '上下文深度无效' })
+  @ApiForbiddenResponse({ description: '缺少所需读取权限' })
+  @ApiNotFoundResponse({
+    description: '平台用户、Minute、参会关系或转写不存在',
+  })
+  getTranscriptContext(
+    @Param('platformUserId', CuidPipe) platformUserId: string,
+    @Param('minuteId', CuidPipe) minuteId: string,
+    @Query(new ValidationPipe({ transform: true }))
+    query: QueryPlatformUserTranscriptContextDto,
+  ) {
+    return this.service.getTranscriptContext(
+      platformUserId,
+      minuteId,
+      query.depth,
+    );
+  }
+}

--- a/src/minute/dto/index.ts
+++ b/src/minute/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './minute.dto';
 export * from './minute-summary.dto';
+export * from './platform-user-transcript.dto';
 export * from './speaker-summary.dto';
 export * from './transcript.dto';

--- a/src/minute/dto/platform-user-transcript.dto.spec.ts
+++ b/src/minute/dto/platform-user-transcript.dto.spec.ts
@@ -1,0 +1,106 @@
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+import {
+  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserTranscriptContextResponseDto,
+  QueryPlatformUserMeetingTranscriptsDto,
+  QueryPlatformUserTranscriptContextDto,
+} from './platform-user-transcript.dto';
+
+@Controller('platform-user-transcript-contract-test')
+class PlatformUserTranscriptContractTestController {
+  @Get('meetings')
+  @ApiOkResponse({ type: PlatformUserMeetingTranscriptsResponseDto })
+  getMeetings(): void {}
+
+  @Get('context')
+  @ApiOkResponse({ type: PlatformUserTranscriptContextResponseDto })
+  getContext(): void {}
+}
+
+describe('Platform user transcript query DTOs', () => {
+  it('accepts timezone-explicit meeting transcript dates', async () => {
+    const dto = plainToInstance(QueryPlatformUserMeetingTranscriptsDto, {
+      startDate: '2026-08-01T00:00:00+08:00',
+      endDate: '2026-09-01T00:00:00+08:00',
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+  });
+
+  it('rejects dates without timezone information', async () => {
+    const dto = plainToInstance(QueryPlatformUserMeetingTranscriptsDto, {
+      startDate: '2026-08-01T00:00:00',
+      endDate: '2026-08-02T00:00:00',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.map((error) => error.property)).toEqual(
+      expect.arrayContaining(['startDate', 'endDate']),
+    );
+  });
+
+  it.each([0, 20])('accepts context depth %s', async (depth) => {
+    const dto = plainToInstance(QueryPlatformUserTranscriptContextDto, {
+      depth: String(depth),
+    });
+
+    await expect(validate(dto)).resolves.toHaveLength(0);
+    expect(dto.depth).toBe(depth);
+  });
+
+  it.each([-1, 21, 1.5])('rejects invalid context depth %s', async (depth) => {
+    const dto = plainToInstance(QueryPlatformUserTranscriptContextDto, {
+      depth,
+    });
+
+    await expect(validate(dto)).resolves.not.toHaveLength(0);
+  });
+});
+
+describe('Platform user transcript response OpenAPI contract', () => {
+  let app: INestApplication;
+  let schemas: Record<string, SchemaObject>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PlatformUserTranscriptContractTestController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+
+    const document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().build(),
+    );
+    schemas = document.components?.schemas as Record<string, SchemaObject>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it.each([
+    'PlatformUserTranscriptSegmentDto',
+    'PlatformUserTranscriptContextSegmentDto',
+  ])('documents %s platformUser as a nullable object', (schemaName) => {
+    const segment = schemas[schemaName];
+    const platformUser = segment.properties?.platformUser as SchemaObject;
+
+    expect(platformUser).toMatchObject({
+      type: 'object',
+      nullable: true,
+    });
+    expect(platformUser).not.toHaveProperty('allOf');
+    expect(platformUser.properties?.id).toMatchObject({ type: 'string' });
+    expect(platformUser.properties?.displayName).toMatchObject({
+      type: 'string',
+      nullable: true,
+    });
+    expect(segment.required).toContain('platformUser');
+  });
+});

--- a/src/minute/dto/platform-user-transcript.dto.ts
+++ b/src/minute/dto/platform-user-transcript.dto.ts
@@ -1,0 +1,181 @@
+import { Type } from 'class-transformer';
+import { IsDateString, IsInt, Matches, Max, Min } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
+
+const TIMEZONE_SUFFIX = /(?:Z|[+-]\d{2}:\d{2})$/;
+
+export class QueryPlatformUserMeetingTranscriptsDto {
+  @ApiProperty({
+    description: '查询开始时间（包含时区的 ISO 8601 时间，包含边界）',
+    example: '2026-08-01T00:00:00+08:00',
+  })
+  @IsDateString({}, { message: 'startDate 必须是有效的 ISO 8601 时间' })
+  @Matches(TIMEZONE_SUFFIX, { message: 'startDate 必须包含时区信息' })
+  startDate: string;
+
+  @ApiProperty({
+    description: '查询结束时间（包含时区的 ISO 8601 时间，不包含边界）',
+    example: '2026-09-01T00:00:00+08:00',
+  })
+  @IsDateString({}, { message: 'endDate 必须是有效的 ISO 8601 时间' })
+  @Matches(TIMEZONE_SUFFIX, { message: 'endDate 必须包含时区信息' })
+  endDate: string;
+}
+
+export class QueryPlatformUserTranscriptContextDto {
+  @ApiProperty({
+    description: '每个目标发言前后分别包含的转写段落数',
+    minimum: 0,
+    maximum: 20,
+    example: 3,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(20)
+  depth: number;
+}
+
+export class PlatformUserTranscriptIdentityDto {
+  @ApiProperty({ description: '平台用户记录 ID' })
+  id: string;
+
+  @ApiProperty({
+    description: '平台用户显示名称',
+    type: String,
+    nullable: true,
+  })
+  displayName: string | null;
+}
+
+export class PlatformUserTranscriptSegmentDto {
+  @ApiProperty({ description: '转写段落 ID' })
+  id: string;
+
+  @ApiProperty({ description: '说话人名称' })
+  speakerName: string;
+
+  @ApiProperty({ description: '开始时间，格式为 hh:mm:ss' })
+  startTime: string;
+
+  @ApiProperty({ description: '结束时间，格式为 hh:mm:ss' })
+  endTime: string;
+
+  @ApiProperty({ description: '转写文本' })
+  text: string;
+
+  @ApiProperty({
+    description: '说话人关联的平台用户；未关联时为 null',
+    type: 'object',
+    nullable: true,
+    properties: {
+      id: {
+        type: 'string',
+        description: '平台用户记录 ID',
+      },
+      displayName: {
+        type: 'string',
+        description: '平台用户显示名称',
+        nullable: true,
+      },
+    },
+  })
+  platformUser: PlatformUserTranscriptIdentityDto | null;
+}
+
+export class PlatformUserTranscriptContextSegmentDto extends PlatformUserTranscriptSegmentDto {
+  @ApiProperty({ description: '该段是否为目标平台用户的发言' })
+  isTargetSpeaker: boolean;
+}
+
+export class PlatformUserTranscriptGroupDto {
+  @ApiProperty({ description: '转写记录 ID' })
+  transcriptId: string;
+
+  @ApiProperty({ type: [PlatformUserTranscriptSegmentDto] })
+  segments: PlatformUserTranscriptSegmentDto[];
+}
+
+export class PlatformUserTranscriptContextGroupDto {
+  @ApiProperty({ description: '转写记录 ID' })
+  transcriptId: string;
+
+  @ApiProperty({ type: [PlatformUserTranscriptContextSegmentDto] })
+  segments: PlatformUserTranscriptContextSegmentDto[];
+}
+
+export class PlatformUserTranscriptMinuteDto {
+  @ApiProperty({ description: 'Minute ID' })
+  minuteId: string;
+
+  @ApiProperty({
+    description: '外部系统录制 ID',
+    type: String,
+    nullable: true,
+  })
+  externalId: string | null;
+
+  @ApiProperty({ description: '录制来源', enum: RecordingSource })
+  source: RecordingSource;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startAt: Date | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endAt: Date | null;
+
+  @ApiProperty({ type: [PlatformUserTranscriptGroupDto] })
+  transcripts: PlatformUserTranscriptGroupDto[];
+}
+
+export class PlatformUserTranscriptMeetingDto {
+  @ApiProperty({ description: '会议 ID' })
+  meetingId: string;
+
+  @ApiProperty({ description: '会议标题' })
+  title: string;
+
+  @ApiProperty({ description: '会议平台', enum: MeetingPlatform })
+  platform: MeetingPlatform;
+
+  @ApiProperty({ description: '会议类型', enum: MeetingType })
+  type: MeetingType;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startAt: Date | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endAt: Date | null;
+
+  @ApiProperty({ type: [PlatformUserTranscriptMinuteDto] })
+  minutes: PlatformUserTranscriptMinuteDto[];
+}
+
+export class PlatformUserMeetingTranscriptsResponseDto {
+  @ApiProperty({ type: PlatformUserTranscriptIdentityDto })
+  platformUser: PlatformUserTranscriptIdentityDto;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  startDate: string;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  endDate: string;
+
+  @ApiProperty({ type: [PlatformUserTranscriptMeetingDto] })
+  meetings: PlatformUserTranscriptMeetingDto[];
+}
+
+export class PlatformUserTranscriptContextResponseDto {
+  @ApiProperty({ type: PlatformUserTranscriptIdentityDto })
+  platformUser: PlatformUserTranscriptIdentityDto;
+
+  @ApiProperty({ description: 'Minute ID' })
+  minuteId: string;
+
+  @ApiProperty({ minimum: 0, maximum: 20 })
+  depth: number;
+
+  @ApiProperty({ type: [PlatformUserTranscriptContextGroupDto] })
+  transcripts: PlatformUserTranscriptContextGroupDto[];
+}

--- a/src/minute/minute.module.ts
+++ b/src/minute/minute.module.ts
@@ -2,16 +2,19 @@ import { Module } from '@nestjs/common';
 import { MinuteController } from './controllers/minute.controller';
 import { MinuteSummaryController } from './controllers/minute-summary.controller';
 import { SpeakerSummaryController } from './controllers/speaker-summary.controller';
+import { PlatformUserTranscriptController } from './controllers/platform-user-transcript.controller';
 import { MinuteService } from './services/minute.service';
 import { MinuteSummaryService } from './services/minute-summary.service';
 import { SpeakerSummaryCrudService } from './services/speaker-summary-crud.service';
 import { SpeakerSummaryService } from './services/speaker-summary.service';
 import { TranscriptService } from './services/transcript.service';
+import { PlatformUserTranscriptService } from './services/platform-user-transcript.service';
 import { MinuteRepository } from './repositories/minute.repository';
 import { MinuteSummaryRepository } from './repositories/minute-summary.repository';
 import { SpeakerSummaryRepository } from './repositories/speaker-summary.repository';
 import { MinuteFileRepository } from './repositories/minute-file.repository';
 import { TranscriptRepository } from './repositories/transcript.repository';
+import { PlatformUserTranscriptRepository } from './repositories/platform-user-transcript.repository';
 import { LlmModule } from '@/llm/llm.module';
 import { ConfigModule } from '@nestjs/config';
 import { openaiConfig } from '@/configs/openai.config';
@@ -29,6 +32,7 @@ import { HttpModule } from '@nestjs/axios';
     MinuteController,
     MinuteSummaryController,
     SpeakerSummaryController,
+    PlatformUserTranscriptController,
   ],
   providers: [
     MinuteService,
@@ -36,11 +40,13 @@ import { HttpModule } from '@nestjs/axios';
     SpeakerSummaryCrudService,
     SpeakerSummaryService,
     TranscriptService,
+    PlatformUserTranscriptService,
     MinuteRepository,
     MinuteSummaryRepository,
     SpeakerSummaryRepository,
     MinuteFileRepository,
     TranscriptRepository,
+    PlatformUserTranscriptRepository,
   ],
   exports: [
     MinuteService,
@@ -48,11 +54,13 @@ import { HttpModule } from '@nestjs/axios';
     SpeakerSummaryCrudService,
     SpeakerSummaryService,
     TranscriptService,
+    PlatformUserTranscriptService,
     MinuteRepository,
     MinuteSummaryRepository,
     SpeakerSummaryRepository,
     MinuteFileRepository,
     TranscriptRepository,
+    PlatformUserTranscriptRepository,
   ],
 })
 export class MinuteModule {}

--- a/src/minute/repositories/index.ts
+++ b/src/minute/repositories/index.ts
@@ -2,4 +2,5 @@ export * from './minute.repository';
 export * from './minute-summary.repository';
 export * from './speaker-summary.repository';
 export * from './minute-file.repository';
+export * from './platform-user-transcript.repository';
 export * from './transcript.repository';

--- a/src/minute/repositories/platform-user-transcript.repository.spec.ts
+++ b/src/minute/repositories/platform-user-transcript.repository.spec.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { PrismaService } from '@/prisma/prisma.service';
+import { PlatformUserTranscriptRepository } from './platform-user-transcript.repository';
+
+describe('PlatformUserTranscriptRepository', () => {
+  const platformUser = { findFirst: jest.fn() };
+  const meeting = { findMany: jest.fn() };
+  const minute = { findFirst: jest.fn() };
+  const prisma = { platformUser, meeting, minute } as unknown as PrismaService;
+  const repository = new PlatformUserTranscriptRepository(prisma);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('queries every meeting type through active participation and a half-open range', async () => {
+    meeting.findMany.mockResolvedValue([]);
+    const startDate = new Date('2026-08-01T00:00:00+08:00');
+    const endDate = new Date('2026-09-01T00:00:00+08:00');
+
+    await repository.findMeetingTranscripts(
+      'platform-user-1',
+      startDate,
+      endDate,
+    );
+
+    expect(meeting.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          deletedAt: null,
+          startAt: { gte: startDate, lt: endDate },
+          participants: {
+            some: { ptUserId: 'platform-user-1', deletedAt: null },
+          },
+        },
+        select: expect.objectContaining({
+          minutes: expect.objectContaining({
+            where: { deletedAt: null },
+            select: expect.objectContaining({
+              transcripts: expect.objectContaining({
+                select: expect.objectContaining({
+                  segments: expect.objectContaining({
+                    where: { speakerId: 'platform-user-1' },
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('loads all transcript segments while filtering the minute membership', async () => {
+    minute.findFirst.mockResolvedValue(null);
+
+    await repository.findMinuteContextSource('minute-1', 'platform-user-1');
+
+    expect(minute.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'minute-1',
+          deletedAt: null,
+          meeting: { is: { deletedAt: null } },
+        },
+        select: expect.objectContaining({
+          meeting: {
+            select: {
+              participants: expect.objectContaining({
+                where: {
+                  ptUserId: 'platform-user-1',
+                  deletedAt: null,
+                },
+              }),
+            },
+          },
+          transcripts: expect.objectContaining({
+            select: expect.objectContaining({
+              segments: expect.not.objectContaining({
+                where: expect.anything(),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/minute/repositories/platform-user-transcript.repository.ts
+++ b/src/minute/repositories/platform-user-transcript.repository.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '@/prisma/prisma.service';
+
+const transcriptSegmentSelect = {
+  id: true,
+  speakerId: true,
+  speakerName: true,
+  startTimeMs: true,
+  endTimeMs: true,
+  text: true,
+  speaker: {
+    select: {
+      id: true,
+      displayName: true,
+    },
+  },
+} satisfies Prisma.TranscriptSegmentSelect;
+
+const minuteContextSelect = {
+  id: true,
+  meeting: {
+    select: {
+      participants: {
+        select: { id: true },
+      },
+    },
+  },
+  transcripts: {
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    select: {
+      id: true,
+      segments: {
+        orderBy: [{ startTimeMs: 'asc' }, { id: 'asc' }],
+        select: transcriptSegmentSelect,
+      },
+    },
+  },
+} satisfies Prisma.MinuteSelect;
+
+@Injectable()
+export class PlatformUserTranscriptRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findPlatformUser(platformUserId: string) {
+    return this.prisma.platformUser.findFirst({
+      where: { id: platformUserId, deletedAt: null },
+      select: { id: true, displayName: true },
+    });
+  }
+
+  findMeetingTranscripts(
+    platformUserId: string,
+    startDate: Date,
+    endDate: Date,
+  ) {
+    return this.prisma.meeting.findMany({
+      where: {
+        deletedAt: null,
+        startAt: { gte: startDate, lt: endDate },
+        participants: {
+          some: { ptUserId: platformUserId, deletedAt: null },
+        },
+      },
+      orderBy: [
+        { startAt: { sort: 'desc', nulls: 'last' } },
+        { createdAt: 'desc' },
+        { id: 'asc' },
+      ],
+      select: {
+        id: true,
+        title: true,
+        platform: true,
+        type: true,
+        startAt: true,
+        endAt: true,
+        minutes: {
+          where: { deletedAt: null },
+          orderBy: [
+            { startAt: { sort: 'asc', nulls: 'last' } },
+            { createdAt: 'asc' },
+            { id: 'asc' },
+          ],
+          select: {
+            id: true,
+            externalId: true,
+            source: true,
+            startAt: true,
+            endAt: true,
+            transcripts: {
+              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+              select: {
+                id: true,
+                segments: {
+                  where: { speakerId: platformUserId },
+                  orderBy: [{ startTimeMs: 'asc' }, { id: 'asc' }],
+                  select: transcriptSegmentSelect,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  findMinuteContextSource(minuteId: string, platformUserId: string) {
+    return this.prisma.minute.findFirst({
+      where: {
+        id: minuteId,
+        deletedAt: null,
+        meeting: { is: { deletedAt: null } },
+      },
+      select: {
+        ...minuteContextSelect,
+        meeting: {
+          select: {
+            participants: {
+              where: { ptUserId: platformUserId, deletedAt: null },
+              select: { id: true },
+              take: 1,
+            },
+          },
+        },
+      },
+    });
+  }
+}

--- a/src/minute/services/index.ts
+++ b/src/minute/services/index.ts
@@ -1,5 +1,6 @@
 export * from './minute.service';
 export * from './minute-summary.service';
+export * from './platform-user-transcript.service';
 export * from './speaker-summary.service';
 export * from './speaker-summary-crud.service';
 export * from './transcript.service';

--- a/src/minute/services/platform-user-transcript.service.spec.ts
+++ b/src/minute/services/platform-user-transcript.service.spec.ts
@@ -1,0 +1,202 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
+import { PlatformUserTranscriptRepository } from '../repositories/platform-user-transcript.repository';
+import { PlatformUserTranscriptService } from './platform-user-transcript.service';
+
+const segment = (
+  id: string,
+  speakerId: string | null,
+  startTimeMs: number,
+) => ({
+  id,
+  speakerId,
+  speakerName: speakerId ? `speaker-${speakerId}` : null,
+  startTimeMs: BigInt(startTimeMs),
+  endTimeMs: BigInt(startTimeMs + 1_000),
+  text: `text-${id}`,
+  speaker: speakerId
+    ? { id: speakerId, displayName: `user-${speakerId}` }
+    : null,
+});
+
+describe('PlatformUserTranscriptService', () => {
+  let repository: {
+    findPlatformUser: jest.Mock;
+    findMeetingTranscripts: jest.Mock;
+    findMinuteContextSource: jest.Mock;
+  };
+  let service: PlatformUserTranscriptService;
+
+  beforeEach(() => {
+    repository = {
+      findPlatformUser: jest.fn().mockResolvedValue({
+        id: 'target',
+        displayName: 'Target User',
+      }),
+      findMeetingTranscripts: jest.fn(),
+      findMinuteContextSource: jest.fn(),
+    };
+    service = new PlatformUserTranscriptService(
+      repository as unknown as PlatformUserTranscriptRepository,
+    );
+  });
+
+  it('maps nested meetings, minutes and target transcript segments', async () => {
+    repository.findMeetingTranscripts.mockResolvedValue([
+      {
+        id: 'meeting-1',
+        title: 'One-time meeting',
+        platform: MeetingPlatform.TENCENT_MEETING,
+        type: MeetingType.ONE_TIME,
+        startAt: new Date('2026-08-02T01:00:00Z'),
+        endAt: null,
+        minutes: [
+          {
+            id: 'minute-1',
+            externalId: null,
+            source: RecordingSource.PLATFORM_AUTO,
+            startAt: null,
+            endAt: null,
+            transcripts: [
+              { id: 'transcript-1', segments: [segment('s1', 'target', 0)] },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'meeting-2',
+        title: 'Recurring meeting without recordings',
+        platform: MeetingPlatform.FEISHU,
+        type: MeetingType.RECURRING,
+        startAt: new Date('2026-08-01T01:00:00Z'),
+        endAt: null,
+        minutes: [],
+      },
+    ]);
+
+    const result = await service.getMeetingTranscripts(
+      'target',
+      '2026-08-01T00:00:00Z',
+      '2026-09-01T00:00:00Z',
+    );
+
+    expect(result.meetings).toHaveLength(2);
+    expect(result.meetings[0].type).toBe(MeetingType.ONE_TIME);
+    expect(result.meetings[0].minutes[0].transcripts[0].segments[0]).toEqual({
+      id: 's1',
+      speakerName: 'speaker-target',
+      startTime: '00:00:00',
+      endTime: '00:00:01',
+      text: 'text-s1',
+      platformUser: { id: 'target', displayName: 'user-target' },
+    });
+    expect(result.meetings[1].minutes).toEqual([]);
+  });
+
+  it('rejects reversed and longer-than-31-day ranges', async () => {
+    await expect(
+      service.getMeetingTranscripts(
+        'target',
+        '2026-08-02T00:00:00Z',
+        '2026-08-01T00:00:00Z',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    await expect(
+      service.getMeetingTranscripts(
+        'target',
+        '2026-08-01T00:00:00Z',
+        '2026-09-02T00:00:00Z',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('computes each target window independently, merges overlaps and keeps transcripts separate', async () => {
+    repository.findMinuteContextSource.mockResolvedValue({
+      id: 'minute-1',
+      meeting: { participants: [{ id: 'participant-1' }] },
+      transcripts: [
+        {
+          id: 'transcript-1',
+          segments: [
+            segment('s0', 'other', 0),
+            segment('s1', 'target', 1_000),
+            segment('s2', 'other', 2_000),
+            segment('s3', 'target', 3_000),
+            segment('s4', 'other', 4_000),
+            segment('s5', 'other', 5_000),
+          ],
+        },
+        {
+          id: 'transcript-2',
+          segments: [segment('s6', 'target', 0), segment('s7', 'other', 1_000)],
+        },
+      ],
+    });
+
+    const result = await service.getTranscriptContext('target', 'minute-1', 1);
+
+    expect(result.transcripts[0].segments.map(({ id }) => id)).toEqual([
+      's0',
+      's1',
+      's2',
+      's3',
+      's4',
+    ]);
+    expect(
+      result.transcripts[0].segments.map(
+        ({ isTargetSpeaker }) => isTargetSpeaker,
+      ),
+    ).toEqual([false, true, false, true, false]);
+    expect(result.transcripts[1].segments.map(({ id }) => id)).toEqual([
+      's6',
+      's7',
+    ]);
+  });
+
+  it('returns empty segment groups when transcripts contain no target speech', async () => {
+    repository.findMinuteContextSource.mockResolvedValue({
+      id: 'minute-1',
+      meeting: { participants: [{ id: 'participant-1' }] },
+      transcripts: [
+        { id: 'transcript-1', segments: [segment('s1', 'other', 0)] },
+      ],
+    });
+
+    const result = await service.getTranscriptContext('target', 'minute-1', 20);
+
+    expect(result.transcripts).toEqual([
+      { transcriptId: 'transcript-1', segments: [] },
+    ]);
+  });
+
+  it.each([
+    { minute: null, scenario: 'missing minute' },
+    {
+      minute: { id: 'minute-1', meeting: null, transcripts: [] },
+      scenario: 'missing meeting',
+    },
+    {
+      minute: {
+        id: 'minute-1',
+        meeting: { participants: [] },
+        transcripts: [],
+      },
+      scenario: 'missing participation',
+    },
+    {
+      minute: {
+        id: 'minute-1',
+        meeting: { participants: [{ id: 'participant-1' }] },
+        transcripts: [],
+      },
+      scenario: 'missing transcript',
+    },
+  ])('returns 404 for $scenario', async ({ minute }) => {
+    repository.findMinuteContextSource.mockResolvedValue(minute);
+
+    await expect(
+      service.getTranscriptContext('target', 'minute-1', 1),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/src/minute/services/platform-user-transcript.service.ts
+++ b/src/minute/services/platform-user-transcript.service.ts
@@ -1,0 +1,174 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { formatTimeMs } from '@/common/utils/time.util';
+import {
+  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserTranscriptContextResponseDto,
+  PlatformUserTranscriptSegmentDto,
+} from '../dto/platform-user-transcript.dto';
+import { PlatformUserTranscriptRepository } from '../repositories/platform-user-transcript.repository';
+
+const MAX_QUERY_RANGE_MS = 31 * 24 * 60 * 60 * 1000;
+
+type TranscriptSegmentRecord = {
+  id: string;
+  speakerId: string | null;
+  speakerName: string | null;
+  startTimeMs: bigint;
+  endTimeMs: bigint;
+  text: string;
+  speaker: { id: string; displayName: string | null } | null;
+};
+
+@Injectable()
+export class PlatformUserTranscriptService {
+  constructor(private readonly repository: PlatformUserTranscriptRepository) {}
+
+  async getMeetingTranscripts(
+    platformUserId: string,
+    startDateValue: string,
+    endDateValue: string,
+  ): Promise<PlatformUserMeetingTranscriptsResponseDto> {
+    const { startDate, endDate } = this.validateDateRange(
+      startDateValue,
+      endDateValue,
+    );
+    const platformUser = await this.ensurePlatformUser(platformUserId);
+    const meetings = await this.repository.findMeetingTranscripts(
+      platformUserId,
+      startDate,
+      endDate,
+    );
+
+    return {
+      platformUser,
+      startDate: startDate.toISOString(),
+      endDate: endDate.toISOString(),
+      meetings: meetings.map((meeting) => ({
+        meetingId: meeting.id,
+        title: meeting.title,
+        platform: meeting.platform,
+        type: meeting.type,
+        startAt: meeting.startAt,
+        endAt: meeting.endAt,
+        minutes: meeting.minutes.map((minute) => ({
+          minuteId: minute.id,
+          externalId: minute.externalId,
+          source: minute.source,
+          startAt: minute.startAt,
+          endAt: minute.endAt,
+          transcripts: minute.transcripts.map((transcript) => ({
+            transcriptId: transcript.id,
+            segments: transcript.segments.map((segment) =>
+              this.mapSegment(segment),
+            ),
+          })),
+        })),
+      })),
+    };
+  }
+
+  async getTranscriptContext(
+    platformUserId: string,
+    minuteId: string,
+    depth: number,
+  ): Promise<PlatformUserTranscriptContextResponseDto> {
+    const platformUser = await this.ensurePlatformUser(platformUserId);
+    const minute = await this.repository.findMinuteContextSource(
+      minuteId,
+      platformUserId,
+    );
+
+    if (!minute) {
+      throw new NotFoundException('Minute not found');
+    }
+    if (!minute.meeting || minute.meeting.participants.length === 0) {
+      throw new NotFoundException(
+        'Platform user did not participate in the minute meeting',
+      );
+    }
+    if (minute.transcripts.length === 0) {
+      throw new NotFoundException('Transcript not found for minute');
+    }
+
+    return {
+      platformUser,
+      minuteId: minute.id,
+      depth,
+      transcripts: minute.transcripts.map((transcript) => {
+        const selectedIndexes = new Set<number>();
+        const segments = transcript.segments;
+
+        segments.forEach((segment, index) => {
+          if (segment.speakerId !== platformUserId) return;
+          const start = Math.max(0, index - depth);
+          const end = Math.min(segments.length - 1, index + depth);
+          for (
+            let selectedIndex = start;
+            selectedIndex <= end;
+            selectedIndex++
+          ) {
+            selectedIndexes.add(selectedIndex);
+          }
+        });
+
+        return {
+          transcriptId: transcript.id,
+          segments: [...selectedIndexes]
+            .sort((left, right) => left - right)
+            .map((index) => ({
+              ...this.mapSegment(segments[index]),
+              isTargetSpeaker: segments[index].speakerId === platformUserId,
+            })),
+        };
+      }),
+    };
+  }
+
+  private async ensurePlatformUser(platformUserId: string) {
+    const platformUser = await this.repository.findPlatformUser(platformUserId);
+    if (!platformUser) {
+      throw new NotFoundException('Platform user not found');
+    }
+    return platformUser;
+  }
+
+  private validateDateRange(startValue: string, endValue: string) {
+    const startDate = new Date(startValue);
+    const endDate = new Date(endValue);
+    const rangeMs = endDate.getTime() - startDate.getTime();
+
+    if (
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime()) ||
+      rangeMs <= 0
+    ) {
+      throw new BadRequestException('endDate must be later than startDate');
+    }
+    if (rangeMs > MAX_QUERY_RANGE_MS) {
+      throw new BadRequestException('Date range cannot exceed 31 days');
+    }
+    return { startDate, endDate };
+  }
+
+  private mapSegment(
+    segment: TranscriptSegmentRecord,
+  ): PlatformUserTranscriptSegmentDto {
+    return {
+      id: segment.id,
+      speakerName: segment.speakerName || '未知发言人',
+      startTime: formatTimeMs(Number(segment.startTimeMs)),
+      endTime: formatTimeMs(Number(segment.endTimeMs)),
+      text: segment.text,
+      platformUser: segment.speaker
+        ? {
+            id: segment.speaker.id,
+            displayName: segment.speaker.displayName,
+          }
+        : null,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- add a time-bounded query for meetings, minutes, transcripts, and target PlatformUser segments
- add per-minute PlatformUser transcript context with independent depth windows and overlap deduplication
- keep the feature in the Minute module with explicit DTOs, permissions, soft-delete filters, and OpenAPI contracts

## API

- GET /platform-users/:platformUserId/meeting-transcripts
- GET /minutes/:minuteId/platform-users/:platformUserId/transcript-context

## Validation

- pnpm exec jest --selectProjects unit --runInBand (66 suites, 376 tests)
- pnpm build
- targeted ESLint for changed Minute files
- git diff --cached --check
- staged credential-pattern scan

## Database

- no Prisma schema or migration changes

## Related PRs

- CLI: https://github.com/lulabs-org/nove-cli/pull/32
