### PR TITLE
feat(minute): return recordings containing platform user speech

### DIFF
--- a/src/minute/controllers/platform-user-transcript.controller.spec.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.spec.ts
@@ -21,13 +21,14 @@ describe('PlatformUserTranscriptController', () => {
 
   it('exposes both transcript query routes', () => {
     expect(
+      Reflect.getMetadata(PATH_METADATA, PlatformUserTranscriptController),
+    ).toBe('platform-users/:platformUserId');
+    expect(
       Reflect.getMetadata(PATH_METADATA, controller.getMinuteTranscripts),
-    ).toBe('platform-users/:platformUserId/minute-transcripts');
+    ).toBe('minutes/transcripts');
     expect(
       Reflect.getMetadata(PATH_METADATA, controller.getTranscriptContext),
-    ).toBe(
-      'minutes/:minuteId/platform-users/:platformUserId/transcript-context',
-    );
+    ).toBe('minutes/:minuteId/transcript-context');
   });
 
   it.each([['getMinuteTranscripts'], ['getTranscriptContext']] as const)(

--- a/src/minute/controllers/platform-user-transcript.controller.spec.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.spec.ts
@@ -10,7 +10,7 @@ import { PlatformUserTranscriptController } from './platform-user-transcript.con
 
 describe('PlatformUserTranscriptController', () => {
   const service = {
-    getMeetingTranscripts: jest.fn(),
+    getMinuteTranscripts: jest.fn(),
     getTranscriptContext: jest.fn(),
   };
   const controller = new PlatformUserTranscriptController(
@@ -21,8 +21,8 @@ describe('PlatformUserTranscriptController', () => {
 
   it('exposes both transcript query routes', () => {
     expect(
-      Reflect.getMetadata(PATH_METADATA, controller.getMeetingTranscripts),
-    ).toBe('platform-users/:platformUserId/meeting-transcripts');
+      Reflect.getMetadata(PATH_METADATA, controller.getMinuteTranscripts),
+    ).toBe('platform-users/:platformUserId/minute-transcripts');
     expect(
       Reflect.getMetadata(PATH_METADATA, controller.getTranscriptContext),
     ).toBe(
@@ -30,7 +30,7 @@ describe('PlatformUserTranscriptController', () => {
     );
   });
 
-  it.each([['getMeetingTranscripts'], ['getTranscriptContext']] as const)(
+  it.each([['getMinuteTranscripts'], ['getTranscriptContext']] as const)(
     'requires both platform-user and minute read permissions for %s',
     (method) => {
       expect(Reflect.getMetadata(PERMISSIONS_KEY, controller[method])).toEqual([
@@ -43,15 +43,15 @@ describe('PlatformUserTranscriptController', () => {
     },
   );
 
-  it('delegates meeting transcript queries', async () => {
-    service.getMeetingTranscripts.mockResolvedValue({ meetings: [] });
+  it('delegates minute transcript queries', async () => {
+    service.getMinuteTranscripts.mockResolvedValue({ minutes: [] });
 
-    await controller.getMeetingTranscripts('platform-user-1', {
+    await controller.getMinuteTranscripts('platform-user-1', {
       startDate: '2026-08-01T00:00:00Z',
       endDate: '2026-09-01T00:00:00Z',
     });
 
-    expect(service.getMeetingTranscripts).toHaveBeenCalledWith(
+    expect(service.getMinuteTranscripts).toHaveBeenCalledWith(
       'platform-user-1',
       '2026-08-01T00:00:00Z',
       '2026-09-01T00:00:00Z',

--- a/src/minute/controllers/platform-user-transcript.controller.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.ts
@@ -12,9 +12,9 @@ import {
 import { RequireAllPermissions } from '@/admin/permission/decorators/permissions.decorator';
 import { CuidPipe } from '@/common/pipes/cuid.pipe';
 import {
-  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserMinuteTranscriptsResponseDto,
   PlatformUserTranscriptContextResponseDto,
-  QueryPlatformUserMeetingTranscriptsDto,
+  QueryPlatformUserMinuteTranscriptsDto,
   QueryPlatformUserTranscriptContextDto,
 } from '../dto/platform-user-transcript.dto';
 import { PlatformUserTranscriptService } from '../services/platform-user-transcript.service';
@@ -25,20 +25,20 @@ import { PlatformUserTranscriptService } from '../services/platform-user-transcr
 export class PlatformUserTranscriptController {
   constructor(private readonly service: PlatformUserTranscriptService) {}
 
-  @Get('platform-users/:platformUserId/meeting-transcripts')
+  @Get('platform-users/:platformUserId/minute-transcripts')
   @RequireAllPermissions('platform-user:read', 'minute:read')
-  @ApiOperation({ summary: '查询用户会议记录及发言' })
+  @ApiOperation({ summary: '查询用户有发言的录制及转写段落' })
   @ApiParam({ name: 'platformUserId', description: '平台用户记录 ID' })
-  @ApiOkResponse({ type: PlatformUserMeetingTranscriptsResponseDto })
+  @ApiOkResponse({ type: PlatformUserMinuteTranscriptsResponseDto })
   @ApiBadRequestResponse({ description: '时间格式、顺序或跨度无效' })
   @ApiForbiddenResponse({ description: '缺少所需读取权限' })
   @ApiNotFoundResponse({ description: '平台用户不存在' })
-  getMeetingTranscripts(
+  getMinuteTranscripts(
     @Param('platformUserId', CuidPipe) platformUserId: string,
     @Query(new ValidationPipe({ transform: true }))
-    query: QueryPlatformUserMeetingTranscriptsDto,
+    query: QueryPlatformUserMinuteTranscriptsDto,
   ) {
-    return this.service.getMeetingTranscripts(
+    return this.service.getMinuteTranscripts(
       platformUserId,
       query.startDate,
       query.endDate,

--- a/src/minute/controllers/platform-user-transcript.controller.ts
+++ b/src/minute/controllers/platform-user-transcript.controller.ts
@@ -21,11 +21,11 @@ import { PlatformUserTranscriptService } from '../services/platform-user-transcr
 
 @ApiTags('Minute')
 @ApiBearerAuth()
-@Controller()
+@Controller('platform-users/:platformUserId')
 export class PlatformUserTranscriptController {
   constructor(private readonly service: PlatformUserTranscriptService) {}
 
-  @Get('platform-users/:platformUserId/minute-transcripts')
+  @Get('minutes/transcripts')
   @RequireAllPermissions('platform-user:read', 'minute:read')
   @ApiOperation({ summary: '查询用户有发言的录制及转写段落' })
   @ApiParam({ name: 'platformUserId', description: '平台用户记录 ID' })
@@ -45,7 +45,7 @@ export class PlatformUserTranscriptController {
     );
   }
 
-  @Get('minutes/:minuteId/platform-users/:platformUserId/transcript-context')
+  @Get('minutes/:minuteId/transcript-context')
   @RequireAllPermissions('platform-user:read', 'minute:read')
   @ApiOperation({ summary: '获取用户转写上下文' })
   @ApiParam({ name: 'platformUserId', description: '平台用户记录 ID' })

--- a/src/minute/dto/platform-user-transcript.dto.spec.ts
+++ b/src/minute/dto/platform-user-transcript.dto.spec.ts
@@ -5,17 +5,17 @@ import { validate } from 'class-validator';
 import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 import {
-  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserMinuteTranscriptsResponseDto,
   PlatformUserTranscriptContextResponseDto,
-  QueryPlatformUserMeetingTranscriptsDto,
+  QueryPlatformUserMinuteTranscriptsDto,
   QueryPlatformUserTranscriptContextDto,
 } from './platform-user-transcript.dto';
 
 @Controller('platform-user-transcript-contract-test')
 class PlatformUserTranscriptContractTestController {
-  @Get('meetings')
-  @ApiOkResponse({ type: PlatformUserMeetingTranscriptsResponseDto })
-  getMeetings(): void {}
+  @Get('minutes')
+  @ApiOkResponse({ type: PlatformUserMinuteTranscriptsResponseDto })
+  getMinutes(): void {}
 
   @Get('context')
   @ApiOkResponse({ type: PlatformUserTranscriptContextResponseDto })
@@ -23,8 +23,8 @@ class PlatformUserTranscriptContractTestController {
 }
 
 describe('Platform user transcript query DTOs', () => {
-  it('accepts timezone-explicit meeting transcript dates', async () => {
-    const dto = plainToInstance(QueryPlatformUserMeetingTranscriptsDto, {
+  it('accepts timezone-explicit minute transcript dates', async () => {
+    const dto = plainToInstance(QueryPlatformUserMinuteTranscriptsDto, {
       startDate: '2026-08-01T00:00:00+08:00',
       endDate: '2026-09-01T00:00:00+08:00',
     });
@@ -33,7 +33,7 @@ describe('Platform user transcript query DTOs', () => {
   });
 
   it('rejects dates without timezone information', async () => {
-    const dto = plainToInstance(QueryPlatformUserMeetingTranscriptsDto, {
+    const dto = plainToInstance(QueryPlatformUserMinuteTranscriptsDto, {
       startDate: '2026-08-01T00:00:00',
       endDate: '2026-08-02T00:00:00',
     });
@@ -102,5 +102,15 @@ describe('Platform user transcript response OpenAPI contract', () => {
       nullable: true,
     });
     expect(segment.required).toContain('platformUser');
+  });
+
+  it('documents minute meeting metadata as nullable', () => {
+    const minute = schemas.PlatformUserTranscriptMinuteDto;
+    const meeting = minute.properties?.meeting as SchemaObject;
+
+    expect(meeting).toMatchObject({ type: 'object', nullable: true });
+    expect(meeting).not.toHaveProperty('allOf');
+    expect(meeting.properties?.meetingId).toMatchObject({ type: 'string' });
+    expect(minute.required).toContain('meeting');
   });
 });

--- a/src/minute/dto/platform-user-transcript.dto.ts
+++ b/src/minute/dto/platform-user-transcript.dto.ts
@@ -5,7 +5,7 @@ import { MeetingPlatform, MeetingType, RecordingSource } from '@prisma/client';
 
 const TIMEZONE_SUFFIX = /(?:Z|[+-]\d{2}:\d{2})$/;
 
-export class QueryPlatformUserMeetingTranscriptsDto {
+export class QueryPlatformUserMinuteTranscriptsDto {
   @ApiProperty({
     description: '查询开始时间（包含时区的 ISO 8601 时间，包含边界）',
     example: '2026-08-01T00:00:00+08:00',
@@ -105,6 +105,26 @@ export class PlatformUserTranscriptContextGroupDto {
   segments: PlatformUserTranscriptContextSegmentDto[];
 }
 
+export class PlatformUserTranscriptMeetingDto {
+  @ApiProperty({ description: '会议 ID' })
+  meetingId: string;
+
+  @ApiProperty({ description: '会议标题' })
+  title: string;
+
+  @ApiProperty({ description: '会议平台', enum: MeetingPlatform })
+  platform: MeetingPlatform;
+
+  @ApiProperty({ description: '会议类型', enum: MeetingType })
+  type: MeetingType;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  startAt: Date | null;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  endAt: Date | null;
+}
+
 export class PlatformUserTranscriptMinuteDto {
   @ApiProperty({ description: 'Minute ID' })
   minuteId: string;
@@ -125,34 +145,26 @@ export class PlatformUserTranscriptMinuteDto {
   @ApiProperty({ type: String, format: 'date-time', nullable: true })
   endAt: Date | null;
 
+  @ApiProperty({
+    description: '录制关联的会议；独立录制时为 null',
+    type: 'object',
+    nullable: true,
+    properties: {
+      meetingId: { type: 'string', description: '会议 ID' },
+      title: { type: 'string', description: '会议标题' },
+      platform: { type: 'string', enum: Object.values(MeetingPlatform) },
+      type: { type: 'string', enum: Object.values(MeetingType) },
+      startAt: { type: 'string', format: 'date-time', nullable: true },
+      endAt: { type: 'string', format: 'date-time', nullable: true },
+    },
+  })
+  meeting: PlatformUserTranscriptMeetingDto | null;
+
   @ApiProperty({ type: [PlatformUserTranscriptGroupDto] })
   transcripts: PlatformUserTranscriptGroupDto[];
 }
 
-export class PlatformUserTranscriptMeetingDto {
-  @ApiProperty({ description: '会议 ID' })
-  meetingId: string;
-
-  @ApiProperty({ description: '会议标题' })
-  title: string;
-
-  @ApiProperty({ description: '会议平台', enum: MeetingPlatform })
-  platform: MeetingPlatform;
-
-  @ApiProperty({ description: '会议类型', enum: MeetingType })
-  type: MeetingType;
-
-  @ApiProperty({ type: String, format: 'date-time', nullable: true })
-  startAt: Date | null;
-
-  @ApiProperty({ type: String, format: 'date-time', nullable: true })
-  endAt: Date | null;
-
-  @ApiProperty({ type: [PlatformUserTranscriptMinuteDto] })
-  minutes: PlatformUserTranscriptMinuteDto[];
-}
-
-export class PlatformUserMeetingTranscriptsResponseDto {
+export class PlatformUserMinuteTranscriptsResponseDto {
   @ApiProperty({ type: PlatformUserTranscriptIdentityDto })
   platformUser: PlatformUserTranscriptIdentityDto;
 
@@ -162,8 +174,8 @@ export class PlatformUserMeetingTranscriptsResponseDto {
   @ApiProperty({ type: String, format: 'date-time' })
   endDate: string;
 
-  @ApiProperty({ type: [PlatformUserTranscriptMeetingDto] })
-  meetings: PlatformUserTranscriptMeetingDto[];
+  @ApiProperty({ type: [PlatformUserTranscriptMinuteDto] })
+  minutes: PlatformUserTranscriptMinuteDto[];
 }
 
 export class PlatformUserTranscriptContextResponseDto {

--- a/src/minute/repositories/platform-user-transcript.repository.spec.ts
+++ b/src/minute/repositories/platform-user-transcript.repository.spec.ts
@@ -4,43 +4,46 @@ import { PlatformUserTranscriptRepository } from './platform-user-transcript.rep
 
 describe('PlatformUserTranscriptRepository', () => {
   const platformUser = { findFirst: jest.fn() };
-  const meeting = { findMany: jest.fn() };
-  const minute = { findFirst: jest.fn() };
-  const prisma = { platformUser, meeting, minute } as unknown as PrismaService;
+  const minute = { findFirst: jest.fn(), findMany: jest.fn() };
+  const prisma = { platformUser, minute } as unknown as PrismaService;
   const repository = new PlatformUserTranscriptRepository(prisma);
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('queries every meeting type through active participation and a half-open range', async () => {
-    meeting.findMany.mockResolvedValue([]);
+  it('queries matching minutes by speech and a half-open minute range', async () => {
+    minute.findMany.mockResolvedValue([]);
     const startDate = new Date('2026-08-01T00:00:00+08:00');
     const endDate = new Date('2026-09-01T00:00:00+08:00');
 
-    await repository.findMeetingTranscripts(
+    await repository.findMinuteTranscripts(
       'platform-user-1',
       startDate,
       endDate,
     );
 
-    expect(meeting.findMany).toHaveBeenCalledWith(
+    expect(minute.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
+        where: expect.objectContaining({
           deletedAt: null,
           startAt: { gte: startDate, lt: endDate },
-          participants: {
-            some: { ptUserId: 'platform-user-1', deletedAt: null },
+          OR: [
+            { meeting: { is: null } },
+            { meeting: { is: { deletedAt: null } } },
+          ],
+          transcripts: {
+            some: {
+              segments: { some: { speakerId: 'platform-user-1' } },
+            },
           },
-        },
+        }),
         select: expect.objectContaining({
-          minutes: expect.objectContaining({
-            where: { deletedAt: null },
+          transcripts: expect.objectContaining({
+            where: {
+              segments: { some: { speakerId: 'platform-user-1' } },
+            },
             select: expect.objectContaining({
-              transcripts: expect.objectContaining({
-                select: expect.objectContaining({
-                  segments: expect.objectContaining({
-                    where: { speakerId: 'platform-user-1' },
-                  }),
-                }),
+              segments: expect.objectContaining({
+                where: { speakerId: 'platform-user-1' },
               }),
             }),
           }),

--- a/src/minute/repositories/platform-user-transcript.repository.ts
+++ b/src/minute/repositories/platform-user-transcript.repository.ts
@@ -49,17 +49,23 @@ export class PlatformUserTranscriptRepository {
     });
   }
 
-  findMeetingTranscripts(
+  findMinuteTranscripts(
     platformUserId: string,
     startDate: Date,
     endDate: Date,
   ) {
-    return this.prisma.meeting.findMany({
+    return this.prisma.minute.findMany({
       where: {
         deletedAt: null,
         startAt: { gte: startDate, lt: endDate },
-        participants: {
-          some: { ptUserId: platformUserId, deletedAt: null },
+        OR: [
+          { meeting: { is: null } },
+          { meeting: { is: { deletedAt: null } } },
+        ],
+        transcripts: {
+          some: {
+            segments: { some: { speakerId: platformUserId } },
+          },
         },
       },
       orderBy: [
@@ -69,34 +75,31 @@ export class PlatformUserTranscriptRepository {
       ],
       select: {
         id: true,
-        title: true,
-        platform: true,
-        type: true,
+        externalId: true,
+        source: true,
         startAt: true,
         endAt: true,
-        minutes: {
-          where: { deletedAt: null },
-          orderBy: [
-            { startAt: { sort: 'asc', nulls: 'last' } },
-            { createdAt: 'asc' },
-            { id: 'asc' },
-          ],
+        meeting: {
           select: {
             id: true,
-            externalId: true,
-            source: true,
+            title: true,
+            platform: true,
+            type: true,
             startAt: true,
             endAt: true,
-            transcripts: {
-              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-              select: {
-                id: true,
-                segments: {
-                  where: { speakerId: platformUserId },
-                  orderBy: [{ startTimeMs: 'asc' }, { id: 'asc' }],
-                  select: transcriptSegmentSelect,
-                },
-              },
+          },
+        },
+        transcripts: {
+          where: {
+            segments: { some: { speakerId: platformUserId } },
+          },
+          orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+          select: {
+            id: true,
+            segments: {
+              where: { speakerId: platformUserId },
+              orderBy: [{ startTimeMs: 'asc' }, { id: 'asc' }],
+              select: transcriptSegmentSelect,
             },
           },
         },

--- a/src/minute/services/platform-user-transcript.service.spec.ts
+++ b/src/minute/services/platform-user-transcript.service.spec.ts
@@ -22,7 +22,7 @@ const segment = (
 describe('PlatformUserTranscriptService', () => {
   let repository: {
     findPlatformUser: jest.Mock;
-    findMeetingTranscripts: jest.Mock;
+    findMinuteTranscripts: jest.Mock;
     findMinuteContextSource: jest.Mock;
   };
   let service: PlatformUserTranscriptService;
@@ -33,7 +33,7 @@ describe('PlatformUserTranscriptService', () => {
         id: 'target',
         displayName: 'Target User',
       }),
-      findMeetingTranscripts: jest.fn(),
+      findMinuteTranscripts: jest.fn(),
       findMinuteContextSource: jest.fn(),
     };
     service = new PlatformUserTranscriptService(
@@ -41,48 +41,48 @@ describe('PlatformUserTranscriptService', () => {
     );
   });
 
-  it('maps nested meetings, minutes and target transcript segments', async () => {
-    repository.findMeetingTranscripts.mockResolvedValue([
+  it('maps matching minutes, optional meetings and target transcript segments', async () => {
+    repository.findMinuteTranscripts.mockResolvedValue([
       {
-        id: 'meeting-1',
-        title: 'One-time meeting',
-        platform: MeetingPlatform.TENCENT_MEETING,
-        type: MeetingType.ONE_TIME,
+        id: 'minute-1',
+        externalId: null,
+        source: RecordingSource.PLATFORM_AUTO,
         startAt: new Date('2026-08-02T01:00:00Z'),
         endAt: null,
-        minutes: [
-          {
-            id: 'minute-1',
-            externalId: null,
-            source: RecordingSource.PLATFORM_AUTO,
-            startAt: null,
-            endAt: null,
-            transcripts: [
-              { id: 'transcript-1', segments: [segment('s1', 'target', 0)] },
-            ],
-          },
+        meeting: {
+          id: 'meeting-1',
+          title: 'One-time meeting',
+          platform: MeetingPlatform.TENCENT_MEETING,
+          type: MeetingType.ONE_TIME,
+          startAt: new Date('2026-08-02T01:00:00Z'),
+          endAt: null,
+        },
+        transcripts: [
+          { id: 'transcript-1', segments: [segment('s1', 'target', 0)] },
         ],
       },
       {
-        id: 'meeting-2',
-        title: 'Recurring meeting without recordings',
-        platform: MeetingPlatform.FEISHU,
-        type: MeetingType.RECURRING,
+        id: 'minute-2',
+        externalId: 'external-2',
+        source: RecordingSource.THIRD_PARTY,
         startAt: new Date('2026-08-01T01:00:00Z'),
         endAt: null,
-        minutes: [],
+        meeting: null,
+        transcripts: [
+          { id: 'transcript-2', segments: [segment('s2', 'target', 1_000)] },
+        ],
       },
     ]);
 
-    const result = await service.getMeetingTranscripts(
+    const result = await service.getMinuteTranscripts(
       'target',
       '2026-08-01T00:00:00Z',
       '2026-09-01T00:00:00Z',
     );
 
-    expect(result.meetings).toHaveLength(2);
-    expect(result.meetings[0].type).toBe(MeetingType.ONE_TIME);
-    expect(result.meetings[0].minutes[0].transcripts[0].segments[0]).toEqual({
+    expect(result.minutes).toHaveLength(2);
+    expect(result.minutes[0].meeting?.type).toBe(MeetingType.ONE_TIME);
+    expect(result.minutes[0].transcripts[0].segments[0]).toEqual({
       id: 's1',
       speakerName: 'speaker-target',
       startTime: '00:00:00',
@@ -90,12 +90,12 @@ describe('PlatformUserTranscriptService', () => {
       text: 'text-s1',
       platformUser: { id: 'target', displayName: 'user-target' },
     });
-    expect(result.meetings[1].minutes).toEqual([]);
+    expect(result.minutes[1].meeting).toBeNull();
   });
 
   it('rejects reversed and longer-than-31-day ranges', async () => {
     await expect(
-      service.getMeetingTranscripts(
+      service.getMinuteTranscripts(
         'target',
         '2026-08-02T00:00:00Z',
         '2026-08-01T00:00:00Z',
@@ -103,7 +103,7 @@ describe('PlatformUserTranscriptService', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
 
     await expect(
-      service.getMeetingTranscripts(
+      service.getMinuteTranscripts(
         'target',
         '2026-08-01T00:00:00Z',
         '2026-09-02T00:00:00Z',

--- a/src/minute/services/platform-user-transcript.service.ts
+++ b/src/minute/services/platform-user-transcript.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { formatTimeMs } from '@/common/utils/time.util';
 import {
-  PlatformUserMeetingTranscriptsResponseDto,
+  PlatformUserMinuteTranscriptsResponseDto,
   PlatformUserTranscriptContextResponseDto,
   PlatformUserTranscriptSegmentDto,
 } from '../dto/platform-user-transcript.dto';
@@ -27,17 +27,17 @@ type TranscriptSegmentRecord = {
 export class PlatformUserTranscriptService {
   constructor(private readonly repository: PlatformUserTranscriptRepository) {}
 
-  async getMeetingTranscripts(
+  async getMinuteTranscripts(
     platformUserId: string,
     startDateValue: string,
     endDateValue: string,
-  ): Promise<PlatformUserMeetingTranscriptsResponseDto> {
+  ): Promise<PlatformUserMinuteTranscriptsResponseDto> {
     const { startDate, endDate } = this.validateDateRange(
       startDateValue,
       endDateValue,
     );
     const platformUser = await this.ensurePlatformUser(platformUserId);
-    const meetings = await this.repository.findMeetingTranscripts(
+    const minutes = await this.repository.findMinuteTranscripts(
       platformUserId,
       startDate,
       endDate,
@@ -47,25 +47,27 @@ export class PlatformUserTranscriptService {
       platformUser,
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
-      meetings: meetings.map((meeting) => ({
-        meetingId: meeting.id,
-        title: meeting.title,
-        platform: meeting.platform,
-        type: meeting.type,
-        startAt: meeting.startAt,
-        endAt: meeting.endAt,
-        minutes: meeting.minutes.map((minute) => ({
-          minuteId: minute.id,
-          externalId: minute.externalId,
-          source: minute.source,
-          startAt: minute.startAt,
-          endAt: minute.endAt,
-          transcripts: minute.transcripts.map((transcript) => ({
-            transcriptId: transcript.id,
-            segments: transcript.segments.map((segment) =>
-              this.mapSegment(segment),
-            ),
-          })),
+      minutes: minutes.map((minute) => ({
+        minuteId: minute.id,
+        externalId: minute.externalId,
+        source: minute.source,
+        startAt: minute.startAt,
+        endAt: minute.endAt,
+        meeting: minute.meeting
+          ? {
+              meetingId: minute.meeting.id,
+              title: minute.meeting.title,
+              platform: minute.meeting.platform,
+              type: minute.meeting.type,
+              startAt: minute.meeting.startAt,
+              endAt: minute.meeting.endAt,
+            }
+          : null,
+        transcripts: minute.transcripts.map((transcript) => ({
+          transcriptId: transcript.id,
+          segments: transcript.segments.map((segment) =>
+            this.mapSegment(segment),
+          ),
         })),
       })),
     };


### PR DESCRIPTION
## Summary

- Replace the meeting-centric platform-user transcript query with a minute-centric query.
- Expose `GET /platform-users/:platformUserId/minute-transcripts` and filter by `Minute.startAt` in the requested half-open range.
- Return only minutes, transcripts, and segments where the target platform user actually spoke.
- Preserve nullable meeting metadata for standalone minutes and keep all meeting types eligible.
- Update Swagger contracts and focused controller, DTO, repository, and service tests.

## API contract

- The previous `/meeting-transcripts` route is replaced by `/minute-transcripts`.
- The response root changes from `meetings` to `minutes`.
- Each minute contains nullable `meeting` metadata plus matching transcripts and target-speaker segments.
- No matching speech returns `200` with an empty `minutes` array.

## Validation

- `pnpm test:unit` — 66 suites, 377 tests passed.
- `pnpm build` — passed.
- Targeted ESLint over all changed TypeScript files — passed.
- `git diff --check` — passed.

## Related PRs

- CLI: https://github.com/lulabs-org/nove-cli/pull/33
